### PR TITLE
Multi-session support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ cd web/wasm && cargo clippy   # its .cargo/config.toml defaults to wasm32
 
 ## Commits
 
-[Conventional Commits](https://www.conventionalcommits.org/), lowercase imperative subject. Scope is a module, not a file: `transcript`, `state`, `graph`, `timeline`, `tailer`, `ui`, `panel`, `cli`, `wasm`, `web`, `docs`.
+[Conventional Commits](https://www.conventionalcommits.org/), lowercase imperative subject. Scope is a module, not a file: `transcript`, `index`, `sessions`, `monitor`, `state`, `graph`, `timeline`, `rail`, `tailer`, `ui`, `panel`, `cli`, `wasm`, `web`, `docs`.
 
 ```
 feat(timeline): index the playhead by event instead of wall-clock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca55ee147b1926dbea904f50fe4902494e97bc742205abbbf10c709e43815f"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +81,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +97,12 @@ name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "cast"
@@ -590,6 +608,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "imbl"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ea8d4c37ee560727e824d62804183624d371e632019b0e9e3532bce64a33e5"
+dependencies = [
+ "archery",
+ "bitmaps",
+ "equivalent",
+ "imbl-sized-chunks",
+ "rand_core",
+ "rand_xoshiro",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +973,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rataflow"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +1165,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -1378,6 +1445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1529,16 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -1592,6 +1675,7 @@ dependencies = [
  "criterion",
  "crossterm",
  "futures",
+ "imbl",
  "memchr",
  "memmap2",
  "rataflow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +34,18 @@ checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -57,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +132,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +213,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +299,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
@@ -358,6 +512,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +619,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -557,6 +731,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +780,22 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "palette"
@@ -673,6 +872,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,7 +962,7 @@ dependencies = [
  "bitflags",
  "compact_str",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
@@ -769,7 +996,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -780,6 +1007,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +1034,35 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rust-sugiyama"
@@ -831,6 +1107,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1033,6 +1318,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,7 +1366,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1081,6 +1376,16 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1134,6 +1439,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1473,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1234,6 +1558,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,8 +1589,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "criterion",
  "crossterm",
  "futures",
+ "memchr",
+ "memmap2",
  "rataflow",
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,3 +118,7 @@ harness = false
 [[bench]]
 name = "memory"
 harness = false
+
+[[bench]]
+name = "index"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ native = [
   "dep:crossterm",
   "dep:futures",
   "dep:anyhow",
+  "dep:memchr",
+  "dep:memmap2",
   "ratatui/crossterm",
   "rataflow/crossterm",
 ]
@@ -85,6 +87,10 @@ tokio = { version = "1", features = [
 ], optional = true }
 futures = { version = "0.3", optional = true }
 anyhow = { version = "1", optional = true }
+# Skeleton indexing (src/index.rs): SIMD substring search over transcript
+# bytes, and mmap so a re-scan of an already-indexed file costs no copy.
+memchr = { version = "2.8", optional = true }
+memmap2 = { version = "0.9", optional = true }
 
 # The library's own wasm requirement, independent of any frontend: chrono needs
 # its wasm time binding for `Utc::now()` to work in-browser. A browser backend

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ anyhow = { version = "1", optional = true }
 # bytes, and mmap so a re-scan of an already-indexed file costs no copy.
 memchr = { version = "2.8", optional = true }
 memmap2 = { version = "0.9", optional = true }
+imbl = "7.0.1"
 
 # The library's own wasm requirement, independent of any frontend: chrono needs
 # its wasm time binding for `Utc::now()` to work in-browser. A browser backend

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,16 @@ name = "zoe"
 path = "src/main.rs"
 # Native terminal binary — skipped by a `--no-default-features` build.
 required-features = ["native"]
+
+[dev-dependencies]
+criterion = { version = "0.8.2", features = ["html_reports"] }
+
+# Baselines for the parse -> timeline -> fold -> seek pipeline, over synthetic
+# sessions (benches/common).
+[[bench]]
+name = "timeline"
+harness = false
+
+[[bench]]
+name = "memory"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,3 +123,5 @@ harness = false
 [[bench]]
 name = "index"
 harness = false
+# Benches the native-only skeleton index and discovery sweep.
+required-features = ["native"]

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -470,20 +470,29 @@ fn subagent_transcript(aid: &str, start: u64, spec: Spec) -> String {
 /// The index and discovery benches measure the filesystem path (mmap, cache
 /// sidecars, directory sweeps), so they need real files rather than strings.
 pub fn write_to_disk(s: &Session, project_dir: &std::path::Path, uuid: &str) -> std::path::PathBuf {
+    use zoetrope::transcript::{subagents_dir, workflow_dir, workflow_journal};
+
     std::fs::create_dir_all(project_dir).unwrap();
     let main = project_dir.join(format!("{uuid}.jsonl"));
     std::fs::write(&main, &s.main).unwrap();
 
-    let subs = project_dir.join(uuid).join("subagents");
+    // Derive the sidecar layout from the same helpers the app reads it with,
+    // so a layout change cannot leave the benches testing a stale shape.
+    let subs = subagents_dir(&main).unwrap();
     std::fs::create_dir_all(&subs).unwrap();
     for sc in &s.sidecars {
         let dir = match &sc.workflow {
-            Some(wf) => subs.join("workflows").join(wf),
+            Some(wf) => workflow_dir(&subs, wf),
             None => subs.clone(),
         };
         std::fs::create_dir_all(&dir).unwrap();
         if sc.journal {
-            std::fs::write(dir.join("journal.jsonl"), &sc.transcript).unwrap();
+            let journal = sc
+                .workflow
+                .as_deref()
+                .map(|wf| workflow_journal(&subs, wf))
+                .unwrap_or_else(|| dir.join("journal.jsonl"));
+            std::fs::write(journal, &sc.transcript).unwrap();
             continue;
         }
         std::fs::write(

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -1,0 +1,501 @@
+//! Deterministic synthetic session generator for the benchmarks.
+//!
+//! Produces transcripts in the on-disk shape (`<uuid>.jsonl` + `subagents/`
+//! sidecars) without touching `~/.claude/projects`: benches must be
+//! reproducible on any machine and must never read a real session. Every line
+//! is built with `serde_json::json!`, so the output parses by construction.
+//!
+//! Shape and volume are calibrated against the aggregate statistics of real
+//! transcripts: a line is a couple of kilobytes, spawns land every few prompt
+//! eras, and the subagent sidecars outweigh the main transcript. The scales are
+//! deliberately spread so a result can be read as a trend rather than a point —
+//! see `Spec::SMALL/MEDIUM/LARGE`.
+
+#![allow(dead_code)]
+
+use serde_json::json;
+
+/// Filler text of exactly `n` bytes — JSON-safe ASCII, no escapes, so a line's
+/// serialized size is predictable.
+fn filler(n: usize) -> String {
+    const WORDS: [&str; 8] = [
+        "resolve ",
+        "the ",
+        "handler ",
+        "before ",
+        "folding ",
+        "into ",
+        "the model ",
+        "again ",
+    ];
+    let mut s = String::with_capacity(n + 16);
+    let mut i = 0;
+    while s.len() < n {
+        s.push_str(WORDS[i % WORDS.len()]);
+        i += 1;
+    }
+    s.truncate(n);
+    s
+}
+
+/// ISO-8601 stamp `t` seconds after a fixed epoch. Monotone across a session.
+fn ts(t: u64) -> String {
+    let base = chrono::DateTime::parse_from_rfc3339("2026-06-01T09:00:00.000Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    (base + chrono::Duration::seconds(t as i64))
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string()
+}
+
+/// The volume knobs of a generated session.
+#[derive(Debug, Clone, Copy)]
+pub struct Spec {
+    /// Human prompts — the era spine.
+    pub eras: usize,
+    /// Assistant turns per era.
+    pub turns_per_era: usize,
+    /// `tool_use` blocks per assistant turn (each gets a `tool_result`).
+    pub tools_per_turn: usize,
+    /// Direct `Agent` spawns (one subagent sidecar each).
+    pub subagents: usize,
+    /// Assistant turns inside each subagent transcript.
+    pub sub_turns: usize,
+    /// `Workflow` launches (one group + `wf_agents` sidecars + a journal each).
+    pub workflows: usize,
+    /// Subagents per workflow.
+    pub wf_agents: usize,
+    /// Filler bytes per text/thinking/result payload — the line-size dial.
+    pub payload: usize,
+}
+
+impl Spec {
+    /// A short session: 222 lines / ~0.3 MB. Generation is deterministic, so
+    /// these figures describe the generator, not a measurement.
+    pub const SMALL: Spec = Spec {
+        eras: 12,
+        turns_per_era: 3,
+        tools_per_turn: 3,
+        subagents: 4,
+        sub_turns: 8,
+        workflows: 1,
+        wf_agents: 3,
+        payload: 900,
+    };
+    /// A long working session: 2,391 lines / ~4.6 MB.
+    pub const MEDIUM: Spec = Spec {
+        eras: 60,
+        turns_per_era: 5,
+        tools_per_turn: 4,
+        subagents: 20,
+        sub_turns: 20,
+        workflows: 4,
+        wf_agents: 5,
+        payload: 1100,
+    };
+    /// A pathologically large session: 31,371 lines / ~67 MB, the order of the
+    /// largest single transcripts that occur in practice.
+    pub const LARGE: Spec = Spec {
+        eras: 450,
+        turns_per_era: 6,
+        tools_per_turn: 5,
+        subagents: 130,
+        sub_turns: 45,
+        workflows: 18,
+        wf_agents: 8,
+        payload: 1300,
+    };
+}
+
+/// One generated subagent sidecar: transcript text + `meta.json` text.
+pub struct Sidecar {
+    pub agent_id: String,
+    pub meta: String,
+    pub transcript: String,
+    pub workflow: Option<String>,
+    pub journal: bool,
+}
+
+/// A generated session: the main transcript plus every sidecar.
+pub struct Session {
+    pub main: String,
+    pub sidecars: Vec<Sidecar>,
+}
+
+impl Session {
+    /// Total bytes across every file — what a cold parse actually reads.
+    pub fn bytes(&self) -> usize {
+        self.main.len()
+            + self
+                .sidecars
+                .iter()
+                .map(|s| s.transcript.len() + s.meta.len())
+                .sum::<usize>()
+    }
+
+    /// Total lines across every file.
+    pub fn lines(&self) -> usize {
+        self.main.lines().count()
+            + self
+                .sidecars
+                .iter()
+                .map(|s| s.transcript.lines().count())
+                .sum::<usize>()
+    }
+
+    /// Borrowed view in the shape `tailer::replay_from_session` expects.
+    pub fn demo_subagents(&self) -> Vec<zoetrope::tailer::DemoSubagent<'_>> {
+        self.sidecars
+            .iter()
+            .map(|s| zoetrope::tailer::DemoSubagent {
+                agent_id: &s.agent_id,
+                meta: &s.meta,
+                transcript: &s.transcript,
+                workflow: s.workflow.as_deref(),
+                journal: s.journal,
+            })
+            .collect()
+    }
+}
+
+/// 17-hex agent id, the width real `agent-<id>.jsonl` filenames use.
+fn agent_id(n: usize) -> String {
+    format!("{n:017x}")
+}
+
+/// Build a full synthetic session from `spec`.
+///
+/// The main transcript interleaves prompt eras with spawns so the model
+/// exercises every join it has: era attribution, `Agent`/`Workflow` spawn
+/// context, `tool_result` completion, and the workflow journal's `result`
+/// ledger.
+pub fn session(spec: Spec) -> Session {
+    let mut main = String::new();
+    let mut sidecars = Vec::new();
+    let mut t = 0u64;
+    let mut uuid = 0usize;
+    let mut tool_seq = 0usize;
+    let next_uuid = |uuid: &mut usize| {
+        *uuid += 1;
+        format!("u{uuid:07}")
+    };
+
+    // Flat session metadata (untimed — routed to SessionInfo, off the timeline).
+    for line in [
+        json!({"type":"ai-title","aiTitle":"Synthetic benchmark session","sessionId":"bench"}),
+        json!({"type":"mode","mode":"normal","sessionId":"bench"}),
+        json!({"type":"permission-mode","permissionMode":"acceptEdits","sessionId":"bench"}),
+    ] {
+        main.push_str(&line.to_string());
+        main.push('\n');
+    }
+
+    // Spawns are spread evenly across the eras rather than clustered at the
+    // front, so a mid-timeline seek always lands inside live subagent work.
+    let total_spawns = spec.subagents + spec.workflows;
+    let spawn_every = spec
+        .eras
+        .checked_div(total_spawns)
+        .map_or(usize::MAX, |n| n.max(1));
+    let mut spawned_subs = 0usize;
+    let mut spawned_wfs = 0usize;
+
+    let mut prev = String::new();
+    for era in 0..spec.eras {
+        // --- the human prompt: an era boundary ---
+        let id = next_uuid(&mut uuid);
+        t += 30;
+        main.push_str(
+            &json!({
+                "type":"user","uuid":id,
+                "parentUuid": if prev.is_empty() { serde_json::Value::Null } else { json!(prev) },
+                "timestamp": ts(t),
+                "sessionId":"bench","cwd":"/home/dev/project",
+                "origin":{"kind":"human"},
+                "message":{"role":"user","content":format!("era {era}: {}", filler(spec.payload / 4))}
+            })
+            .to_string(),
+        );
+        main.push('\n');
+        prev = id;
+
+        // --- assistant turns, each answered by a tool_result user turn ---
+        for _ in 0..spec.turns_per_era {
+            let a_id = next_uuid(&mut uuid);
+            t += 7;
+            let tools: Vec<_> = (0..spec.tools_per_turn)
+                .map(|_| {
+                    tool_seq += 1;
+                    let tid = format!("toolu_{tool_seq:08}");
+                    (
+                        tid.clone(),
+                        json!({"type":"tool_use","id":tid,"name":"Read",
+                               "input":{"file_path":"/home/dev/project/src/state/mod.rs","offset":1,"limit":200}}),
+                    )
+                })
+                .collect();
+            let mut content = vec![
+                json!({"type":"thinking","thinking":filler(spec.payload),"signature":"sig"}),
+                json!({"type":"text","text":filler(spec.payload / 2)}),
+            ];
+            content.extend(tools.iter().map(|(_, b)| b.clone()));
+            main.push_str(
+                &json!({
+                    "type":"assistant","uuid":a_id,"parentUuid":prev,"timestamp":ts(t),
+                    "sessionId":"bench","requestId":"req_bench",
+                    "message":{"role":"assistant","model":"claude-opus-5","stop_reason":"tool_use",
+                               "content":content,
+                               "usage":{"input_tokens":12000,"output_tokens":800,
+                                        "cache_read_input_tokens":9000}}
+                })
+                .to_string(),
+            );
+            main.push('\n');
+            prev = a_id;
+
+            let r_id = next_uuid(&mut uuid);
+            t += 4;
+            // One result per call; every 9th fails, so failure markers land on
+            // the scrubber the way a real session's do.
+            let blocks: Vec<_> = tools
+                .iter()
+                .enumerate()
+                .map(|(i, (tid, _))| {
+                    json!({"type":"tool_result","tool_use_id":tid,
+                           "is_error": i % 9 == 8,
+                           "content": filler(spec.payload)})
+                })
+                .collect();
+            main.push_str(
+                &json!({
+                    "type":"user","uuid":r_id,"parentUuid":prev,"timestamp":ts(t),
+                    "sessionId":"bench","message":{"role":"user","content":blocks}
+                })
+                .to_string(),
+            );
+            main.push('\n');
+            prev = r_id;
+        }
+
+        // --- periodic spawn: a direct subagent, then a workflow ---
+        if era % spawn_every == 0 {
+            if spawned_subs < spec.subagents {
+                let n = spawned_subs;
+                spawned_subs += 1;
+                tool_seq += 1;
+                let tid = format!("toolu_{tool_seq:08}");
+                let aid = agent_id(0x1000 + n);
+                let a_id = next_uuid(&mut uuid);
+                t += 6;
+                main.push_str(
+                    &json!({
+                        "type":"assistant","uuid":a_id,"parentUuid":prev,"timestamp":ts(t),
+                        "sessionId":"bench",
+                        "message":{"role":"assistant","model":"claude-opus-5","stop_reason":"tool_use",
+                            "content":[
+                                {"type":"text","text":filler(spec.payload / 2)},
+                                {"type":"tool_use","id":tid,"name":"Agent",
+                                 "input":{"description":format!("probe subsystem {n}"),
+                                          "subagent_type":"Explore",
+                                          "prompt":filler(spec.payload / 2)}}]}
+                    })
+                    .to_string(),
+                );
+                main.push('\n');
+                prev = a_id;
+
+                // The spawn ack (a tool_result), then the subagent's own file.
+                let r_id = next_uuid(&mut uuid);
+                t += 2;
+                main.push_str(
+                    &json!({
+                        "type":"user","uuid":r_id,"parentUuid":prev,"timestamp":ts(t),
+                        "sessionId":"bench",
+                        "message":{"role":"user","content":[
+                            {"type":"tool_result","tool_use_id":tid,"content":filler(spec.payload / 2)}]}
+                    })
+                    .to_string(),
+                );
+                main.push('\n');
+                prev = r_id;
+
+                sidecars.push(Sidecar {
+                    meta: json!({"agentType":"Explore",
+                                 "description":format!("probe subsystem {n}"),
+                                 "toolUseId":tid})
+                    .to_string(),
+                    transcript: subagent_transcript(&aid, t, spec),
+                    agent_id: aid,
+                    workflow: None,
+                    journal: false,
+                });
+            } else if spawned_wfs < spec.workflows {
+                let n = spawned_wfs;
+                spawned_wfs += 1;
+                tool_seq += 1;
+                let tid = format!("toolu_{tool_seq:08}");
+                let run_id = format!("wf_bench{n:04}");
+                let a_id = next_uuid(&mut uuid);
+                t += 6;
+                main.push_str(
+                    &json!({
+                        "type":"assistant","uuid":a_id,"parentUuid":prev,"timestamp":ts(t),
+                        "sessionId":"bench",
+                        "message":{"role":"assistant","model":"claude-opus-5","stop_reason":"tool_use",
+                            "content":[{"type":"tool_use","id":tid,"name":"Workflow",
+                                        "input":{"description":"review the change across dimensions",
+                                                 "name":"review-changes"}}]}
+                    })
+                    .to_string(),
+                );
+                main.push('\n');
+                prev = a_id;
+
+                // The launch ack carries the runId — ground truth for the group id.
+                let r_id = next_uuid(&mut uuid);
+                t += 3;
+                main.push_str(
+                    &json!({
+                        "type":"user","uuid":r_id,"parentUuid":prev,"timestamp":ts(t),
+                        "sessionId":"bench",
+                        "toolUseResult":{"taskType":"local_workflow","runId":run_id,
+                                         "workflowName":"review-changes",
+                                         "summary":"Review changed files across dimensions"},
+                        "message":{"role":"user","content":[
+                            {"type":"tool_result","tool_use_id":tid,"content":"started"}]}
+                    })
+                    .to_string(),
+                );
+                main.push('\n');
+                prev = r_id;
+
+                let mut journal = String::new();
+                for k in 0..spec.wf_agents {
+                    let aid = agent_id(0x2000 + n * 100 + k);
+                    journal.push_str(
+                        &json!({"type":"started","key":format!("agent-{k}"),"agentId":aid})
+                            .to_string(),
+                    );
+                    journal.push('\n');
+                    journal.push_str(
+                        &json!({"type":"result","key":format!("agent-{k}"),"agentId":aid,
+                                "result":{"ok":true,"text":filler(spec.payload / 4)}})
+                        .to_string(),
+                    );
+                    journal.push('\n');
+                    sidecars.push(Sidecar {
+                        meta: json!({"agentType":"workflow-subagent"}).to_string(),
+                        transcript: subagent_transcript(&aid, t, spec),
+                        agent_id: aid,
+                        workflow: Some(run_id.clone()),
+                        journal: false,
+                    });
+                }
+                sidecars.push(Sidecar {
+                    agent_id: String::new(),
+                    meta: String::new(),
+                    transcript: journal,
+                    workflow: Some(run_id),
+                    journal: true,
+                });
+            }
+        }
+    }
+
+    Session { main, sidecars }
+}
+
+/// A subagent's own transcript: a sidechain prompt then `sub_turns` tool turns,
+/// every line stamped with `agentId` (the join key the model folds on).
+fn subagent_transcript(aid: &str, start: u64, spec: Spec) -> String {
+    let mut s = String::new();
+    let mut t = start;
+    let mut seq = 0usize;
+
+    let id = format!("{aid}-u0");
+    t += 1;
+    s.push_str(
+        &json!({
+            "type":"user","uuid":id,"parentUuid":serde_json::Value::Null,"timestamp":ts(t),
+            "agentId":aid,"isSidechain":true,
+            "message":{"role":"user","content":filler(spec.payload)}
+        })
+        .to_string(),
+    );
+    s.push('\n');
+    let mut prev = id;
+
+    for turn in 0..spec.sub_turns {
+        seq += 1;
+        let tid = format!("toolu_{aid}_{seq:05}");
+        let a_id = format!("{aid}-a{turn}");
+        t += 5;
+        s.push_str(
+            &json!({
+                "type":"assistant","uuid":a_id,"parentUuid":prev,"timestamp":ts(t),
+                "agentId":aid,"attributionAgent":aid,
+                "message":{"role":"assistant","model":"claude-sonnet-5","stop_reason":"tool_use",
+                    "content":[
+                        {"type":"thinking","thinking":filler(spec.payload),"signature":"sig"},
+                        {"type":"tool_use","id":tid,"name":"Grep",
+                         "input":{"pattern":"fn apply_update","path":"src"}}],
+                    "usage":{"input_tokens":8000,"output_tokens":400}}
+            })
+            .to_string(),
+        );
+        s.push('\n');
+        prev = a_id;
+
+        let r_id = format!("{aid}-r{turn}");
+        t += 3;
+        s.push_str(
+            &json!({
+                "type":"user","uuid":r_id,"parentUuid":prev,"timestamp":ts(t),
+                "agentId":aid,"isSidechain":true,
+                "message":{"role":"user","content":[
+                    {"type":"tool_result","tool_use_id":tid,"content":filler(spec.payload)}]}
+            })
+            .to_string(),
+        );
+        s.push('\n');
+        prev = r_id;
+    }
+    s
+}
+
+/// Write a generated session to disk in the real on-disk layout, under
+/// `project_dir`: `<uuid>.jsonl` plus `<uuid>/subagents/agent-<id>.jsonl` and
+/// `<uuid>/subagents/workflows/<wf>/…`. Returns the main transcript's path.
+///
+/// The index and discovery benches measure the filesystem path (mmap, cache
+/// sidecars, directory sweeps), so they need real files rather than strings.
+pub fn write_to_disk(s: &Session, project_dir: &std::path::Path, uuid: &str) -> std::path::PathBuf {
+    std::fs::create_dir_all(project_dir).unwrap();
+    let main = project_dir.join(format!("{uuid}.jsonl"));
+    std::fs::write(&main, &s.main).unwrap();
+
+    let subs = project_dir.join(uuid).join("subagents");
+    std::fs::create_dir_all(&subs).unwrap();
+    for sc in &s.sidecars {
+        let dir = match &sc.workflow {
+            Some(wf) => subs.join("workflows").join(wf),
+            None => subs.clone(),
+        };
+        std::fs::create_dir_all(&dir).unwrap();
+        if sc.journal {
+            std::fs::write(dir.join("journal.jsonl"), &sc.transcript).unwrap();
+            continue;
+        }
+        std::fs::write(
+            dir.join(format!("agent-{}.jsonl", sc.agent_id)),
+            &sc.transcript,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join(format!("agent-{}.meta.json", sc.agent_id)),
+            &sc.meta,
+        )
+        .unwrap();
+    }
+    main
+}

--- a/benches/index.rs
+++ b/benches/index.rs
@@ -208,7 +208,7 @@ fn bench_sessions(c: &mut Criterion) {
     let n = sessions::discover(&root, SystemTime::UNIX_EPOCH).len();
     let files: usize = sessions::discover(&root, SystemTime::UNIX_EPOCH)
         .iter()
-        .map(|s| s.sidecar_count + 1)
+        .map(|s| s.sidecar_count() + 1)
         .sum();
     g.throughput(Throughput::Elements(files as u64));
     assert_eq!(n, 80, "the wide corpus is 40 projects x 2 sessions");

--- a/benches/index.rs
+++ b/benches/index.rs
@@ -1,0 +1,238 @@
+//! Benchmarks for the skeleton index — the fast half of the parse pipeline.
+//!
+//! Read these against `timeline.rs`'s `parse` and `load` groups: the same
+//! synthetic sessions go through both, so the numbers are directly comparable.
+//! `parse_line` there is what the model costs today; `skeleton_scan` here is
+//! what it costs to learn the same timeline facts without the bodies.
+
+mod common;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use common::{Session, Spec};
+use zoetrope::index::{self, Index};
+use zoetrope::sessions;
+
+/// A scratch projects root holding written-out synthetic sessions, plus its own
+/// index cache. Removed on drop.
+struct Corpus {
+    root: PathBuf,
+    sessions: Vec<(&'static str, Session, PathBuf)>,
+}
+
+impl Corpus {
+    fn new() -> Corpus {
+        let root =
+            std::env::temp_dir().join(format!("zoetrope-index-bench-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let projects = root.join("projects");
+
+        // Point the index cache at the scratch tree: a benchmark must not read
+        // or write the developer's real `~/.cache`.
+        // SAFETY: single-threaded bench setup, before criterion starts any
+        // measurement threads.
+        unsafe { std::env::set_var("XDG_CACHE_HOME", root.join("cache")) };
+
+        let specs: [(&'static str, Spec); 3] = [
+            ("small", Spec::SMALL),
+            ("medium", Spec::MEDIUM),
+            ("large", Spec::LARGE),
+        ];
+        let sessions = specs
+            .into_iter()
+            .enumerate()
+            .map(|(i, (name, spec))| {
+                let s = common::session(spec);
+                let uuid = format!("{:08x}-1111-2222-3333-444444444444", i + 1);
+                let main = common::write_to_disk(&s, &projects.join(name), &uuid);
+                (name, s, main)
+            })
+            .collect();
+
+        Corpus { root, sessions }
+    }
+
+    /// Drop every cached index, so the next `open` is a genuine cold scan.
+    fn clear_cache(&self) {
+        let _ = std::fs::remove_dir_all(self.root.join("cache"));
+    }
+}
+
+impl Drop for Corpus {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+/// Every transcript file of the session rooted at `main`.
+fn session_files(main: &Path) -> Vec<PathBuf> {
+    let root = main.parent().unwrap().parent().unwrap();
+    sessions::discover(root, SystemTime::UNIX_EPOCH)
+        .iter()
+        .find(|s| s.main_path == main)
+        .expect("session discovered")
+        .files()
+}
+
+/// Every transcript file of a session, as raw bytes.
+fn all_bytes(main: &Path) -> Vec<Vec<u8>> {
+    session_files(main)
+        .iter()
+        .filter_map(|p| std::fs::read(p).ok())
+        .collect()
+}
+
+fn bench_scan(c: &mut Criterion) {
+    let corpus = Corpus::new();
+    let mut g = c.benchmark_group("index");
+    g.sample_size(20);
+    g.warm_up_time(Duration::from_millis(500));
+    g.measurement_time(Duration::from_secs(8));
+
+    for (name, session, main) in &corpus.sessions {
+        let files = all_bytes(main);
+        let bytes: usize = files.iter().map(Vec::len).sum();
+        // `open_*` must cover the SAME files as `skeleton_scan`, or the
+        // throughput divisor describes bytes the benchmark never touched.
+        let paths = session_files(main);
+        g.throughput(Throughput::Bytes(bytes as u64));
+
+        // The skeleton scan itself: bytes → records, no file IO, no bodies.
+        g.bench_with_input(
+            BenchmarkId::new("skeleton_scan", name),
+            &files,
+            |b, files| {
+                b.iter(|| {
+                    let mut n = 0usize;
+                    for f in files {
+                        let mut idx = Index::default();
+                        idx.extend(black_box(f));
+                        n += idx.recs.len();
+                    }
+                    n
+                })
+            },
+        );
+
+        // The real entry point over a whole session, cache cold: mmap + scan +
+        // write the cache, for every file.
+        g.bench_with_input(BenchmarkId::new("open_cold", name), &paths, |b, paths| {
+            b.iter_batched(
+                || corpus.clear_cache(),
+                |()| {
+                    paths
+                        .iter()
+                        .filter_map(|p| index::open(black_box(p)).ok())
+                        .map(|(idx, _map)| idx.recs.len())
+                        .sum::<usize>()
+                },
+                criterion::BatchSize::PerIteration,
+            )
+        });
+
+        // Cache warm: stat, read a header, mmap. What every run after the first
+        // one costs.
+        for p in &paths {
+            let _ = index::open(p);
+        }
+        g.bench_with_input(BenchmarkId::new("open_warm", name), &paths, |b, paths| {
+            b.iter(|| {
+                paths
+                    .iter()
+                    .filter_map(|p| index::open(black_box(p)).ok())
+                    .map(|(idx, _map)| idx.recs.len())
+                    .sum::<usize>()
+            })
+        });
+
+        black_box(session);
+    }
+    g.finish();
+}
+
+/// A corpus shaped like a real `~/.claude/projects`: many projects, several
+/// sessions each. Discovery cost scales with the number of FILES, not their
+/// size, so the three-session corpus above says nothing useful about it.
+struct WideCorpus {
+    root: PathBuf,
+}
+
+impl WideCorpus {
+    /// 40 projects × 2 sessions, with sidecars under each — the order of
+    /// magnitude a long-lived `~/.claude/projects` reaches.
+    fn new() -> WideCorpus {
+        let root = std::env::temp_dir().join(format!("zoetrope-wide-bench-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let projects = root.join("projects");
+        // SAFETY: single-threaded bench setup, before measurement threads start.
+        unsafe { std::env::set_var("XDG_CACHE_HOME", root.join("cache")) };
+
+        let session = common::session(Spec::SMALL);
+        for p in 0..40 {
+            for s in 0..2 {
+                let uuid = format!("{p:08x}-1111-2222-3333-{s:012x}");
+                common::write_to_disk(&session, &projects.join(format!("proj-{p}")), &uuid);
+            }
+        }
+        WideCorpus { root }
+    }
+
+    fn projects(&self) -> PathBuf {
+        self.root.join("projects")
+    }
+}
+
+impl Drop for WideCorpus {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn bench_sessions(c: &mut Criterion) {
+    let corpus = WideCorpus::new();
+    let root = corpus.projects();
+    // Warm every cache once: the summary bench measures steady state, and the
+    // cold cost is already covered by `open_cold`.
+    for s in sessions::discover(&root, SystemTime::UNIX_EPOCH) {
+        let _ = sessions::Summary::of(&s);
+    }
+
+    let mut g = c.benchmark_group("sessions");
+    g.sample_size(20);
+    g.warm_up_time(Duration::from_millis(500));
+    g.measurement_time(Duration::from_secs(8));
+
+    let n = sessions::discover(&root, SystemTime::UNIX_EPOCH).len();
+    let files: usize = sessions::discover(&root, SystemTime::UNIX_EPOCH)
+        .iter()
+        .map(|s| s.sidecar_count + 1)
+        .sum();
+    g.throughput(Throughput::Elements(files as u64));
+    assert_eq!(n, 80, "the wide corpus is 40 projects x 2 sessions");
+
+    // Phase 1: the stat sweep over every project and every sidecar.
+    g.bench_function("discover_80_sessions", |b| {
+        b.iter(|| sessions::discover(black_box(&root), SystemTime::UNIX_EPOCH).len())
+    });
+
+    // Phase 2: summarize every discovered session from its index.
+    g.bench_function("summarize_80_sessions", |b| {
+        b.iter_batched(
+            || sessions::discover(&root, SystemTime::UNIX_EPOCH),
+            |found| {
+                found
+                    .iter()
+                    .map(|s| sessions::Summary::of(s).lines)
+                    .sum::<usize>()
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+    g.finish();
+}
+
+criterion_group!(benches, bench_scan, bench_sessions);
+criterion_main!(benches);

--- a/benches/memory.rs
+++ b/benches/memory.rs
@@ -1,0 +1,91 @@
+//! Memory baseline: how much resident memory one loaded session costs.
+//!
+//! Not a criterion bench — it prints a table. Timing lives in `timeline.rs`;
+//! this answers the other half of the multi-session question, since the whole
+//! point of tracking N sessions is that N × this has to fit.
+//!
+//! RSS is sampled from `/proc/self/statm`, so the deltas are approximate: the
+//! allocator does not return freed pages to the OS, which makes each stage's
+//! delta an upper bound on what that stage retains and the total a fair figure
+//! for "what one open session costs". Non-Linux prints the shape only.
+
+mod common;
+
+use common::{Session, Spec};
+use zoetrope::state::{App, Mode};
+use zoetrope::tailer::{UiEvent, replay_from_session};
+
+/// Resident set size in bytes, or `None` where `/proc` is not available.
+fn rss() -> Option<usize> {
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let pages: usize = statm.split_whitespace().nth(1)?.parse().ok()?;
+    Some(pages * page_size())
+}
+
+fn page_size() -> usize {
+    // 4 KiB everywhere this runs; reading it out of `getconf` is not worth a dep.
+    4096
+}
+
+fn mb(bytes: usize) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+/// Load one scale end to end, sampling RSS at each stage.
+fn measure(name: &str, spec: Spec) {
+    let base = rss();
+
+    let s: Session = common::session(spec);
+    let after_gen = rss();
+
+    let (items, info) = replay_from_session(&s.main, &s.demo_subagents());
+    let item_count = items.len();
+    let after_items = rss();
+
+    let mut app = App::new("bench".to_string(), Mode::Live);
+    app.handle_ui_event(UiEvent::ReplayLoaded {
+        session_id: "bench".to_string(),
+        items,
+        speed: 8.0,
+        info,
+    });
+    app.go_live();
+    let after_app = rss();
+
+    let delta = |a: Option<usize>, b: Option<usize>| match (a, b) {
+        (Some(a), Some(b)) => format!("{:>8.1}", mb(b.saturating_sub(a))),
+        _ => "     n/a".to_string(),
+    };
+
+    println!(
+        "{name:<7} {:>7} {:>9.1} {:>9} {:>8} {:>8} {:>8} {:>8} {:>7} {:>7}",
+        s.lines(),
+        mb(s.bytes()),
+        item_count,
+        delta(base, after_gen),
+        delta(after_gen, after_items),
+        delta(after_items, after_app),
+        delta(base, after_app),
+        app.session.agents.len(),
+        app.flow.nodes().count(),
+    );
+
+    // Keep everything alive to the end of the measurement.
+    std::hint::black_box(&s);
+    std::hint::black_box(&app);
+}
+
+fn main() {
+    println!("synthetic session memory baseline (RSS deltas, MB)\n");
+    println!(
+        "{:<7} {:>7} {:>9} {:>9} {:>8} {:>8} {:>8} {:>8} {:>7} {:>7}",
+        "scale", "lines", "text MB", "items", "gen", "items", "app", "total", "agents", "nodes"
+    );
+    println!("{}", "-".repeat(88));
+    // Each scale runs in its own process-lifetime segment; the allocator's
+    // retained pages make later rows read high, so run them smallest-first and
+    // read each row's `total` as the headline.
+    measure("small", Spec::SMALL);
+    measure("medium", Spec::MEDIUM);
+    measure("large", Spec::LARGE);
+}

--- a/benches/timeline.rs
+++ b/benches/timeline.rs
@@ -1,0 +1,183 @@
+//! Baseline benchmarks for the parse → timeline → fold → seek pipeline.
+//!
+//! Every input is synthesized (`common::session`) — the benches never read a
+//! real transcript, so a run is reproducible on any machine. Three scales
+//! bracket what the format produces in practice: a short session, a long
+//! working session, and a pathologically large one.
+//!
+//! What each group answers:
+//! - `parse`   — raw `parse_line` throughput, the floor on any cold open.
+//! - `load`    — assembling the ts-ordered timeline, and folding it into a model.
+//! - `seek`    — the playhead moves. `seek_back_*` is the O(k) rebuild path
+//!   (`App::rebuild_to`), the number that decides whether scrubbing is usable.
+
+mod common;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+use std::time::Duration;
+
+use common::{Session, Spec};
+use zoetrope::state::session::SessionModel;
+use zoetrope::state::{App, Mode};
+use zoetrope::tailer::{ReplayItem, UiEvent, replay_from_session};
+use zoetrope::transcript;
+
+/// The scales every group runs over.
+fn scales() -> Vec<(&'static str, Session)> {
+    vec![
+        ("small", common::session(Spec::SMALL)),
+        ("medium", common::session(Spec::MEDIUM)),
+        ("large", common::session(Spec::LARGE)),
+    ]
+}
+
+/// Assemble the ts-ordered timeline for a session (the untimed setup step
+/// shared by the fold and seek benches).
+fn items_of(s: &Session) -> Vec<ReplayItem> {
+    replay_from_session(&s.main, &s.demo_subagents()).0
+}
+
+/// An App with the whole session loaded and the playhead at the live edge —
+/// the state a user is in when they grab the scrubber.
+fn app_at_edge(s: &Session) -> App {
+    let (items, info) = replay_from_session(&s.main, &s.demo_subagents());
+    let mut app = App::new("bench".to_string(), Mode::Live);
+    app.handle_ui_event(UiEvent::ReplayLoaded {
+        session_id: "bench".to_string(),
+        items,
+        speed: 8.0,
+        info,
+    });
+    app.go_live();
+    app
+}
+
+fn bench_parse(c: &mut Criterion) {
+    let mut g = c.benchmark_group("parse");
+    for (name, s) in scales() {
+        // Every line of every file — what a cold open of one session reads.
+        let lines: Vec<&str> = s
+            .main
+            .lines()
+            .chain(s.sidecars.iter().flat_map(|sc| sc.transcript.lines()))
+            .collect();
+        let bytes: usize = lines.iter().map(|l| l.len() + 1).sum();
+        g.throughput(Throughput::Bytes(bytes as u64));
+        g.bench_with_input(BenchmarkId::new("parse_line", name), &lines, |b, lines| {
+            b.iter(|| {
+                let mut n = 0usize;
+                for l in lines {
+                    if transcript::parse_line(black_box(l)).is_some() {
+                        n += 1;
+                    }
+                }
+                n
+            })
+        });
+    }
+    g.finish();
+}
+
+fn bench_load(c: &mut Criterion) {
+    let mut g = c.benchmark_group("load");
+    // A cold open at the large scale is on the order of a second, so the
+    // criterion defaults (100 samples, 3 s warm-up) would run for many minutes
+    // to sharpen a number whose interesting digit is the first one.
+    g.sample_size(10);
+    g.warm_up_time(Duration::from_millis(500));
+    g.measurement_time(Duration::from_secs(10));
+    for (name, s) in scales() {
+        g.throughput(Throughput::Bytes(s.bytes() as u64));
+
+        // Text → dated, sorted timeline items.
+        g.bench_with_input(BenchmarkId::new("replay_assemble", name), &s, |b, s| {
+            b.iter(|| black_box(items_of(s).len()))
+        });
+
+        // Items → model. The pure fold, no graph projection.
+        g.bench_with_input(BenchmarkId::new("fold_cold", name), &s, |b, s| {
+            b.iter_batched(
+                || items_of(s),
+                |items| {
+                    let mut m = SessionModel::new("bench".to_string());
+                    for it in &items {
+                        m.apply_update(&it.update);
+                    }
+                    black_box(m.agents.len())
+                },
+                BatchSize::LargeInput,
+            )
+        });
+
+        // The real cold open: assemble + fold + project onto the flow graph.
+        g.bench_with_input(BenchmarkId::new("app_cold_open", name), &s, |b, s| {
+            b.iter(|| black_box(app_at_edge(s).flow.nodes().count()))
+        });
+    }
+    g.finish();
+}
+
+fn bench_seek(c: &mut Criterion) {
+    let mut g = c.benchmark_group("seek");
+    // Each sample re-loads the session in untimed setup (a seek mutates the
+    // App, so it cannot be reused) — same reasoning as `load` above.
+    g.sample_size(10);
+    g.warm_up_time(Duration::from_millis(500));
+    g.measurement_time(Duration::from_secs(10));
+    for (name, s) in scales() {
+        let n = items_of(&s).len();
+        g.throughput(Throughput::Elements(n as u64));
+
+        // Backward seek to the middle — rebuilds the model from items[0..n/2].
+        g.bench_with_input(BenchmarkId::new("back_to_50pct", name), &s, |b, s| {
+            b.iter_batched_ref(
+                || app_at_edge(s),
+                |app| app.seek_to_fraction(black_box(0.5)),
+                BatchSize::PerIteration,
+            )
+        });
+
+        // Backward seek to the start — the cheapest rebuild (folds nothing) but
+        // still pays the full model + flow teardown.
+        g.bench_with_input(BenchmarkId::new("back_to_start", name), &s, |b, s| {
+            b.iter_batched_ref(
+                || app_at_edge(s),
+                |app| app.seek_to_fraction(black_box(0.0)),
+                BatchSize::PerIteration,
+            )
+        });
+
+        // Forward seek across the whole timeline — the in-place fold path, for
+        // contrast with the rebuild above.
+        g.bench_with_input(BenchmarkId::new("fwd_start_to_edge", name), &s, |b, s| {
+            b.iter_batched_ref(
+                || {
+                    let mut app = app_at_edge(s);
+                    app.seek_to_fraction(0.0);
+                    app
+                },
+                |app| app.seek_to_fraction(black_box(1.0)),
+                BatchSize::PerIteration,
+            )
+        });
+
+        // A scrub drag: ten backward hops. This is what holding the mouse down
+        // on the scrubber actually costs.
+        g.bench_with_input(BenchmarkId::new("drag_10_back", name), &s, |b, s| {
+            b.iter_batched_ref(
+                || app_at_edge(s),
+                |app| {
+                    for i in (0..10).rev() {
+                        app.seek_to_fraction(black_box(i as f64 / 10.0));
+                    }
+                },
+                BatchSize::PerIteration,
+            )
+        });
+    }
+    g.finish();
+}
+
+criterion_group!(benches, bench_parse, bench_load, bench_seek);
+criterion_main!(benches);

--- a/benches/timeline.rs
+++ b/benches/timeline.rs
@@ -162,6 +162,18 @@ fn bench_seek(c: &mut Criterion) {
             )
         });
 
+        // One SMALL backward hop — what a scrubber drag actually delivers once
+        // `pending_seek` coalesces a burst to one seek per frame. The big jumps
+        // above are the worst case for patching the canvas; this is the case
+        // it exists for.
+        g.bench_with_input(BenchmarkId::new("back_one_hop", name), &s, |b, s| {
+            b.iter_batched_ref(
+                || app_at_edge(s),
+                |app| app.seek_to_fraction(black_box(0.95)),
+                BatchSize::PerIteration,
+            )
+        });
+
         // A scrub drag: ten backward hops. This is what holding the mouse down
         // on the scrubber actually costs.
         g.bench_with_input(BenchmarkId::new("drag_10_back", name), &s, |b, s| {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -339,17 +339,6 @@ Honest ledger of what's derived-but-imperfect, for whoever touches this next:
 - **Aggregate chip error-coloring.** A settled run shows a single aggregate
   ✓/✗; a run of N where only one call failed still reads as an error run. Cosmetic
   over-alarm, noted for a future pass.
-- **Selecting a monitored session's node does nothing.** The canvas lets you click
-  any card, but the detail panel reads the focused model, so a card in another
-  session highlights and shows nothing — with no affordance saying why. Either
-  selecting it should focus that session, or the panel should render a read-only
-  summary from the monitored model.
-- **`MonitorBatch`/`MonitorReset` encode a routing decision the App already makes.**
-  "Is this the focused session" is exactly `is_current(session_id)`; carrying it in
-  the wire protocol as parallel variants means every future per-session event faces
-  the same fork. It already bit once: a monitor's `Error` is dropped, because there
-  is no `MonitorError`. The deeper fix is one tailer owning every session, which
-  also removes a poll loop and two relay tasks per monitored session.
 - **The monitor fleet is capped silently.** Past `MAX_MONITORED` a live session is
   simply not drawn, and nothing on screen says so.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,9 @@ The whole program solves one hard problem:
 > agent session from an **undocumented, append-only, partially-timestamped,
 > multi-file** transcript — in which **completion is frequently unknowable**.
 
-Almost every design decision below is downstream of that one sentence.
+Almost every design decision below is downstream of that one sentence. Watching
+*every* live session at once (§8) adds a second: the same reconstruction, N times
+over, cheaply enough that the sessions nobody is looking at cost almost nothing.
 
 ---
 
@@ -243,9 +245,87 @@ Detailed in [`DESIGN.md`](DESIGN.md#timeline); the architectural essence:
 - **Transport is emergent** (`Live`/`Playing`/`Paused`/`History`/`Idle`), read from
   edge-following + append freshness — never a hardcoded mode.
 
+### 6.1 Seeking backward without re-folding (the snapshot ladder)
+
+Folding is forward-only, so moving the playhead back means rebuilding the model
+from a prefix. Doing that from item zero costs O(k) in the distance travelled —
+visibly janky on a large session.
+
+- **A snapshot is a clone.** `SessionModel` is built from persistent (`imbl`)
+  collections, so cloning it is O(1) and shares structure rather than copying.
+  A ladder of rungs every `SNAPSHOT_STRIDE` items therefore costs little, and a
+  backward seek restores the nearest rung and folds forward from there.
+- **This only works if the *values* are persistent too.** `imbl` copy-on-writes
+  the value at a touched node, so an `AgentInfo` owning a plain `Vec` of tool
+  calls would deep-copy that agent's whole history on every append — O(n²), the
+  exact quadratic `tool_index` was added to remove. Every growing collection in
+  the model is persistent, not just the outer map.
+- **Rungs hold fold state, never projections.** Liveness and workflow rollups are
+  functions of the playhead (§4), not of the fact set, so baking them into a rung
+  would restore yesterday's answer. `resync` re-runs them after every restore.
+  This is the fold/projection split (§2) becoming load-bearing rather than
+  descriptive.
+- **Item indices are not stable, so rungs expire.** A late batch that dates a
+  previously-pending item re-sorts the list around it (undated items sort ahead
+  of dated ones), shifting every index in between. A rung keyed to `items[0..N]`
+  then silently describes a different prefix — wrong, not slow. `Timeline::generation`
+  moves on every re-sort and stale rungs are discarded.
+
+The remaining cost of a backward seek is no longer the fold: `rebuild_to` still
+discards the whole `Flow` and re-projects it. That is the next thing to fix, and
+why `agents` is an `OrdMap` (which has a structural `diff`) rather than the
+faster `HashMap` (which does not).
+
 ---
 
-## 7. Known soft spots
+## 7. Watching every live session
+
+The canvas shows every session that is currently running, each as a root card
+with its agents beneath it. The rail indexes them — including the idle ones the
+canvas leaves out — and picks which one is *focused*.
+
+- **Only the focused session gets a playhead.** It owns the `Timeline` and can be
+  scrubbed; the rest are folded straight off their live edge and only render.
+  The asymmetry is the domain shape, not an accident: one collection holding both
+  would either hand every session a timeline it never uses, or pretend the focused
+  one is not special when every seek path says it is.
+- **A monitored session costs a model, not a timeline.** Its batches fold and are
+  dropped, so N sessions cost `1× items + N× models` — and a model is small next
+  to the parsed item list.
+- **Discovery over-includes, then the bytes decide.** The stat sweep filters on
+  mtime, which can only ever *over*-include (appending always advances it), so no
+  live session can be filtered out. The index then reports ground truth. Activity
+  is the newest mtime across the main transcript **and its sidecars**: a session
+  blocked on a subagent writes nothing to its own file, and filtering on that file
+  alone drops exactly the sessions most worth watching.
+- **Focus is derived, never stored twice.** The rail marks whichever row matches
+  the session actually being watched, which the tailer confirms via `SessionReset`.
+  A parallel focus field would eventually point at a session nobody is tailing —
+  a marker that lies.
+- **Node ids carry their session.** Every `SessionModel` names its root `"main"`,
+  so a shared flow needs the session in the id or the second root is a duplicate
+  no-op and its agents hang off the first session's tree. Wrong picture, no error.
+
+### 7.1 A second reader of the same format
+
+The skeleton index parses none of the payload — it probes for the handful of
+facts the timeline needs and leaves the body on disk. Two readers of one
+undocumented format is normally a mistake; here it is the point, and the thing
+that makes it legitimate is that **the fast path is never allowed to guess**:
+
+- where the format is ambiguous, the record says so and the caller parses that
+  line properly;
+- a differential test asserts record-for-record agreement with the real parser
+  over a whole corpus.
+
+That test is not a formality. Both format-drift bugs it found — envelope keys
+that are not emitted first, and activity counts that must come from real content
+blocks rather than from text that merely contains the literal — were invisible to
+review and to every synthetic fixture.
+
+---
+
+## 8. Known soft spots
 
 Honest ledger of what's derived-but-imperfect, for whoever touches this next:
 
@@ -259,6 +339,19 @@ Honest ledger of what's derived-but-imperfect, for whoever touches this next:
 - **Aggregate chip error-coloring.** A settled run shows a single aggregate
   ✓/✗; a run of N where only one call failed still reads as an error run. Cosmetic
   over-alarm, noted for a future pass.
+- **Selecting a monitored session's node does nothing.** The canvas lets you click
+  any card, but the detail panel reads the focused model, so a card in another
+  session highlights and shows nothing — with no affordance saying why. Either
+  selecting it should focus that session, or the panel should render a read-only
+  summary from the monitored model.
+- **`MonitorBatch`/`MonitorReset` encode a routing decision the App already makes.**
+  "Is this the focused session" is exactly `is_current(session_id)`; carrying it in
+  the wire protocol as parallel variants means every future per-session event faces
+  the same fork. It already bit once: a monitor's `Error` is dropped, because there
+  is no `MonitorError`. The deeper fix is one tailer owning every session, which
+  also removes a poll loop and two relay tasks per monitored session.
+- **The monitor fleet is capped silently.** Past `MAX_MONITORED` a live session is
+  simply not drawn, and nothing on screen says so.
 
 ---
 
@@ -275,3 +368,9 @@ Honest ledger of what's derived-but-imperfect, for whoever touches this next:
 7. A heuristic is legitimate only when it is a **reversible function of current
    facts filling a real gap** — never when it overrides ground truth already in the
    model.
+8. A **fast path may be faster, never different** — where it cannot know, it says
+   so, and a differential test keeps it honest.
+9. **Cache the fold, never the projection.** Anything derived from the playhead is
+   re-run after a restore, not stored with it.
+10. **An index into a list that can re-sort is not an identity.** Anything keyed by
+    position carries the generation it was taken under.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -100,7 +100,7 @@ src/
 ├── autopilot.rs   # native-only: the scripted pointer/keystroke pilot behind ZOETROPE_DEMO=1 (see DEMO-ASSETS.md)
 ├── transcript.rs  # serde model for JSONL entries + meta.json sidecars + project-dir discovery/sanitization
 ├── index.rs       # native-only: skeleton index — 32 bytes/line of facts, no body parsing; append-incremental, cached
-├── sessions.rs    # native-only: multi-session discovery (stat sweep) + Summary folded from index records
+├── sessions.rs    # native-only: multi-session discovery (cached stat sweep) + Summary folded from index records
 ├── monitor.rs     # native-only: the monitor fleet — one tailer per live unfocused session; publishes rail rows
 ├── state/
 │   ├── mod.rs     # App: owns the Flow + SessionModel + Timeline + SessionInfo + UI state; handle_ui_event, seek, camera
@@ -131,15 +131,22 @@ beneath it. Only one session is *focused*; the rail picks which.
 
 ```text
 discovery (2s sweep, blocking pool)
-  sessions::discover   stat every ~/.claude/projects/*/<uuid>.jsonl + its sidecars
+  sessions::Sweeper    stat every ~/.claude/projects/*/<uuid>.jsonl + its sidecars,
+                       reusing the sidecar list and the folded Summary of anything
+                       whose mtimes and size have not moved since the last tick
   sessions::Summary    fold index records → counts, first/last activity, cwd
       │
       ├── UiEvent::Sessions(Vec<RailRow>) ──────────────► App.rail        (the rail pane)
       └── monitor::supervise: one tailer per live UNFOCUSED session
-             └── UiEvent::MonitorBatch / MonitorReset ──► App.others      (model only, no timeline)
+             └── UiEvent::Batch / SessionReset ─────────► App.others      (model only, no timeline)
 
-focus tailer (unchanged)
+focus tailer
       └── UiEvent::Batch / SessionReset ────────────────► App.session     (model + Timeline)
+
+Every tailer emits the SAME events, stamped with a `session_id`; the App routes
+on that alone, because it is the only thing that knows which session is focused.
+A monitor stopping because focus took its session is therefore NOT a reset —
+see `monitor::retired`.
 ```
 
 - **`App.session` vs `App.others`.** The focused session owns a `Timeline` and can
@@ -266,7 +273,7 @@ pub enum TailRequest { Watch(PathBuf) }                  // switch session; only
 pub enum UiEvent {
     ReplayLoaded { session_id, items: Vec<ReplayItem>, speed, info: SessionInfo }, // bulk hand-off
     Batch { session_id: String, updates: Vec<Update> },  // appends, per poll tick (live + post-load tailing)
-    SessionReset { session_id: String },                 // truncation/rotation/auto-switch
+    SessionReset { session_id: String },                 // truncation/rotation
     Error(String),
 }
 pub enum Update {
@@ -282,8 +289,8 @@ pub enum Timing {                     // how an item is placed on the timeline (
 ```
 
 **Two load strategies, one tail loop.** Both feeders end in the shared `tail_loop`, so EVERY session keeps tailing for appends (a replayed file that grows just "goes live" on its own — completion is unknowable, so nothing is ever assumed finished):
-- **File target** (`run_replay`): `build_replay` parses every session file, dates untimed metas/journals/`ai-title` (`date_and_sort`), **routes the untimed flat-metadata into `SessionInfo`** (off the timeline via `is_timeline_noise`), and merges the rest into a ts-sorted `Vec<ReplayItem>` → one `ReplayLoaded`. Then enter `tail_loop`, resuming each file's tail from the **byte offset the parse consumed** (a *snapshot seed* — not live EOF — so lines appended *during* the parse aren't dropped). Auto-switch disabled (`project_dir = None`; you asked for this file).
-- **Dir/none target** (`run_live`): announce `SessionReset` (id adoption), then `tail_loop` — the first poll backfills the existing file (arrival order); subsequent polls emit appends; the project dir is re-scanned for a *newer* session (throttled auto-switch: `SWITCH_SCAN_EVERY`~2s, only after `SWITCH_IDLE_TICKS`~30s idle, dir targets only).
+- **File target** (`run_replay`): `build_replay` parses every session file, dates untimed metas/journals/`ai-title` (`date_and_sort`), **routes the untimed flat-metadata into `SessionInfo`** (off the timeline via `is_timeline_noise`), and merges the rest into a ts-sorted `Vec<ReplayItem>` → one `ReplayLoaded`. Then enter `tail_loop`, resuming each file's tail from the **byte offset the parse consumed** (a *snapshot seed* — not live EOF — so lines appended *during* the parse aren't dropped). Nothing ever re-targets the tailer on its own — it watches the file it was asked for.
+- **Dir/none target** (`run_live`): resolve the directory to its newest session ONCE, then `tail_loop` — the first poll backfills the existing file (arrival order); subsequent polls emit appends. There is no announce and no auto-switch: the App picks the session (it is the only thing that knows which one is focused) and tells the tailer via `TailRequest::Watch`, so their ids can never disagree. Discovery (`monitor::supervise`) is what notices a newer session; changing focus is then the App's decision, not the tailer's.
 
 Per-file tail state `{ offset, partial, overflowed, identity: (dev, ino) }`. Each tick: stat the file; a shrink (`len < offset`) **or an inode swap** (rotation — a different `(dev,ino)` even if not shorter) → reset + `SessionReset` and re-attach; grown → read appended bytes, split on `\n`, parse complete lines, buffer the trailing partial (a runaway line past `MAX_PARTIAL`=8 MiB is dropped, not buffered forever). Scan `subagents/**` each tick for new files (cheap readdir; absent dirs are fine).
 
@@ -311,9 +318,9 @@ pub struct Timeline {
 - **`replay`** is the one surviving "mode" bit — the **launch intent**: are you replaying a recording, or following a live session? Set from the launch `Mode`, and **not runtime-derivable** (a quiet live session is byte-identical to a finished recording, so the flag can't be eliminated). It is NOT a claim the file is complete — a replay can grow and go live (the feeder always tails; nothing is assumed finished), which is why it's named for the intent, not a "bounded/complete" property. It does NOT gate pacing (the edge does); it gates only the `now` reference and the end-settle latch.
 - **Pacing** (`advance`, per 16ms frame): paces the cursor toward the next event, **compressing dead air** — but not with a flat cap. `compress_gap` is a **log-compression** curve (`GAP_FAITHFUL_KNEE`=0.8s, `GAP_COMPRESS_SCALE`=0.6): real-time below the knee, then `knee + scale·ln(1 + (t−knee)/knee)` above it — *graded*, so a 5-minute wait still reads longer than a 5-second one (an hour of dead air crosses in <10s). The `g` key sets `compress_gaps = false` for faithful real-time pacing. The App folds the prefix `items[0..fold_target()]` (`App::fold_to`); the live append and replay paths share it.
 - **`now` reference** = wall clock only at a *live* edge (`!replay && follow_head && at_edge`), the cursor otherwise (incl. live catch-up) — so a replay always judges liveness as-of-the-playhead (its timestamps are a past recording, unrelated to wall time). See Status rules.
-- **Seek / scrub** (`App::seek`, `seek_to_fraction`, `seek_prompt`, `go_live`): forward → fold in place (cheap); backward → `App::rebuild_to` restores the nearest **snapshot ladder** rung and folds forward from it, re-syncing and carrying view across by id (`graph::restore_positions` + `select_node`).
+- **Seek / scrub** (`App::seek`, `seek_to_fraction`, `seek_prompt`, `go_live`): forward → fold in place (cheap); backward → `App::rebuild_to` restores the nearest **snapshot ladder** rung and folds forward from it. The `Flow` is *patched*, not rebuilt: `OrdMap::diff` between the outgoing and restored models names the agents that left, and only those nodes come off (`graph::remove_agents`, one `retain_nodes` pass). Everything else — positions, viewport, selection, and every other session's subtree — is simply never touched.
 - **The snapshot ladder** (`App::snapshots`, `SNAPSHOT_STRIDE`): a rung every N folded items, taken *inside* the fold loop — a jump to the live edge folds the whole timeline in one call, so a ladder recording only where each fold *ended* would hold one useless rung at the edge. Restoring a rung is `SessionModel::clone`, which is O(1) because the model is built from persistent (`imbl`) collections. A rung stores **fold state only**; liveness and workflow rollups are playhead-dependent projections and are re-run by `resync` after every restore.
-- **`generation` guards the ladder.** Item indices are NOT stable: `append_live` re-sorts the whole list whenever a batch carries untimed items or dates a previously-`Pending` one, and undated items sort ahead of dated ones — so a resolving item jumps right and shifts every index in between. A rung keyed to `items[0..N]` would then describe a different prefix. Rungs record the generation they were taken under and are discarded wholesale when it moves. `SessionReset` clears them outright, since a fresh `Timeline` restarts the counter and they could not be told apart by it. A seek is discontinuous → ephemerals reset (chips re-baseline via `adopt_baseline`, then the per-frame `reconcile` reconstructs in-flight runs from state; glide cancels — see [`ARCHITECTURE.md`](ARCHITECTURE.md) §5). `space` is a unified play/pause that resumes from the current cursor; `End`/`go_live` re-pins to the edge.
+- **`generation` guards the ladder.** Item indices are NOT stable: `append_live` re-sorts the whole list whenever a batch carries untimed items or dates a previously-`Pending` one, and undated items sort ahead of dated ones — so a resolving item jumps right and shifts every index in between. A rung keyed to `items[0..N]` would then describe a different prefix. Rungs record the generation they were taken under. When it moves, only the rungs the re-sort could actually have disturbed are dropped: the timeline reports how much of the prefix it left alone (`Timeline::take_disturbance`), and rungs below that line are re-stamped instead. That distinction is what keeps the ladder useful live — a sidecar entry landing a moment out of order re-sorts the tail on most batches, and discarding everything there left every backward seek folding from item zero. `SessionReset` clears them outright, since a fresh `Timeline` restarts the counter and they could not be told apart by it. A seek is discontinuous → ephemerals reset (chips re-baseline via `adopt_baseline`, then the per-frame `reconcile` reconstructs in-flight runs from state; glide cancels — see [`ARCHITECTURE.md`](ARCHITECTURE.md) §5). `space` is a unified play/pause that resumes from the current cursor; `End`/`go_live` re-pins to the edge.
 - **Scrubber position is event-indexed, not time-linear** — real sessions cluster work then sit idle (the rwy sample: ~11 min across 10.65 h), so a time-linear bar would bury all action in a sliver. `progress` / `fold_at_fraction` map the bar over `[floor, len]` where `floor` is the unavoidable start clump (same-timestamp ties + dated metadata that can only fold atomically), so the leftmost click reaches position 0. `gap_markers` (≥`GAP_MARKER_SECS`=60s) place the fast-forward `»` markers on the marker strip. Because the axis is event-indexed, a raw event-count would be flat — so the track is a **tool-activity sparkline** (per-column sum of `Entry::tool_use_count` over its item range) which peaks where the work happened; see UI.
 - **Emergent transport** (`App::transport` → Live / Playing / Paused / History / Idle): "Live" = following the edge **and** a fresh append (`last_batch_at` within ~10s), so a resumed *replay* reads Live and an old followed session reads Idle. Drives the status badge + scrubber tag — never a hardcoded mode.
 
@@ -348,7 +355,7 @@ The crossterm input channel is **unbounded** (input must never block); the **cap
 
 ## Graph sync (state/graph.rs — rwy's incremental pattern)
 
-- **Never rebuild — except a backward seek.** Forward (live/replay playback): `flow.node_content_mut(id)` → mutate in place; else `flow.add_node(...)` + `flow.add_edge(...)` (duplicate-id `Err` is an idempotent no-op; add nodes before edges). The ONE exception is scrubbing into the past: folding is forward-only, so `App::rebuild_to` restores a ladder rung and rebuilds the `Flow` from the prefix, with `graph::restore_positions` carrying node positions across by id (selection too) so the layout doesn't jump.
+- **Never rebuild — except a backward seek.** Forward (live/replay playback): `flow.node_content_mut(id)` → mutate in place; else `flow.add_node(...)` + `flow.add_edge(...)` (duplicate-id `Err` is an idempotent no-op; add nodes before edges). The ONE exception is scrubbing into the past: folding is forward-only, so `App::rebuild_to` restores a ladder rung — but the `Flow` survives it. Seeking back can only *remove* agents, and `sync` adds and updates but never removes, so the difference is exactly the departed nodes (`OrdMap::diff` → `graph::remove_agents`). Nothing has to be captured and restored around a teardown, so positions and selection carry across by construction.
 - **Node ids are `<session>/<agent>`** (`graph::node_id` / `split_node_id`, separator `graph::ID_SEP`). One flow holds every watched session and every `SessionModel` calls its root `"main"`, so the session has to be in the id. `sync` is the only place the model's session-local ids and the flow's ids meet.
 - **Session trees are shelf-packed** (`graph::pack_sessions`): rataflow applies each connected component's Sugiyama coordinates verbatim — its layout loop discards exactly the per-component offsets that would separate them — so without a packing pass every session's tree stacks at the origin. Rows rather than one endless line, with the row count chosen for the best **screen** aspect (world units are cells, and a cell is ~2× taller than wide, so `CELL_ASPECT` converts before comparing). Packing moves whole sessions only; positions *within* a session are untouched, which is what lets `repack_if_overlapping` run on every structural change — a session that grows into its neighbour is separated, while a session the user dragged somewhere clear is left alone.
 - Node: `Node::new(id, (0.0, 0.0), (W, H), AgentNode{…})` — fixed dims ~`(30.0, 7.0)` main/workflow, ~`(26.0, 6.0)` subagents (explicit dims; no DOM-style measuring). Handles: `Handle::source(HandlePosition::Bottom).with_hidden(true)`, `Handle::target(HandlePosition::Top).with_hidden(true)` (clean look, rwy does this).

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -22,9 +22,13 @@ zoe <dir>                # follow another project's live session
 zoe <file> --follow      # ride a file's live edge instead of replaying it
 zoe <file> --speed 8     # playback speed (default 8.0)
 zoe inspect <file.jsonl> # no TUI: print session info + parsed tree (smoke-test)
+zoe sessions             # no TUI: list every session active in a window, with sweep timings
+zoe sessions --since 120 --root DIR
 ```
 
-Resolution: a **file** target bulk-loads + tails (replay feeder); a **dir** (or none → cwd) discovers the latest session and live-tails. `--follow` only changes the start position (head vs beginning) via `Mode`. `Cli = View { target: Option<PathBuf>, follow: bool, speed: f64 } | Inspect { file }`. Arg parsing: hand-rolled over `std::env::args` (no clap; keep deps lean).
+Resolution: a **file** target bulk-loads + tails (replay feeder); a **dir** (or none → cwd) discovers the latest session and live-tails. `--follow` only changes the start position (head vs beginning) via `Mode`. `Cli = View { target: Option<PathBuf>, follow: bool, speed: f64 } | Inspect { file } | Sessions { window, root }`. Arg parsing: hand-rolled over `std::env::args` (no clap; keep deps lean).
+
+`ZOE_PROJECTS_ROOT` overrides `~/.claude/projects` for both discovery and `project_dir`. It exists because the multi-session rail is otherwise only exercisable by running several real Claude Code sessions at once; with it, a fixture workspace is a directory. `zoe sessions --root` does the same for the headless sweep.
 
 ## Workspace layout
 
@@ -48,6 +52,11 @@ web/wasm/           # the zoetrope-web crate: Cargo.toml, index.html (trunk entr
 
 ```toml
 # Portable core (native + wasm): model, timeline, graph, UI rendering, parsing.
+# imbl — persistent collections. SessionModel is built from them so cloning it is
+#   O(1) and can be used as a snapshot (see Timeline / ARCHITECTURE.md §6.1).
+#   Arc-backed by default, so the model stays Send for the tokio tasks.
+# memchr, memmap2 — native-only, behind the `native` feature: the skeleton index's
+#   SIMD probes and its no-copy re-scan of already-indexed files.
 ratatui       = { version = "0.30", default-features = false, features = ["underline-color"] }
 rataflow  = { path = "../rataflow", default-features = false, features = ["sugiyama"] }
 serde         = { version = "1", features = ["derive"] }
@@ -90,11 +99,15 @@ src/
 ├── handler.rs     # input routing: app-level keys → App, the rest → the flow; scrubber clicks; process_flow_events
 ├── autopilot.rs   # native-only: the scripted pointer/keystroke pilot behind ZOETROPE_DEMO=1 (see DEMO-ASSETS.md)
 ├── transcript.rs  # serde model for JSONL entries + meta.json sidecars + project-dir discovery/sanitization
+├── index.rs       # native-only: skeleton index — 32 bytes/line of facts, no body parsing; append-incremental, cached
+├── sessions.rs    # native-only: multi-session discovery (stat sweep) + Summary folded from index records
+├── monitor.rs     # native-only: the monitor fleet — one tailer per live unfocused session; publishes rail rows
 ├── state/
 │   ├── mod.rs     # App: owns the Flow + SessionModel + Timeline + SessionInfo + UI state; handle_ui_event, seek, camera
 │   ├── session.rs # SessionModel: the pure domain model (agents, statuses, tool calls) derived from parsed updates
 │   ├── timeline.rs# Timeline: the ts-ordered item list + playhead (time-travel); pacing, gap-compression, seek, floor
-│   ├── graph.rs   # incremental SessionModel → Flow projection (never rebuilds except backward seek; Sugiyama on `r`)
+│   ├── graph.rs   # incremental SessionModel → Flow projection; session-scoped node ids; shelf-packs session trees
+│   ├── rail.rs    # portable session-rail state: rows, focus derivation, visibility (fed by native discovery)
 │   └── info.rs    # SessionInfo: untimed session metadata, folded off the timeline (i overlay + inspect header)
 ├── tailer/        # background FEEDER (pure: no pacing/seeking — the App owns the playhead)
 │   ├── mod.rs     # task entry + shared wire types (TailRequest / UiEvent / Update / Source)
@@ -107,8 +120,70 @@ src/
     ├── nodes.rs   # AgentNode: the agent-card NodeContent (semantic zoom: Card vs Cell)
     ├── edges.rs   # AgentEdge: parent→agent EdgeContent (animated while target Running)
     ├── chips.rs   # ephemeral tool-call chips — one reconcile pass, anchored to agent nodes (see ARCHITECTURE.md §5)
+    ├── rail.rs    # the session rail pane: one row per discovered session, themed from the flow palette
     └── panel.rs   # detail panel for the selected agent
 ```
+
+## Multi-session
+
+The canvas shows **every live session**, each as a root card with its agents
+beneath it. Only one session is *focused*; the rail picks which.
+
+```text
+discovery (2s sweep, blocking pool)
+  sessions::discover   stat every ~/.claude/projects/*/<uuid>.jsonl + its sidecars
+  sessions::Summary    fold index records → counts, first/last activity, cwd
+      │
+      ├── UiEvent::Sessions(Vec<RailRow>) ──────────────► App.rail        (the rail pane)
+      └── monitor::supervise: one tailer per live UNFOCUSED session
+             └── UiEvent::MonitorBatch / MonitorReset ──► App.others      (model only, no timeline)
+
+focus tailer (unchanged)
+      └── UiEvent::Batch / SessionReset ────────────────► App.session     (model + Timeline)
+```
+
+- **`App.session` vs `App.others`.** The focused session owns a `Timeline` and can
+  be scrubbed; monitored ones are folded straight off their live edge and only
+  render. One collection holding both would either give every session a timeline
+  it never uses, or pretend the focused one is not special when every seek path
+  says it is.
+- **Node ids are session-scoped** (`<session>/<agent>`, `graph::node_id`). Every
+  `SessionModel` names its root `"main"`, so a shared flow needs the session in
+  the id or the roots collide — silently merging two sessions into one tree.
+- **Focus is derived, never stored twice.** The rail marks whichever row matches
+  `App.current_session_id`, which `SessionReset` updates when a switch actually
+  lands. A parallel focus field could point at a session the tailer is not
+  watching.
+- **Only *running* sessions get a monitor** (activity within `RAIL_IDLE_SECS`),
+  capped at `monitor::MAX_MONITORED`. The rail lists everything from the last day;
+  the canvas is for what is happening now.
+
+## Skeleton index (index.rs)
+
+A second reader of the same format, deliberately: the timeline needs a few dozen
+bytes per line (when, what kind, whose agent, how much tool activity) out of a
+line that is mostly payload.
+
+- One fixed **32-byte `Rec` per line** — offset, length, timestamp, kind, agent
+  hash, tool/spawn/failure counts, flags. Bodies stay on disk.
+- **Envelope fields are read from the TOP LEVEL only.** Claude Code does not emit
+  envelope keys first, and nested objects reuse the names — an `attachment` entry
+  serializes `"attachment":{"type":…}` *before* its own `"type"`. Taking the first
+  match in the line reads the payload's type as the entry's kind.
+- **Activity counts come from real `message.content` blocks**, scoped by entry kind
+  the way the parser scopes them. A `user` line quoting output that mentions
+  `"name":"Agent"` is not a spawn.
+- **It never guesses.** Where the format is genuinely ambiguous (a legacy `user`
+  line with no `origin`) the record says so via `flags::AMBIGUOUS_PROMPT` and the
+  caller parses that one line properly.
+- **Append-only ⇒ extendable.** A grown file is scanned from `scanned_len`; the
+  result is cached under `$XDG_CACHE_HOME/zoetrope/idx/`, guarded by a head hash
+  so rotation is detected rather than misread. Bump `MAGIC` when any probe's
+  meaning changes.
+- `index::tests::skeleton_agrees_with_parser_on_a_real_corpus` (opt-in, via
+  `ZOE_DIFF_CORPUS`) asserts record-for-record agreement with `transcript::parse_line`.
+  That test is the only thing keeping two readers of one format honest — both
+  format-drift bugs above were found by it, not by review.
 
 ## Transcript format (verified against real data, Claude Code 2.1.153–2.1.165)
 
@@ -227,6 +302,7 @@ pub struct Timeline {
     pub follow_head: bool,        // pinned to the edge (playing/following) vs parked (scrubbed)
     pub speed: f64,
     pub compress_gaps: bool,      // skip idle dead air (default on); `g` toggles faithful pacing
+    pub generation: u64,          // bumped whenever an item INDEX changes meaning (re-sort / bulk load)
     // + cached head, gap-pacing anchor/elapsed, `undated_agents` (Pending-item join set), ended latch
 }
 ```
@@ -235,7 +311,9 @@ pub struct Timeline {
 - **`replay`** is the one surviving "mode" bit — the **launch intent**: are you replaying a recording, or following a live session? Set from the launch `Mode`, and **not runtime-derivable** (a quiet live session is byte-identical to a finished recording, so the flag can't be eliminated). It is NOT a claim the file is complete — a replay can grow and go live (the feeder always tails; nothing is assumed finished), which is why it's named for the intent, not a "bounded/complete" property. It does NOT gate pacing (the edge does); it gates only the `now` reference and the end-settle latch.
 - **Pacing** (`advance`, per 16ms frame): paces the cursor toward the next event, **compressing dead air** — but not with a flat cap. `compress_gap` is a **log-compression** curve (`GAP_FAITHFUL_KNEE`=0.8s, `GAP_COMPRESS_SCALE`=0.6): real-time below the knee, then `knee + scale·ln(1 + (t−knee)/knee)` above it — *graded*, so a 5-minute wait still reads longer than a 5-second one (an hour of dead air crosses in <10s). The `g` key sets `compress_gaps = false` for faithful real-time pacing. The App folds the prefix `items[0..fold_target()]` (`App::fold_to`); the live append and replay paths share it.
 - **`now` reference** = wall clock only at a *live* edge (`!replay && follow_head && at_edge`), the cursor otherwise (incl. live catch-up) — so a replay always judges liveness as-of-the-playhead (its timestamps are a past recording, unrelated to wall time). See Status rules.
-- **Seek / scrub** (`App::seek`, `seek_to_fraction`, `seek_prompt`, `go_live`): forward → fold in place (cheap); backward → `App::rebuild_to` re-folds the prefix into a fresh `SessionModel` and re-syncs, carrying view across by id (`graph::restore_positions` + `select_node`). A seek is discontinuous → ephemerals reset (chips re-baseline via `adopt_baseline`, then the per-frame `reconcile` reconstructs in-flight runs from state; glide cancels — see [`ARCHITECTURE.md`](ARCHITECTURE.md) §5). `space` is a unified play/pause that resumes from the current cursor; `End`/`go_live` re-pins to the edge.
+- **Seek / scrub** (`App::seek`, `seek_to_fraction`, `seek_prompt`, `go_live`): forward → fold in place (cheap); backward → `App::rebuild_to` restores the nearest **snapshot ladder** rung and folds forward from it, re-syncing and carrying view across by id (`graph::restore_positions` + `select_node`).
+- **The snapshot ladder** (`App::snapshots`, `SNAPSHOT_STRIDE`): a rung every N folded items, taken *inside* the fold loop — a jump to the live edge folds the whole timeline in one call, so a ladder recording only where each fold *ended* would hold one useless rung at the edge. Restoring a rung is `SessionModel::clone`, which is O(1) because the model is built from persistent (`imbl`) collections. A rung stores **fold state only**; liveness and workflow rollups are playhead-dependent projections and are re-run by `resync` after every restore.
+- **`generation` guards the ladder.** Item indices are NOT stable: `append_live` re-sorts the whole list whenever a batch carries untimed items or dates a previously-`Pending` one, and undated items sort ahead of dated ones — so a resolving item jumps right and shifts every index in between. A rung keyed to `items[0..N]` would then describe a different prefix. Rungs record the generation they were taken under and are discarded wholesale when it moves. `SessionReset` clears them outright, since a fresh `Timeline` restarts the counter and they could not be told apart by it. A seek is discontinuous → ephemerals reset (chips re-baseline via `adopt_baseline`, then the per-frame `reconcile` reconstructs in-flight runs from state; glide cancels — see [`ARCHITECTURE.md`](ARCHITECTURE.md) §5). `space` is a unified play/pause that resumes from the current cursor; `End`/`go_live` re-pins to the edge.
 - **Scrubber position is event-indexed, not time-linear** — real sessions cluster work then sit idle (the rwy sample: ~11 min across 10.65 h), so a time-linear bar would bury all action in a sliver. `progress` / `fold_at_fraction` map the bar over `[floor, len]` where `floor` is the unavoidable start clump (same-timestamp ties + dated metadata that can only fold atomically), so the leftmost click reaches position 0. `gap_markers` (≥`GAP_MARKER_SECS`=60s) place the fast-forward `»` markers on the marker strip. Because the axis is event-indexed, a raw event-count would be flat — so the track is a **tool-activity sparkline** (per-column sum of `Entry::tool_use_count` over its item range) which peaks where the work happened; see UI.
 - **Emergent transport** (`App::transport` → Live / Playing / Paused / History / Idle): "Live" = following the edge **and** a fresh append (`last_batch_at` within ~10s), so a resumed *replay* reads Live and an old followed session reads Idle. Drives the status badge + scrubber tag — never a hardcoded mode.
 
@@ -270,7 +348,9 @@ The crossterm input channel is **unbounded** (input must never block); the **cap
 
 ## Graph sync (state/graph.rs — rwy's incremental pattern)
 
-- **Never rebuild — except a backward seek.** Forward (live/replay playback): `flow.node_content_mut(id)` → mutate in place; else `flow.add_node(...)` + `flow.add_edge(...)` (duplicate-id `Err` is an idempotent no-op; add nodes before edges). The ONE exception is scrubbing into the past: folding is forward-only, so `App::rebuild_to` builds a fresh `SessionModel` + `Flow` from the prefix and `graph::restore_positions` carries node positions across by id (selection too) so the layout doesn't jump.
+- **Never rebuild — except a backward seek.** Forward (live/replay playback): `flow.node_content_mut(id)` → mutate in place; else `flow.add_node(...)` + `flow.add_edge(...)` (duplicate-id `Err` is an idempotent no-op; add nodes before edges). The ONE exception is scrubbing into the past: folding is forward-only, so `App::rebuild_to` restores a ladder rung and rebuilds the `Flow` from the prefix, with `graph::restore_positions` carrying node positions across by id (selection too) so the layout doesn't jump.
+- **Node ids are `<session>/<agent>`** (`graph::node_id` / `split_node_id`, separator `graph::ID_SEP`). One flow holds every watched session and every `SessionModel` calls its root `"main"`, so the session has to be in the id. `sync` is the only place the model's session-local ids and the flow's ids meet.
+- **Session trees are shelf-packed** (`graph::pack_sessions`): rataflow applies each connected component's Sugiyama coordinates verbatim — its layout loop discards exactly the per-component offsets that would separate them — so without a packing pass every session's tree stacks at the origin. Rows rather than one endless line, with the row count chosen for the best **screen** aspect (world units are cells, and a cell is ~2× taller than wide, so `CELL_ASPECT` converts before comparing). Packing moves whole sessions only; positions *within* a session are untouched, which is what lets `repack_if_overlapping` run on every structural change — a session that grows into its neighbour is separated, while a session the user dragged somewhere clear is left alone.
 - Node: `Node::new(id, (0.0, 0.0), (W, H), AgentNode{…})` — fixed dims ~`(30.0, 7.0)` main/workflow, ~`(26.0, 6.0)` subagents (explicit dims; no DOM-style measuring). Handles: `Handle::source(HandlePosition::Bottom).with_hidden(true)`, `Handle::target(HandlePosition::Top).with_hidden(true)` (clean look, rwy does this).
 - **Layout (strictly user-driven):** `sync` never auto-relayouts (it retains a `relayout` param, but every caller passes `false`). A Sugiyama pass on every new node reflowed the whole graph and read as "jumpy" as a session grew (confirmed by toggling it off), so newcomers always get local placement (below parent, fanned past siblings) and nothing existing ever moves on its own. The ONLY relayout trigger is `r` (`App::relayout_now` → `flow.apply_layout(Sugiyama::vertical())` + reframe for the current camera). Layout is orthogonal to the camera: `o`/`f` move the viewport only and never rearrange nodes. `layout_dirty` (set on structural growth, cleared by `r`) drives a subtle status-bar hint so pending growth is discoverable. (Earlier designs auto-relayouted, then auto-relayouted except in Manual, then applied debt on `o`/`f`; all superseded — layout is now always explicit.)
 - **Camera** (supersedes the original "fit only on first populate" — a one-shot fit goes stale as the graph grows): three mutually exclusive modes on `App.camera`. **Overview** (default) re-requests fit-view on every structural change — the camera pulls back as the swarm grows. **Follow** holds readable zoom (≥ `FOLLOW_ZOOM`) and centers on the most recently active agent (`SessionModel::last_active_agent_id`, latest `last_ts`, spawn-order tie-break). **Manual**: a uniform rule in `process_flow_events`, not per-event — every `FlowEvent` there is a user gesture (programmatic `select_node`/`center_on`/`set_offset` are quiet and never surface), so **Follow yields to ANY interaction**: click, spatial nav (`SelectionChanged`), pan/zoom (`ViewportChanged`), or node drag (`NodeDragged`). **Overview** yields only to a viewport change — selecting/dragging while auto-framing is fine to leave in Overview. Dropping Follow on selection is deliberate: the user is inspecting a node, and spatial nav already pans to keep it visible (rataflow's `ensure_selected_node_visible`, 1-cell margin) — staying in Follow would fight that and glide back over the selection. Keys name destinations: `o` → Overview, `f` → Follow — the only exits from Manual. Session reset → Overview. Follow auto-narrates the panel (quiet `select_node`, no event); a user selection ends that by dropping to Manual. Status bar shows `⌖ overview` / `⌖ follow` / nothing. Camera moves in Follow are eased (`CameraGlide`), cancelled the instant the user takes over.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -155,7 +155,7 @@ fn handle_key(key: &KeyEvent, app: &mut App) -> bool {
             return false;
         }
 
-        // Session rail: show/hide, move the focus, switch layout.
+        // Session rail: show/hide, move the focus.
         KeyCode::Char('w') | KeyCode::Char('W') => {
             app.rail.toggle_visible();
             return false;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -21,6 +21,17 @@ pub fn handle_event(event: &Event, app: &mut App) -> bool {
     match event {
         Event::Key(key) => handle_key(key, app),
         Event::Mouse(mouse) => {
+            // A left click inside the rail focuses that session. Intercepted
+            // before the flow, which would otherwise read it as a pane drag.
+            if let Some(area) = app.rail_area
+                && matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+                && mouse.column >= area.x
+                && mouse.column < area.x + area.width
+                && let Some(index) = crate::ui::rail::row_at(area, mouse.row, app.rail.rows.len())
+            {
+                app.focus_session_index(index);
+                return false;
+            }
             // A press/drag on the scrubber row seeks the playhead — intercept it
             // before the flow sees it (else it reads as a pane drag → pan).
             if let Some(bar) = app.scrubber_area
@@ -144,6 +155,19 @@ fn handle_key(key: &KeyEvent, app: &mut App) -> bool {
             return false;
         }
 
+        // Session rail: show/hide, move the focus, switch layout.
+        KeyCode::Char('w') | KeyCode::Char('W') => {
+            app.rail.toggle_visible();
+            return false;
+        }
+        KeyCode::Char('n') => {
+            app.focus_session(1);
+            return false;
+        }
+        KeyCode::Char('p') | KeyCode::Char('N') => {
+            app.focus_session(-1);
+            return false;
+        }
         // Help overlay.
         KeyCode::Char('?') => {
             app.show_help = !app.show_help;
@@ -382,9 +406,12 @@ mod tests {
             )
         };
         let mut app = App::new("s".into(), Mode::Live);
+        // Flow ids are session-qualified everywhere `sync` writes them, so a
+        // hand-built test node uses the same form.
+        let (id_a, id_b) = (app.node_id("a"), app.node_id("b"));
         // Two nodes far apart so the second is off-screen when we focus the first.
-        app.flow.add_node(mk("a", 0.0)).unwrap();
-        app.flow.add_node(mk("b", 500.0)).unwrap();
+        app.flow.add_node(mk(&id_a, 0.0)).unwrap();
+        app.flow.add_node(mk(&id_b, 500.0)).unwrap();
         // Render so the flow has a canvas, then zoom/focus tightly on "a" so "b"
         // is well off-screen (the library WOULD pan to reveal it).
         let area = ratatui::layout::Rect::new(0, 0, 60, 20);
@@ -392,7 +419,7 @@ mod tests {
         (&mut app.flow).render(area, &mut buf);
         app.flow.zoom_to(5.0);
         app.flow.center_on((5.0, 2.5));
-        app.flow.select_node("a");
+        app.flow.select_node(&id_a);
         let before = (app.flow.viewport.x, app.flow.viewport.y);
 
         // Tab to "b": the flow is `SelectionReveal::None`, so the selection moves
@@ -410,7 +437,7 @@ mod tests {
         );
         assert_eq!(
             app.pending_center.as_deref(),
-            Some("b"),
+            Some(id_b.as_str()),
             "the newly-selected node is queued for a smooth center-glide instead"
         );
     }
@@ -420,7 +447,7 @@ mod tests {
         let mut app = App::new("s".into(), Mode::Live);
         // A selected, default-flags node — deletable=true in the library.
         let node = rataflow::Node::new(
-            "a",
+            app.node_id("a"),
             (0.0, 0.0),
             (10.0, 5.0),
             crate::ui::nodes::AgentNode {
@@ -433,13 +460,14 @@ mod tests {
                 interactive: false,
             },
         );
+        let id_a = app.node_id("a");
         app.flow.add_node(node).unwrap();
-        app.flow.select_node("a");
+        app.flow.select_node(&id_a);
 
         // Delete must NOT remove the selected node (read-only graph).
         let del = Event::Key(KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE));
         handle_event(&del, &mut app);
-        assert!(app.flow.node("a").is_some(), "Delete must be inert");
+        assert!(app.flow.node(&id_a).is_some(), "Delete must be inert");
 
         // 'i' must NOT toggle the viewport lock.
         let i = Event::Key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
@@ -451,7 +479,7 @@ mod tests {
     fn esc_closes_the_detail_panel() {
         let mut app = App::new("s".into(), Mode::Live);
         let node = rataflow::Node::new(
-            "a",
+            app.node_id("a"),
             (0.0, 0.0),
             (10.0, 5.0),
             crate::ui::nodes::AgentNode {
@@ -464,8 +492,9 @@ mod tests {
                 interactive: false,
             },
         );
+        let id_a = app.node_id("a");
         app.flow.add_node(node).unwrap();
-        app.flow.select_node("a");
+        app.flow.select_node(&id_a);
         assert!(app.selected_agent_id().is_some());
 
         let esc = Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
@@ -525,10 +554,12 @@ mod tests {
 
         // A USER selection gesture (click or spatial nav) drops Follow so the
         // camera stops chasing activity and gliding back over the selection.
+        // Flow events carry flow ids, which are session-qualified.
+        let id_a = app.node_id("a");
         process_flow_events(
             &mut app,
             vec![FlowEvent::SelectionChanged {
-                node_ids: vec!["a".into()],
+                node_ids: vec![id_a.clone()],
                 edge_ids: vec![],
             }]
             .into_iter(),
@@ -540,7 +571,7 @@ mod tests {
         );
         assert_eq!(
             app.pending_center.as_deref(),
-            Some("a"),
+            Some(id_a.as_str()),
             "the selected node is queued for a center-glide on the next draw"
         );
     }
@@ -548,7 +579,7 @@ mod tests {
     #[test]
     fn deselection_clears_a_pending_center() {
         let mut app = App::new("s".into(), Mode::Live);
-        app.pending_center = Some("a".into());
+        app.pending_center = Some(app.node_id("a"));
         process_flow_events(
             &mut app,
             vec![FlowEvent::SelectionChanged {

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,1299 @@
+//! Skeleton index over transcript files — the cheap half of parsing.
+//!
+//! A transcript line is mostly payload, of which the timeline needs very
+//! little: when it happened, what kind of entry it is, which agent it belongs
+//! to, and how much tool activity it carries. Parsing every line in full to
+//! learn that is slower than searching for it, and leaves the whole payload
+//! resident afterwards. This module extracts the same facts with SIMD
+//! substring probes into a fixed 32-byte [`Rec`] per line, and leaves the body
+//! on disk until something actually renders it.
+//!
+//! `benches/index.rs` measures the difference against `parse_line`; no figure
+//! is quoted here, because a number in a comment is a number from whichever
+//! machine happened to write it.
+//!
+//! Two properties make the whole design work:
+//!
+//! - **Transcripts are append-only.** An index is therefore extendable: a file
+//!   that grew is scanned from [`Index::scanned_len`], never from the start, and
+//!   the result can be cached on disk across runs ([`Index::load`] / [`save`]).
+//! - **The index never guesses.** Every probe either reads a fact out of the
+//!   bytes or records that it could not, via [`flags::AMBIGUOUS_PROMPT`]. Where
+//!   the format is ambiguous the caller parses that one line properly. A
+//!   differential test (`index::tests::skeleton_agrees_with_parser`) asserts
+//!   record-for-record agreement with [`crate::transcript::parse_line`], so the
+//!   fast path can never silently drift from the real parser.
+//!
+//! [`save`]: Index::save
+
+use std::path::{Path, PathBuf};
+
+use memchr::memmem;
+
+/// Serialized size of one [`Rec`] — so an index costs exactly 32 bytes per
+/// line of transcript, whatever the lines contain.
+pub const REC_SIZE: usize = 32;
+
+/// Magic + version stamp at the head of a cached index. Bump the trailing digits
+/// whenever [`Rec`]'s layout or any probe's meaning changes — a stale cache is
+/// then rejected wholesale instead of being read as garbage.
+const MAGIC: [u8; 8] = *b"ZOEIDX03";
+
+/// Size of the cache header: magic, scanned length, head hash + its covered
+/// length, record count.
+const HEADER_SIZE: usize = 40;
+
+/// Bytes of a file's head that the rotation guard hashes.
+const HEAD_HASH_LEN: usize = 4096;
+
+/// Sentinel `ts_micros` for a line with no parsable `timestamp`.
+pub const UNDATED: i64 = i64::MIN;
+
+/// Which entry a line is, mirroring [`crate::transcript::Entry`]'s variants.
+///
+/// Read from the `"type"` field alone, so it is exactly as reliable as serde's
+/// tag dispatch — and [`Kind::Unknown`] covers anything new, the same way
+/// `Entry::Unknown` does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Kind {
+    User = 0,
+    Assistant = 1,
+    System = 2,
+    Attachment = 3,
+    AiTitle = 4,
+    LastPrompt = 5,
+    Mode = 6,
+    PermissionMode = 7,
+    FileHistorySnapshot = 8,
+    QueueOperation = 9,
+    Started = 10,
+    Result = 11,
+    Unknown = 12,
+}
+
+impl Kind {
+    /// Map a raw `"type"` value to a kind. Unrecognized types are
+    /// [`Kind::Unknown`], never an error.
+    fn from_tag(tag: &[u8]) -> Kind {
+        match tag {
+            b"user" => Kind::User,
+            b"assistant" => Kind::Assistant,
+            b"system" => Kind::System,
+            b"attachment" => Kind::Attachment,
+            b"ai-title" => Kind::AiTitle,
+            b"last-prompt" => Kind::LastPrompt,
+            b"mode" => Kind::Mode,
+            b"permission-mode" => Kind::PermissionMode,
+            b"file-history-snapshot" => Kind::FileHistorySnapshot,
+            b"queue-operation" => Kind::QueueOperation,
+            b"started" => Kind::Started,
+            b"result" => Kind::Result,
+            _ => Kind::Unknown,
+        }
+    }
+
+    fn from_u8(b: u8) -> Kind {
+        match b {
+            0 => Kind::User,
+            1 => Kind::Assistant,
+            2 => Kind::System,
+            3 => Kind::Attachment,
+            4 => Kind::AiTitle,
+            5 => Kind::LastPrompt,
+            6 => Kind::Mode,
+            7 => Kind::PermissionMode,
+            8 => Kind::FileHistorySnapshot,
+            9 => Kind::QueueOperation,
+            10 => Kind::Started,
+            11 => Kind::Result,
+            _ => Kind::Unknown,
+        }
+    }
+
+    /// Whether this kind's entry carries the shared envelope (`uuid`,
+    /// `parentUuid`, `timestamp`).
+    ///
+    /// Flat metadata and ledger lines do not — and some of them carry a
+    /// `timestamp` field in the file that the parser's types have nowhere to
+    /// put, so it never reaches the model. The index reports what the parser
+    /// reports, so those lines are [`UNDATED`] here too.
+    pub fn has_envelope(self) -> bool {
+        matches!(
+            self,
+            Kind::User | Kind::Assistant | Kind::System | Kind::Attachment
+        )
+    }
+
+    /// Whether the model folds this kind onto the timeline at all. Mirrors
+    /// [`crate::transcript::Entry::is_timeline_noise`], inverted.
+    pub fn is_timeline_item(self) -> bool {
+        !matches!(
+            self,
+            Kind::AiTitle
+                | Kind::LastPrompt
+                | Kind::Mode
+                | Kind::PermissionMode
+                | Kind::FileHistorySnapshot
+                | Kind::QueueOperation
+        )
+    }
+}
+
+/// Bit meanings for [`Rec::flags`].
+pub mod flags {
+    /// The line carries `origin.kind == "human"` — an authoritative prompt.
+    pub const HUMAN_ORIGIN: u8 = 1 << 0;
+    /// The line carries `origin.kind == "task-notification"` — authoritatively
+    /// NOT a prompt.
+    pub const TASK_NOTIFICATION: u8 = 1 << 1;
+    /// `isSidechain: true` — the line belongs to a subagent's own thread.
+    pub const SIDECHAIN: u8 = 1 << 2;
+    /// A `user` line with no `origin` field at all: a legacy transcript, where
+    /// "is this a prompt" is decided by a text heuristic the skeleton cannot
+    /// replicate. The caller must parse this one line to decide. The index
+    /// records that it does not know rather than guessing.
+    pub const AMBIGUOUS_PROMPT: u8 = 1 << 3;
+}
+
+/// One indexed line: where it is, when it happened, and the handful of counts
+/// the timeline geometry needs — without the payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rec {
+    /// Byte offset of the line's first byte within its file.
+    pub offset: u64,
+    /// Microseconds since the Unix epoch, or [`UNDATED`].
+    pub ts_micros: i64,
+    /// Length of the line in bytes, excluding the newline.
+    pub len: u32,
+    /// FNV-1a hash of the line's `agentId`, or 0 when absent. A stable,
+    /// process-independent hash — the cache on disk outlives the run that
+    /// wrote it, so [`std::collections::hash_map::DefaultHasher`] (randomly
+    /// seeded per process) would be wrong here.
+    pub agent_key: u32,
+    /// Which entry this is.
+    pub kind: Kind,
+    /// `tool_use` blocks in the line.
+    pub tool_uses: u8,
+    /// Agent/workflow spawn calls in the line (`Agent` / `Task` / `Workflow`).
+    pub spawns: u8,
+    /// `tool_result` blocks flagged `is_error: true`.
+    pub failures: u8,
+    /// See [`flags`].
+    pub flags: u8,
+}
+
+impl Rec {
+    /// The line's timestamp, or `None` when undated.
+    pub fn ts(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        if self.ts_micros == UNDATED {
+            return None;
+        }
+        chrono::DateTime::from_timestamp_micros(self.ts_micros)
+    }
+
+    /// Slice this line out of the file's bytes, for the caller to parse fully.
+    pub fn slice<'a>(&self, file: &'a [u8]) -> &'a [u8] {
+        let start = self.offset as usize;
+        let end = (start + self.len as usize).min(file.len());
+        &file[start.min(file.len())..end]
+    }
+
+    fn encode(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.offset.to_le_bytes());
+        out.extend_from_slice(&self.ts_micros.to_le_bytes());
+        out.extend_from_slice(&self.len.to_le_bytes());
+        out.extend_from_slice(&self.agent_key.to_le_bytes());
+        out.push(self.kind as u8);
+        out.push(self.tool_uses);
+        out.push(self.spawns);
+        out.push(self.failures);
+        out.push(self.flags);
+        out.extend_from_slice(&[0u8; 3]);
+    }
+
+    fn decode(b: &[u8]) -> Rec {
+        let u64_at = |i: usize| u64::from_le_bytes(b[i..i + 8].try_into().unwrap());
+        let i64_at = |i: usize| i64::from_le_bytes(b[i..i + 8].try_into().unwrap());
+        let u32_at = |i: usize| u32::from_le_bytes(b[i..i + 4].try_into().unwrap());
+        Rec {
+            offset: u64_at(0),
+            ts_micros: i64_at(8),
+            len: u32_at(16),
+            agent_key: u32_at(20),
+            kind: Kind::from_u8(b[24]),
+            tool_uses: b[25],
+            spawns: b[26],
+            failures: b[27],
+            flags: b[28],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level field scan
+// ---------------------------------------------------------------------------
+//
+// The envelope fields must be read from the line's TOP LEVEL, not from wherever
+// the name first appears. Claude Code does not emit envelope keys first, and a
+// nested object can carry the same names — an `attachment` entry serializes
+// `"attachment":{"type":…}` BEFORE its own `"type":"attachment"`, so taking the
+// first `"type"` in the line reads the attachment's type as the entry's kind.
+// (Found by the real-corpus differential test; the synthetic fixtures all
+// happened to put `type` first.) The same trap applies to `timestamp` and
+// `agentId`, which appear inside attachment payloads and tool results.
+//
+// So: one structural pass that walks depth-1 keys and skips nested values
+// wholesale. It stays fast by using memchr to jump between structural bytes
+// rather than stepping through string contents.
+
+/// Index just past the string starting at `at` (which must be its opening
+/// quote), honouring backslash escapes.
+fn skip_string(line: &[u8], at: usize) -> Option<usize> {
+    let mut i = at + 1;
+    loop {
+        let q = i + memchr::memchr(b'"', line.get(i..)?)?;
+        // A quote is the terminator only if preceded by an EVEN number of
+        // backslashes (`\\"` ends the string, `\"` does not).
+        let mut backslashes = 0;
+        let mut j = q;
+        while j > at + 1 && line[j - 1] == b'\\' {
+            backslashes += 1;
+            j -= 1;
+        }
+        if backslashes % 2 == 0 {
+            return Some(q + 1);
+        }
+        i = q + 1;
+    }
+}
+
+/// Index just past the `{…}` or `[…]` container starting at `at`.
+fn skip_container(line: &[u8], at: usize, open: u8, close: u8) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut i = at;
+    while i < line.len() {
+        let pos = i + memchr::memchr3(b'"', open, close, line.get(i..)?)?;
+        let c = line[pos];
+        if c == b'"' {
+            i = skip_string(line, pos)?;
+        } else if c == open {
+            depth += 1;
+            i = pos + 1;
+        } else {
+            depth -= 1;
+            if depth == 0 {
+                return Some(pos + 1);
+            }
+            i = pos + 1;
+        }
+    }
+    None
+}
+
+/// Index just past the JSON value starting at `at`.
+fn skip_value(line: &[u8], at: usize) -> Option<usize> {
+    match *line.get(at)? {
+        b'"' => skip_string(line, at),
+        b'{' => skip_container(line, at, b'{', b'}'),
+        b'[' => skip_container(line, at, b'[', b']'),
+        // A literal (number, `true`, `false`, `null`) ends at the next
+        // separator; none of them can contain one.
+        _ => {
+            let rel = line[at..]
+                .iter()
+                .position(|&c| c == b',' || c == b'}' || c == b']')?;
+            Some(at + rel)
+        }
+    }
+}
+
+/// A JSON string's contents, without its quotes. `None` when the value is not a
+/// string, or contains an escape.
+///
+/// Escaped values are refused rather than mis-read: every envelope field read
+/// here (`type`, `agentId`, `timestamp`) is a machine-generated identifier that
+/// never contains one, and refusing degrades to "unknown", never to a wrong
+/// answer.
+fn unquote(value: &[u8]) -> Option<&[u8]> {
+    let inner = value.strip_prefix(b"\"")?.strip_suffix(b"\"")?;
+    (!inner.contains(&b'\\')).then_some(inner)
+}
+
+/// Iterator over the top-level `(key, value)` pairs of a JSON object slice.
+///
+/// Nested values are skipped wholesale, so a key at depth 2 is never mistaken
+/// for one at depth 1. Malformed input ends the iteration rather than erroring:
+/// this is a fast path over data the real parser validates, so it degrades to
+/// "less known", never to a wrong answer.
+struct ObjectFields<'a> {
+    buf: &'a [u8],
+    i: usize,
+}
+
+/// Walk the top-level keys of the object beginning at the first `{` in `buf`.
+fn object_fields(buf: &[u8]) -> ObjectFields<'_> {
+    let i = memchr::memchr(b'{', buf).map_or(buf.len(), |o| o + 1);
+    ObjectFields { buf, i }
+}
+
+impl<'a> Iterator for ObjectFields<'a> {
+    type Item = (&'a [u8], &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let rel = memchr::memchr2(b'"', b'}', self.buf.get(self.i..)?)?;
+        let key_start = self.i + rel;
+        if self.buf[key_start] == b'}' {
+            return None;
+        }
+        let key_end = skip_string(self.buf, key_start)?;
+        let key = unquote(&self.buf[key_start..key_end])?;
+
+        // `"key" : value` — whitespace may follow the colon.
+        let colon = key_end + memchr::memchr(b':', self.buf.get(key_end..)?)?;
+        let mut value_start = colon + 1;
+        while self
+            .buf
+            .get(value_start)
+            .is_some_and(u8::is_ascii_whitespace)
+        {
+            value_start += 1;
+        }
+        let value_end = skip_value(self.buf, value_start)?;
+
+        self.i = value_end;
+        Some((key, &self.buf[value_start..value_end]))
+    }
+}
+
+/// Iterator over the top-level elements of a JSON array slice.
+struct ArrayElements<'a> {
+    buf: &'a [u8],
+    i: usize,
+}
+
+/// Walk the elements of the array beginning at the first `[` in `buf`.
+fn array_elements(buf: &[u8]) -> ArrayElements<'_> {
+    let i = memchr::memchr(b'[', buf).map_or(buf.len(), |o| o + 1);
+    ArrayElements { buf, i }
+}
+
+impl<'a> Iterator for ArrayElements<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self
+            .buf
+            .get(self.i)
+            .is_some_and(|c| c.is_ascii_whitespace() || *c == b',')
+        {
+            self.i += 1;
+        }
+        if *self.buf.get(self.i)? == b']' {
+            return None;
+        }
+        let end = skip_value(self.buf, self.i)?;
+        let start = self.i;
+        self.i = end;
+        Some(&self.buf[start..end])
+    }
+}
+
+/// The envelope fields of one line, read from its top level only.
+#[derive(Default)]
+struct EnvelopeFields<'a> {
+    ty: Option<&'a [u8]>,
+    timestamp: Option<&'a [u8]>,
+    agent_id: Option<&'a [u8]>,
+    is_sidechain: bool,
+    /// The raw `origin` value, and whether the key was present at all — an
+    /// absent `origin` is what makes a legacy `user` line ambiguous.
+    origin: Option<&'a [u8]>,
+    saw_origin: bool,
+    /// The raw `message` value, captured here so [`count_blocks`] does not walk
+    /// the line a second time to re-find it. It is the largest value on the
+    /// line, and the envelope walk has already paid to skip past it.
+    message: Option<&'a [u8]>,
+}
+
+/// Walk the top-level keys of `line` and collect the envelope fields.
+///
+/// Malformed input simply yields whatever was read before the scan gave up:
+/// this is a fast path over data the real parser validates, so it degrades to
+/// "less known", never to an error.
+fn scan_envelope(line: &[u8]) -> EnvelopeFields<'_> {
+    let mut out = EnvelopeFields::default();
+    for (key, value) in object_fields(line) {
+        match key {
+            b"type" => out.ty = unquote(value),
+            b"timestamp" => out.timestamp = unquote(value),
+            b"agentId" => out.agent_id = unquote(value),
+            b"isSidechain" => out.is_sidechain = value == b"true",
+            b"origin" => {
+                out.saw_origin = true;
+                out.origin = Some(value);
+            }
+            b"message" => out.message = Some(value),
+            _ => {}
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Content blocks
+// ---------------------------------------------------------------------------
+
+/// Per-line activity counts, taken from the actual `message.content` blocks.
+///
+/// These cannot be byte-counted across the whole line, for two reasons the
+/// real-corpus differential test surfaced. The parser scopes each count to an
+/// entry kind — `tool_use_count` and `spawn_count` read assistant content,
+/// `tool_failure_count` reads user content — and a line's *text* can contain
+/// any of these literals: a `user` line quoting a tool result that mentioned
+/// `"name":"Agent"` six times counted six spawns against the parser's zero.
+#[derive(Default)]
+struct BlockCounts {
+    tool_uses: u8,
+    spawns: u8,
+    failures: u8,
+}
+
+/// Count the content blocks of a line's `message` value, scoped exactly as the
+/// parser scopes them.
+///
+/// `message.content` is string-or-array; only the array form holds blocks, and
+/// a bare string yields zero of everything — which is what the parser reports.
+fn count_blocks(message: Option<&[u8]>, kind: Kind) -> BlockCounts {
+    let mut out = BlockCounts::default();
+    // Only these two kinds carry countable content, and each contributes only
+    // its own counts — mirroring `Entry::{tool_use_count, spawn_count,
+    // tool_failure_count}`, which match on the variant before counting.
+    if !matches!(kind, Kind::Assistant | Kind::User) {
+        return out;
+    }
+    let Some(message) = message else {
+        return out;
+    };
+    let Some((_, content)) = object_fields(message).find(|(k, _)| *k == b"content") else {
+        return out;
+    };
+    if !content.starts_with(b"[") {
+        return out;
+    }
+
+    // The block type this kind counts; anything else is skipped without reading
+    // the rest of its keys (a `tool_use`'s `input` is the biggest value on the
+    // line, and there is no reason to walk it).
+    let wanted: &[u8] = match kind {
+        Kind::Assistant => b"tool_use",
+        _ => b"tool_result",
+    };
+
+    for block in array_elements(content) {
+        let (mut ty, mut name, mut is_error) = (None, None, false);
+        for (key, value) in object_fields(block) {
+            match key {
+                b"type" => {
+                    ty = unquote(value);
+                    if ty != Some(wanted) {
+                        break;
+                    }
+                }
+                b"name" => name = unquote(value),
+                b"is_error" => is_error = value == b"true",
+                _ => {}
+            }
+        }
+        match (kind, ty) {
+            (Kind::Assistant, Some(b"tool_use")) => {
+                out.tool_uses = out.tool_uses.saturating_add(1);
+                // Single source for the spawn rule, shared with the parser.
+                if name
+                    .and_then(|n| std::str::from_utf8(n).ok())
+                    .is_some_and(crate::transcript::is_spawn_tool)
+                {
+                    out.spawns = out.spawns.saturating_add(1);
+                }
+            }
+            (Kind::User, Some(b"tool_result")) if is_error => {
+                out.failures = out.failures.saturating_add(1);
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// FNV-1a (32-bit). Chosen for being fully specified and seed-free, so a hash
+/// written into a cache file means the same thing when read back next week.
+fn fnv1a(bytes: &[u8]) -> u32 {
+    let mut h: u32 = 0x811c_9dc5;
+    for &b in bytes {
+        h ^= b as u32;
+        h = h.wrapping_mul(0x0100_0193);
+    }
+    h
+}
+
+/// FNV-1a (64-bit), for the file-head rotation guard.
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// Parse `YYYY-MM-DDTHH:MM:SS[.fff...]Z` into microseconds since the epoch.
+///
+/// The fast path handles the canonical shape Claude Code writes, digit by
+/// digit, and hands the civil-date arithmetic to chrono (leap years and epoch
+/// offsets are not arithmetic worth re-deriving). Anything else — an offset
+/// other than `Z`, a different precision, a format we have not seen — falls
+/// back to chrono's full RFC-3339 parser, so an unusual stamp is read
+/// correctly rather than dropped.
+fn parse_ts(s: &[u8]) -> Option<i64> {
+    fn digits(b: &[u8]) -> Option<u32> {
+        let mut n: u32 = 0;
+        for &c in b {
+            if !c.is_ascii_digit() {
+                return None;
+            }
+            n = n * 10 + (c - b'0') as u32;
+        }
+        Some(n)
+    }
+
+    let canonical = s.len() >= 20
+        && s[4] == b'-'
+        && s[7] == b'-'
+        && s[10] == b'T'
+        && s[13] == b':'
+        && s[16] == b':';
+
+    if canonical {
+        let micros = match s.len() {
+            // `...SSZ`
+            20 if s[19] == b'Z' => Some(0),
+            // `...SS.fffZ` — the shape every observed transcript uses.
+            24 if s[19] == b'.' && s[23] == b'Z' => digits(&s[20..23]).map(|ms| ms * 1000),
+            _ => None,
+        };
+        if let Some(micro) = micros {
+            let (y, mo, d) = (digits(&s[0..4])?, digits(&s[5..7])?, digits(&s[8..10])?);
+            let (h, mi, sec) = (
+                digits(&s[11..13])?,
+                digits(&s[14..16])?,
+                digits(&s[17..19])?,
+            );
+            let date = chrono::NaiveDate::from_ymd_opt(y as i32, mo, d)?;
+            let dt = date.and_hms_micro_opt(h, mi, sec, micro)?;
+            return Some(dt.and_utc().timestamp_micros());
+        }
+    }
+
+    // Slow path: anything non-canonical.
+    let text = std::str::from_utf8(s).ok()?;
+    Some(
+        chrono::DateTime::parse_from_rfc3339(text)
+            .ok()?
+            .timestamp_micros(),
+    )
+}
+
+/// Extract one line's [`Rec`]. `offset` is the line's position in its file.
+///
+/// Blank lines yield `None` — they are not entries and must not become records
+/// (the parser skips them too).
+fn index_line(line: &[u8], offset: u64) -> Option<Rec> {
+    if line.iter().all(u8::is_ascii_whitespace) {
+        return None;
+    }
+
+    let env = scan_envelope(line);
+    let kind = env.ty.map_or(Kind::Unknown, Kind::from_tag);
+
+    let ts_micros = if kind.has_envelope() {
+        env.timestamp.and_then(parse_ts).unwrap_or(UNDATED)
+    } else {
+        UNDATED
+    };
+
+    let agent_key = env.agent_id.map_or(0, fnv1a);
+
+    let mut flag_bits = 0u8;
+    if env.is_sidechain {
+        flag_bits |= flags::SIDECHAIN;
+    }
+    // Prompt provenance. `origin.kind` is authoritative where present; a `user`
+    // line without it is a legacy transcript whose prompt-ness only the text
+    // heuristic in `UserEntry::is_human_prompt` can settle, so say so. The
+    // search is scoped to the `origin` value — `"kind"` is a common enough key
+    // that a line-wide search would read someone else's.
+    match env.origin {
+        Some(origin) => {
+            if memmem::find(origin, b"\"human\"").is_some() {
+                flag_bits |= flags::HUMAN_ORIGIN;
+            } else if memmem::find(origin, b"\"task-notification\"").is_some() {
+                flag_bits |= flags::TASK_NOTIFICATION;
+            }
+        }
+        None if kind == Kind::User => flag_bits |= flags::AMBIGUOUS_PROMPT,
+        None => {}
+    }
+    debug_assert!(
+        env.saw_origin == env.origin.is_some(),
+        "origin presence and value must agree"
+    );
+
+    let counts = count_blocks(env.message, kind);
+
+    Some(Rec {
+        offset,
+        ts_micros,
+        len: line.len() as u32,
+        agent_key,
+        kind,
+        tool_uses: counts.tool_uses,
+        spawns: counts.spawns,
+        failures: counts.failures,
+        flags: flag_bits,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Index
+// ---------------------------------------------------------------------------
+
+/// The skeleton index of one transcript file.
+#[derive(Debug, Default, Clone)]
+pub struct Index {
+    /// One record per non-blank line, in file order.
+    pub recs: Vec<Rec>,
+    /// Bytes consumed so far, always ending at a newline. A later append is
+    /// scanned from exactly here — never from the start of the file.
+    pub scanned_len: u64,
+    /// FNV-1a of the file's first [`Index::head_len`] bytes. Transcripts are
+    /// append-only, so a changed head means the file was rotated or rewritten
+    /// and the index must be discarded.
+    pub head_hash: u64,
+    /// How many bytes [`head_hash`](Index::head_hash) covers. Recorded rather
+    /// than assumed: a file indexed while it was still shorter than
+    /// [`HEAD_HASH_LEN`] must be re-hashed over that same short prefix, or it
+    /// would appear rotated on its very next append.
+    pub head_len: u64,
+}
+
+impl Index {
+    /// Scan `bytes` — the whole file — building or extending this index.
+    ///
+    /// Only the region past [`scanned_len`](Index::scanned_len) is read, and a
+    /// trailing partial line (no newline yet: the writer is mid-append) is left
+    /// unconsumed for the next call.
+    pub fn extend(&mut self, bytes: &[u8]) {
+        // Grow the guard as the file grows, up to the full window: a session
+        // indexed at 200 bytes gets a 200-byte guard now and a 4 KiB one once
+        // there are 4 KiB to hash.
+        let want = bytes.len().min(HEAD_HASH_LEN) as u64;
+        if want > self.head_len {
+            self.head_len = want;
+            self.head_hash = fnv1a64(&bytes[..want as usize]);
+        }
+        let start = self.scanned_len as usize;
+        if start >= bytes.len() {
+            return;
+        }
+        let tail = &bytes[start..];
+        let mut line_start = 0usize;
+        for nl in memchr::memchr_iter(b'\n', tail) {
+            let line = &tail[line_start..nl];
+            if let Some(rec) = index_line(line, (start + line_start) as u64) {
+                self.recs.push(rec);
+            }
+            line_start = nl + 1;
+        }
+        self.scanned_len = (start + line_start) as u64;
+    }
+
+    /// Whether `bytes` is a valid continuation of what this index already
+    /// covers: same head, and no shorter than what was scanned. A `false` here
+    /// means rotation or truncation — rebuild from scratch.
+    pub fn continues(&self, bytes: &[u8]) -> bool {
+        (bytes.len() as u64) >= self.scanned_len
+            && (bytes.len() as u64) >= self.head_len
+            && self.head_hash == fnv1a64(&bytes[..self.head_len as usize])
+    }
+
+    /// Serialize to the on-disk cache format.
+    fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(HEADER_SIZE + self.recs.len() * REC_SIZE);
+        out.extend_from_slice(&MAGIC);
+        out.extend_from_slice(&self.scanned_len.to_le_bytes());
+        out.extend_from_slice(&self.head_hash.to_le_bytes());
+        out.extend_from_slice(&self.head_len.to_le_bytes());
+        out.extend_from_slice(&(self.recs.len() as u64).to_le_bytes());
+        for r in &self.recs {
+            r.encode(&mut out);
+        }
+        out
+    }
+
+    /// Parse the on-disk cache format. `None` for a foreign, truncated, or
+    /// version-mismatched file — every one of which means "rebuild", never an
+    /// error worth surfacing.
+    fn decode(bytes: &[u8]) -> Option<Index> {
+        if bytes.len() < HEADER_SIZE || bytes[..8] != MAGIC {
+            return None;
+        }
+        let u64_at = |i: usize| u64::from_le_bytes(bytes[i..i + 8].try_into().unwrap());
+        let scanned_len = u64_at(8);
+        let head_hash = u64_at(16);
+        let head_len = u64_at(24);
+        let count = u64_at(32) as usize;
+        if bytes.len() < HEADER_SIZE + count * REC_SIZE {
+            return None;
+        }
+        let recs = (0..count)
+            .map(|i| {
+                let at = HEADER_SIZE + i * REC_SIZE;
+                Rec::decode(&bytes[at..at + REC_SIZE])
+            })
+            .collect();
+        Some(Index {
+            recs,
+            scanned_len,
+            head_hash,
+            head_len,
+        })
+    }
+
+    /// Read the cached index for `transcript`, if one exists and parses.
+    pub fn load(transcript: &Path) -> Option<Index> {
+        let bytes = std::fs::read(cache_path(transcript)?).ok()?;
+        Index::decode(&bytes)
+    }
+
+    /// Write this index to the cache. Best-effort: a full disk or an unwritable
+    /// cache directory costs a re-scan next run, nothing more, so failures are
+    /// swallowed rather than propagated into the UI.
+    pub fn save(&self, transcript: &Path) {
+        let Some(path) = cache_path(transcript) else {
+            return;
+        };
+        let Some(dir) = path.parent() else { return };
+        if std::fs::create_dir_all(dir).is_err() {
+            return;
+        }
+        // Write-then-rename so a killed process can never leave a half-written
+        // index that the next run would read as valid.
+        let tmp = path.with_extension("tmp");
+        if std::fs::write(&tmp, self.encode()).is_ok() {
+            let _ = std::fs::rename(&tmp, &path);
+        }
+    }
+}
+
+/// Cache location for a transcript's index: `~/.cache/zoetrope/idx/<hash>.idx`.
+///
+/// Keyed by a hash of the absolute path rather than the session uuid — two
+/// projects can hold transcripts with the same stem only by accident, but the
+/// cache must be correct even then.
+fn cache_path(transcript: &Path) -> Option<PathBuf> {
+    let root = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .or_else(|| {
+            #[allow(deprecated)]
+            std::env::home_dir()
+                .filter(|h| !h.as_os_str().is_empty())
+                .map(|h| h.join(".cache"))
+        })?;
+    let key = fnv1a64(transcript.as_os_str().as_encoded_bytes());
+    Some(
+        root.join("zoetrope")
+            .join("idx")
+            .join(format!("{key:016x}.idx")),
+    )
+}
+
+/// Build (or refresh from cache) the index for a transcript on disk.
+///
+/// The file is mmapped, so an already-cached index costs a stat and a header
+/// read rather than a copy of the transcript. Returns the index and the mapped
+/// bytes, so the caller can slice bodies out of the same mapping.
+pub fn open(transcript: &Path) -> std::io::Result<(Index, memmap2::Mmap)> {
+    let file = std::fs::File::open(transcript)?;
+    // SAFETY: mmap of a file another process appends to. Appends never move or
+    // rewrite existing bytes, and the index only ever reads the prefix it has
+    // already measured, so a concurrent append cannot invalidate a slice in use.
+    // Truncation would — which is exactly what `continues` checks for.
+    let map = unsafe { memmap2::Mmap::map(&file)? };
+
+    let mut index = match Index::load(transcript) {
+        Some(cached) if cached.continues(&map) => cached,
+        _ => Index::default(),
+    };
+    let before = index.scanned_len;
+    index.extend(&map);
+    if index.scanned_len != before {
+        index.save(transcript);
+    }
+    Ok((index, map))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcript::{self, Entry};
+
+    /// The entry kind the real parser assigns to a line.
+    fn parser_kind(line: &str) -> Option<Kind> {
+        Some(match transcript::parse_line(line)? {
+            Entry::User(_) => Kind::User,
+            Entry::Assistant(_) => Kind::Assistant,
+            Entry::System(_) => Kind::System,
+            Entry::Attachment(_) => Kind::Attachment,
+            Entry::AiTitle(_) => Kind::AiTitle,
+            Entry::LastPrompt(_) => Kind::LastPrompt,
+            Entry::Mode(_) => Kind::Mode,
+            Entry::PermissionMode(_) => Kind::PermissionMode,
+            Entry::FileHistorySnapshot(_) => Kind::FileHistorySnapshot,
+            Entry::QueueOperation(_) => Kind::QueueOperation,
+            Entry::Started(_) => Kind::Started,
+            Entry::Result(_) => Kind::Result,
+            Entry::Unknown => Kind::Unknown,
+        })
+    }
+
+    /// Assert that the skeleton index reports exactly what the real parser
+    /// would, for every line of `text`. This is the contract the whole module
+    /// rests on: the fast path is only allowed to be faster, never different.
+    pub(crate) fn assert_agrees(text: &str) {
+        let found = check_agrees(text);
+        assert!(
+            found.is_empty(),
+            "{} disagreement(s):\n{}",
+            found.len(),
+            found.join("\n")
+        );
+    }
+
+    /// One disagreement between the skeleton and the parser.
+    pub(crate) struct Mismatch {
+        /// What disagreed (`kind`, `timestamp`, `tool_use count`, …) — used to
+        /// group findings so one systematic bug reads as one bug.
+        pub(crate) field: &'static str,
+        pub(crate) detail: String,
+    }
+
+    impl std::fmt::Display for Mismatch {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}: {}", self.field, self.detail)
+        }
+    }
+
+    /// Every disagreement between the skeleton and the parser over `text`.
+    ///
+    /// Collects rather than panicking on the first: a corpus sweep that aborts
+    /// on line one costs a full re-run per bug found, and systematic format
+    /// drift usually shows up as many instances of a few causes.
+    pub(crate) fn check_agrees_detailed(text: &str) -> Vec<Mismatch> {
+        let mut out = Vec::new();
+        let mut index = Index::default();
+        index.extend(text.as_bytes());
+
+        let lines: Vec<&str> = text
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .filter(|l| transcript::parse_line(l).is_some())
+            .collect();
+
+        // A line the parser rejects outright still gets a record (the skeleton
+        // cannot know it is malformed), so compare on the parseable subset.
+        let recs: Vec<&Rec> = index
+            .recs
+            .iter()
+            .filter(|r| {
+                std::str::from_utf8(r.slice(text.as_bytes()))
+                    .ok()
+                    .and_then(transcript::parse_line)
+                    .is_some()
+            })
+            .collect();
+        if recs.len() != lines.len() {
+            out.push(Mismatch {
+                field: "record count",
+                detail: format!("{} records vs {} parseable lines", recs.len(), lines.len()),
+            });
+            return out;
+        }
+
+        let mut note = |field: &'static str, line: &str, detail: String| {
+            out.push(Mismatch {
+                field,
+                detail: format!("{detail} — {line:.160}"),
+            });
+        };
+
+        for (rec, line) in recs.iter().zip(&lines) {
+            // The slice must reproduce the line exactly — offsets are the
+            // foundation everything else sits on.
+            let sliced = std::str::from_utf8(rec.slice(text.as_bytes())).unwrap_or("<non-utf8>");
+            if sliced != *line {
+                note("slice", line, format!("offset {}", rec.offset));
+                continue;
+            }
+
+            let Some(entry) = transcript::parse_line(line) else {
+                continue;
+            };
+            if Some(rec.kind) != parser_kind(line) {
+                note(
+                    "kind",
+                    line,
+                    format!("{:?} vs {:?}", rec.kind, parser_kind(line)),
+                );
+            }
+
+            // Timestamp: identical to what serde + chrono produced.
+            let expect_ts = match &entry {
+                Entry::User(e) => e.envelope.timestamp,
+                Entry::Assistant(e) => e.envelope.timestamp,
+                Entry::System(e) => e.envelope.timestamp,
+                Entry::Attachment(e) => e.envelope.timestamp,
+                _ => None,
+            };
+            if rec.ts() != expect_ts {
+                note(
+                    "timestamp",
+                    line,
+                    format!("{:?} vs {expect_ts:?}", rec.ts()),
+                );
+            }
+
+            // Counts drive the scrubber's markers — they must match exactly.
+            for (field, got, want) in [
+                (
+                    "tool_use count",
+                    rec.tool_uses as usize,
+                    entry.tool_use_count(),
+                ),
+                ("spawn count", rec.spawns as usize, entry.spawn_count()),
+                (
+                    "failure count",
+                    rec.failures as usize,
+                    entry.tool_failure_count(),
+                ),
+            ] {
+                if got != want {
+                    note(field, line, format!("{got} vs {want}"));
+                }
+            }
+            if rec.kind.is_timeline_item() == entry.is_timeline_noise() {
+                note("timeline-item", line, format!("{:?}", rec.kind));
+            }
+
+            // Prompt provenance: where the index claims to know, it must be
+            // right; where it flags ambiguity, no claim is made.
+            if let Entry::User(u) = &entry {
+                let ambiguous = rec.flags & flags::AMBIGUOUS_PROMPT != 0;
+                if !ambiguous && rec.flags & flags::HUMAN_ORIGIN != 0 && !u.is_human_prompt() {
+                    note("human-origin", line, "claimed human prompt".to_string());
+                }
+                if rec.flags & flags::TASK_NOTIFICATION != 0 && u.is_human_prompt() {
+                    note("task-notification", line, "claimed non-prompt".to_string());
+                }
+            }
+        }
+        out
+    }
+
+    /// [`check_agrees_detailed`], rendered as strings.
+    pub(crate) fn check_agrees(text: &str) -> Vec<String> {
+        check_agrees_detailed(text)
+            .into_iter()
+            .map(|m| m.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn skeleton_agrees_with_parser_on_the_demo_session() {
+        assert_agrees(include_str!("../assets/demo.jsonl"));
+    }
+
+    /// Differential check against a REAL corpus — opt-in, never run by default.
+    ///
+    /// The synthetic fixtures only prove agreement on shapes this repository
+    /// already knows about. Transcripts in the wild carry format drift no
+    /// fixture anticipates, and the fast path must agree there too. Point this
+    /// at a directory tree of transcripts to find out:
+    ///
+    /// ```text
+    /// ZOE_DIFF_CORPUS=~/.claude/projects \
+    ///   cargo test --lib index -- --ignored --nocapture
+    /// ```
+    ///
+    /// It reads only; it reports only aggregate counts.
+    #[test]
+    #[ignore = "reads real transcripts; opt in with ZOE_DIFF_CORPUS"]
+    fn skeleton_agrees_with_parser_on_a_real_corpus() {
+        let Some(root) = std::env::var_os("ZOE_DIFF_CORPUS") else {
+            eprintln!("ZOE_DIFF_CORPUS not set — nothing to compare against");
+            return;
+        };
+        let root = PathBuf::from(root);
+
+        // Two levels of `.jsonl` under the root, plus the sidecar trees.
+        fn collect(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
+            if depth > 4 {
+                return;
+            }
+            let Ok(read) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in read.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    collect(&path, out, depth + 1);
+                } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                    out.push(path);
+                }
+            }
+        }
+
+        let mut files = Vec::new();
+        collect(&root, &mut files, 0);
+        files.sort();
+        assert!(
+            !files.is_empty(),
+            "no .jsonl found under {}",
+            root.display()
+        );
+
+        let (mut lines, mut bytes, mut skipped) = (0usize, 0usize, 0usize);
+        // Group by (field, file): one systematic bug then reads as one finding
+        // per file rather than thousands of identical lines.
+        let mut by_field: std::collections::BTreeMap<&'static str, (usize, String)> =
+            std::collections::BTreeMap::new();
+
+        for path in &files {
+            let Ok(text) = std::fs::read_to_string(path) else {
+                // Non-UTF-8 is not a disagreement; the byte path handles it and
+                // the parser would reject it. Count it and move on.
+                skipped += 1;
+                continue;
+            };
+            bytes += text.len();
+            lines += text.lines().filter(|l| !l.trim().is_empty()).count();
+            for m in check_agrees_detailed(&text) {
+                let slot = by_field.entry(m.field).or_insert((0, String::new()));
+                slot.0 += 1;
+                if slot.1.is_empty() {
+                    slot.1 = format!("{}\n      in {}", m.detail, path.display());
+                }
+            }
+        }
+
+        eprintln!(
+            "\ncompared {} files, {lines} lines, {:.1} MB ({skipped} unreadable)",
+            files.len(),
+            bytes as f64 / 1e6,
+        );
+        if by_field.is_empty() {
+            eprintln!("skeleton == parser on every line");
+            return;
+        }
+        eprintln!("\ndisagreements, grouped by field:");
+        for (field, (count, example)) in &by_field {
+            eprintln!("  {field}: {count}\n      e.g. {example}");
+        }
+        let total: usize = by_field.values().map(|(n, _)| n).sum();
+        panic!("{total} disagreement(s) across {} field(s)", by_field.len());
+    }
+
+    /// Envelope keys are NOT emitted first, and nested objects reuse their
+    /// names. This is the shape that broke the first implementation: an
+    /// `attachment` entry whose payload carries its own `"type"` ahead of the
+    /// envelope's. Taking the first match in the line read `"file"` as the
+    /// entry kind.
+    #[test]
+    fn nested_keys_do_not_shadow_the_envelope() {
+        let line = "{\"parentUuid\":\"df4e8281-7786-43cd-a51f-994daff568da\",\"isSidechain\":true,             \"agentId\":\"a1974221057027b73\",             \"attachment\":{\"type\":\"file\",\"timestamp\":\"1999-01-01T00:00:00.000Z\",             \"agentId\":\"nested-should-be-ignored\"},             \"type\":\"attachment\",\"uuid\":\"x1\",             \"timestamp\":\"2026-08-26T09:00:00.000Z\"}";
+
+        let rec = index_line(line.as_bytes(), 0).expect("indexed");
+
+        assert_eq!(
+            rec.kind,
+            Kind::Attachment,
+            "the envelope's type, not the payload's"
+        );
+        assert_eq!(
+            rec.ts()
+                .unwrap()
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            "2026-08-26T09:00:00.000Z",
+            "the envelope's timestamp, not the payload's"
+        );
+        assert_eq!(rec.agent_key, fnv1a(b"a1974221057027b73"));
+        assert_ne!(rec.agent_key, fnv1a(b"nested-should-be-ignored"));
+        assert!(rec.flags & flags::SIDECHAIN != 0);
+
+        // And it agrees with the real parser, which is the actual contract.
+        assert_agrees(&format!("{line}\n"));
+    }
+
+    /// A nested `origin` must not be mistaken for the envelope's, and a `kind`
+    /// key elsewhere in the line must not be read as prompt provenance.
+    #[test]
+    fn prompt_provenance_is_scoped_to_the_envelope_origin() {
+        // No top-level `origin` at all, but a nested one that says "human".
+        let decoy = "{\"type\":\"user\",\"uuid\":\"u1\",             \"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",             \"tool_use_id\":\"t1\",\"content\":\"origin kind human\"}]}}";
+        let rec = index_line(decoy.as_bytes(), 0).unwrap();
+        assert_eq!(
+            rec.flags & flags::HUMAN_ORIGIN,
+            0,
+            "no envelope origin to read"
+        );
+        assert!(
+            rec.flags & flags::AMBIGUOUS_PROMPT != 0,
+            "a user line without origin is ambiguous, not assumed"
+        );
+
+        let real = "{\"type\":\"user\",\"uuid\":\"u1\",\"origin\":{\"kind\":\"human\"},             \"message\":{\"role\":\"user\",\"content\":\"hi\"}}";
+        let rec = index_line(real.as_bytes(), 0).unwrap();
+        assert!(rec.flags & flags::HUMAN_ORIGIN != 0);
+        assert_eq!(rec.flags & flags::AMBIGUOUS_PROMPT, 0);
+    }
+
+    /// Escaped quotes inside string values must not end the value early — a
+    /// mis-terminated string would desynchronize the whole key walk.
+    #[test]
+    fn escaped_quotes_do_not_desync_the_scan() {
+        let line = "{\"type\":\"user\",\"uuid\":\"u1\",             \"message\":{\"role\":\"user\",\"content\":\"she said \\\"type\\\": \\\"assistant\\\" out loud\"},             \"timestamp\":\"2026-08-26T09:00:00.000Z\"}";
+        let rec = index_line(line.as_bytes(), 0).unwrap();
+        assert_eq!(rec.kind, Kind::User, "the quoted text is not a type tag");
+        assert!(
+            rec.ts().is_some(),
+            "the key walk reached the trailing timestamp"
+        );
+        assert_agrees(&format!("{line}\n"));
+    }
+
+    /// Activity counts are scoped to the entry kind and read from real content
+    /// blocks — never byte-counted across the line. This is the shape the
+    /// real-corpus test caught: a `user` line whose quoted tool output mentions
+    /// `"name":"Agent"` repeatedly counted six spawns against the parser's zero.
+    #[test]
+    fn quoted_text_is_not_counted_as_activity() {
+        let echoed = "{\"type\":\"user\",\"uuid\":\"u1\",\"parentUuid\":null,             \"timestamp\":\"2026-08-26T09:00:00.000Z\",             \"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",             \"tool_use_id\":\"t1\",\"content\":\"available tools: \
+             {name: Agent}, {name: Task}, {name: Workflow}, type: tool_use, is_error: true\"}]}}";
+        let rec = index_line(echoed.as_bytes(), 0).expect("indexed");
+        assert_eq!(rec.spawns, 0, "a user line spawns nothing");
+        assert_eq!(
+            rec.tool_uses, 0,
+            "tool_use is counted on assistant lines only"
+        );
+        assert_eq!(rec.failures, 0, "the result is not flagged is_error");
+        assert_agrees(&format!("{echoed}\n"));
+
+        // The assistant side: real blocks are counted, and a spawn name that
+        // appears only inside a tool INPUT is not a spawn.
+        let assistant = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":\"u1\",             \"timestamp\":\"2026-08-26T09:00:05.000Z\",             \"message\":{\"role\":\"assistant\",\"content\":[             {\"type\":\"tool_use\",\"id\":\"t1\",\"name\":\"Read\",              \"input\":{\"prompt\":\"describe the Agent and Workflow tools\"}},             {\"type\":\"tool_use\",\"id\":\"t2\",\"name\":\"Agent\",\"input\":{}}]}}";
+        let rec = index_line(assistant.as_bytes(), 0).expect("indexed");
+        assert_eq!(rec.tool_uses, 2);
+        assert_eq!(rec.spawns, 1, "only the block whose name is a spawn tool");
+        assert_agrees(&format!("{assistant}\n"));
+
+        // A genuine failure still counts, on the user side where it lives.
+        let failed = "{\"type\":\"user\",\"uuid\":\"u2\",\"parentUuid\":\"a1\",             \"timestamp\":\"2026-08-26T09:00:09.000Z\",             \"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",             \"tool_use_id\":\"t1\",\"is_error\":true,\"content\":\"boom\"}]}}";
+        let rec = index_line(failed.as_bytes(), 0).expect("indexed");
+        assert_eq!(rec.failures, 1);
+        assert_agrees(&format!("{failed}\n"));
+    }
+
+    /// String-form `message.content` (a plain prompt) carries no blocks.
+    #[test]
+    fn string_content_yields_no_counts() {
+        let line = "{\"type\":\"user\",\"uuid\":\"u1\",\"parentUuid\":null,             \"timestamp\":\"2026-08-26T09:00:00.000Z\",\"origin\":{\"kind\":\"human\"},             \"message\":{\"role\":\"user\",\"content\":\"use the Agent tool please\"}}";
+        let rec = index_line(line.as_bytes(), 0).expect("indexed");
+        assert_eq!((rec.tool_uses, rec.spawns, rec.failures), (0, 0, 0));
+        assert!(rec.flags & flags::HUMAN_ORIGIN != 0);
+        assert_agrees(&format!("{line}\n"));
+    }
+
+    #[test]
+    fn timestamps_round_trip() {
+        // Canonical millisecond form, the shape transcripts actually use.
+        let micros = parse_ts(b"2026-06-21T10:00:09.250Z").unwrap();
+        assert_eq!(
+            chrono::DateTime::from_timestamp_micros(micros).unwrap(),
+            "2026-06-21T10:00:09.250Z"
+                .parse::<chrono::DateTime<chrono::Utc>>()
+                .unwrap()
+        );
+        // Second precision, and a non-canonical offset via the slow path.
+        assert!(parse_ts(b"2026-06-21T10:00:09Z").is_some());
+        assert_eq!(
+            parse_ts(b"2026-06-21T12:00:09+02:00"),
+            parse_ts(b"2026-06-21T10:00:09Z")
+        );
+        assert!(parse_ts(b"not a timestamp").is_none());
+    }
+
+    #[test]
+    fn extend_resumes_at_the_append_point() {
+        let a = "{\"type\":\"user\",\"uuid\":\"u1\",\"timestamp\":\"2026-06-21T10:00:00.000Z\"}\n";
+        let b =
+            "{\"type\":\"assistant\",\"uuid\":\"a1\",\"timestamp\":\"2026-06-21T10:00:05.000Z\"}\n";
+
+        let mut idx = Index::default();
+        idx.extend(a.as_bytes());
+        assert_eq!(idx.recs.len(), 1);
+        assert_eq!(idx.scanned_len, a.len() as u64);
+
+        // Appending re-scans only the new bytes and keeps the old records.
+        let both = format!("{a}{b}");
+        assert!(idx.continues(both.as_bytes()));
+        idx.extend(both.as_bytes());
+        assert_eq!(idx.recs.len(), 2);
+        assert_eq!(idx.recs[1].offset, a.len() as u64);
+        assert_eq!(idx.recs[1].kind, Kind::Assistant);
+    }
+
+    #[test]
+    fn a_partial_trailing_line_is_left_for_the_next_scan() {
+        let complete = "{\"type\":\"user\",\"uuid\":\"u1\"}\n";
+        let partial = "{\"type\":\"assis";
+        let mut idx = Index::default();
+        idx.extend(format!("{complete}{partial}").as_bytes());
+        // The half-written line is not indexed, and the next scan starts at it.
+        assert_eq!(idx.recs.len(), 1);
+        assert_eq!(idx.scanned_len, complete.len() as u64);
+    }
+
+    #[test]
+    fn truncation_is_detected() {
+        let text = "{\"type\":\"user\",\"uuid\":\"u1\"}\n{\"type\":\"user\",\"uuid\":\"u2\"}\n";
+        let mut idx = Index::default();
+        idx.extend(text.as_bytes());
+        assert!(idx.continues(text.as_bytes()));
+        // A file that got shorter was rotated, not appended to.
+        assert!(!idx.continues(&text.as_bytes()[..10]));
+    }
+
+    #[test]
+    fn cache_round_trips() {
+        let text = include_str!("../assets/demo.jsonl");
+        let mut idx = Index::default();
+        idx.extend(text.as_bytes());
+        let decoded = Index::decode(&idx.encode()).expect("decodes");
+        assert_eq!(decoded.recs, idx.recs);
+        assert_eq!(decoded.scanned_len, idx.scanned_len);
+        assert_eq!(decoded.head_hash, idx.head_hash);
+        assert_eq!(decoded.head_len, idx.head_len);
+        // A foreign file is rejected, not misread.
+        assert!(Index::decode(b"not an index").is_none());
+    }
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -406,10 +406,9 @@ struct EnvelopeFields<'a> {
     timestamp: Option<&'a [u8]>,
     agent_id: Option<&'a [u8]>,
     is_sidechain: bool,
-    /// The raw `origin` value, and whether the key was present at all — an
-    /// absent `origin` is what makes a legacy `user` line ambiguous.
+    /// The raw `origin` value. Its ABSENCE is what makes a legacy `user` line
+    /// ambiguous, so `None` here is itself the signal — see `index_line`.
     origin: Option<&'a [u8]>,
-    saw_origin: bool,
     /// The raw `message` value, captured here so [`count_blocks`] does not walk
     /// the line a second time to re-find it. It is the largest value on the
     /// line, and the envelope walk has already paid to skip past it.
@@ -429,10 +428,7 @@ fn scan_envelope(line: &[u8]) -> EnvelopeFields<'_> {
             b"timestamp" => out.timestamp = unquote(value),
             b"agentId" => out.agent_id = unquote(value),
             b"isSidechain" => out.is_sidechain = value == b"true",
-            b"origin" => {
-                out.saw_origin = true;
-                out.origin = Some(value);
-            }
+            b"origin" => out.origin = Some(value),
             b"message" => out.message = Some(value),
             _ => {}
         }
@@ -643,10 +639,6 @@ fn index_line(line: &[u8], offset: u64) -> Option<Rec> {
         None if kind == Kind::User => flag_bits |= flags::AMBIGUOUS_PROMPT,
         None => {}
     }
-    debug_assert!(
-        env.saw_origin == env.origin.is_some(),
-        "origin presence and value must agree"
-    );
 
     let counts = count_blocks(env.message, kind);
 
@@ -804,12 +796,7 @@ fn cache_path(transcript: &Path) -> Option<PathBuf> {
     let root = std::env::var_os("XDG_CACHE_HOME")
         .map(PathBuf::from)
         .filter(|p| !p.as_os_str().is_empty())
-        .or_else(|| {
-            #[allow(deprecated)]
-            std::env::home_dir()
-                .filter(|h| !h.as_os_str().is_empty())
-                .map(|h| h.join(".cache"))
-        })?;
+        .or_else(|| crate::transcript::home_dir().map(|h| h.join(".cache")))?;
     let key = fnv1a64(transcript.as_os_str().as_encoded_bytes());
     Some(
         root.join("zoetrope")

--- a/src/index.rs
+++ b/src/index.rs
@@ -744,7 +744,13 @@ impl Index {
         let head_hash = u64_at(16);
         let head_len = u64_at(24);
         let count = u64_at(32) as usize;
-        if bytes.len() < HEADER_SIZE + count * REC_SIZE {
+        // A corrupt header can name any count at all. Computing the size it
+        // implies must not wrap — a wrapped total compares small, passes the
+        // guard, and the decode below then reads past the end.
+        let needed = count
+            .checked_mul(REC_SIZE)
+            .and_then(|n| n.checked_add(HEADER_SIZE))?;
+        if bytes.len() < needed {
             return None;
         }
         let recs = (0..count)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,11 @@ pub mod tailer;
 pub mod transcript;
 pub mod ui;
 
-// The native frontend: terminal loop + crossterm input.
+// Native-only: skeleton indexing (needs the filesystem), the terminal loop,
+// and input.
+#[cfg(feature = "native")]
+pub mod index;
+
 #[cfg(feature = "native")]
 pub mod autopilot;
 #[cfg(feature = "native")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@ pub mod ui;
 #[cfg(feature = "native")]
 pub mod index;
 #[cfg(feature = "native")]
+pub mod monitor;
+#[cfg(feature = "native")]
 pub mod sessions;
 
 #[cfg(feature = "native")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,12 @@ pub mod tailer;
 pub mod transcript;
 pub mod ui;
 
-// Native-only: skeleton indexing (needs the filesystem), the terminal loop,
-// and input.
+// Native-only: skeleton indexing + multi-session discovery (both need the
+// filesystem), the terminal loop, and input.
 #[cfg(feature = "native")]
 pub mod index;
+#[cfg(feature = "native")]
+pub mod sessions;
 
 #[cfg(feature = "native")]
 pub mod autopilot;

--- a/src/main.rs
+++ b/src/main.rs
@@ -507,15 +507,21 @@ async fn run_tui(cli: Cli) -> Result<()> {
             };
             let proj = transcript::project_dir(&cwd)
                 .ok_or_else(|| anyhow!("no Claude projects directory for {}", cwd.display()))?;
-            // Best-effort latest session id so stale events filter; the tailer
-            // re-discovers and may switch.
-            let session_id = transcript::latest_session_file(&proj)
-                .as_deref()
-                .and_then(Path::file_stem)
-                .and_then(|s| s.to_str())
-                .unwrap_or("")
-                .to_string();
-            (session_id, proj, Mode::Live, false, DEFAULT_REPLAY_SPEED)
+            // Resolve the project's newest session HERE, and watch that file
+            // rather than the directory. The tailer no longer announces which
+            // session it picked — it watches what it is told — so the App must
+            // be the one that chose, or its id and the tailer's would disagree
+            // and every batch would be routed as some other session's.
+            //
+            // No session yet is fine: the directory is watched until one
+            // appears, and discovery names it within a sweep.
+            match transcript::latest_session_file(&proj) {
+                Some(main) => {
+                    let session_id = transcript::session_id_from_path(&main);
+                    (session_id, main, Mode::Live, false, DEFAULT_REPLAY_SPEED)
+                }
+                None => (String::new(), proj, Mode::Live, false, DEFAULT_REPLAY_SPEED),
+            }
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -481,6 +481,8 @@ async fn run_tui(cli: Cli) -> Result<()> {
         unreachable!("inspect handled in main");
     };
 
+    // Set only when the project has no session yet (see the `None` arm below).
+    let mut awaiting_project: Option<std::path::PathBuf> = None;
     let (session_id, watch_target, mode, replay, speed) = match target {
         // A concrete file → bulk-load + tail. Paced from the start unless
         // `--follow` asks to ride the (possibly still-growing) edge.
@@ -520,7 +522,10 @@ async fn run_tui(cli: Cli) -> Result<()> {
                     let session_id = transcript::session_id_from_path(&main);
                     (session_id, main, Mode::Live, false, DEFAULT_REPLAY_SPEED)
                 }
-                None => (String::new(), proj, Mode::Live, false, DEFAULT_REPLAY_SPEED),
+                None => {
+                    awaiting_project = Some(proj.clone());
+                    (String::new(), proj, Mode::Live, false, DEFAULT_REPLAY_SPEED)
+                }
             }
         }
     };
@@ -550,7 +555,12 @@ async fn run_tui(cli: Cli) -> Result<()> {
         }
     });
 
-    let app = App::new(session_id, mode);
+    let mut app = App::new(session_id, mode);
+    // Nothing recorded in this project yet: wait for one of ITS sessions rather
+    // than adopting the first the workspace-wide sweep happens to report.
+    if let Some(project) = awaiting_project {
+        app.await_project(project);
+    }
     tui::run(app, tail_tx, ui_rx, focus_tx).await
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@
 //! zoe <file> --follow       follow a file's live edge instead of replaying
 //! zoe <file> --speed N      playback speed multiplier (default 8.0)
 //! zoe inspect <file.jsonl>  headless: print the session tree + info
+//! zoe sessions [--since M]  headless: list every session active in a window
 //! ```
 
 use std::path::{Path, PathBuf};
@@ -19,7 +20,7 @@ use tokio::sync::mpsc;
 use zoetrope::state::session::{AgentKind, SessionModel, ToolState};
 use zoetrope::state::{App, Mode};
 use zoetrope::tailer::{Source, TailRequest, UiEvent, Update};
-use zoetrope::{tailer, transcript, tui};
+use zoetrope::{monitor, sessions, tailer, transcript, tui};
 
 /// Channel capacity for the bounded request/event channels.
 const CHANNEL_CAP: usize = 32;
@@ -42,10 +43,21 @@ pub enum Cli {
     },
     /// Headless: parse and print the session tree + info; no TUI.
     Inspect { file: PathBuf },
+    /// Headless: discover every session touched within `window` and summarize
+    /// each from its skeleton index. No TUI, no transcript bodies parsed.
+    Sessions {
+        window: std::time::Duration,
+        /// Projects root to sweep. `None` = `~/.claude/projects`.
+        root: Option<PathBuf>,
+    },
 }
 
 /// Default replay speed multiplier.
 const DEFAULT_REPLAY_SPEED: f64 = 8.0;
+
+/// Default `sessions` window: a day. Wide enough that "what was I running?"
+/// is answerable, narrow enough that the sweep stays a stat sweep.
+const DEFAULT_SESSION_WINDOW_MINS: u64 = 24 * 60;
 
 const USAGE: &str = "\
 zoetrope — visualize Claude Code agent sessions as a flow graph
@@ -57,7 +69,12 @@ USAGE:
     zoe <file> --follow     follow a file's live edge instead of replaying
     zoe <file> --speed N    playback speed (default 8.0)
     zoe inspect <file>      headless: print the session tree + info
+    zoe sessions [--since M] [--root DIR]
+                            headless: list sessions active in the last M minutes
     zoe --version           print the version and exit
+
+ENV:
+    ZOE_PROJECTS_ROOT       use this tree instead of ~/.claude/projects
 
 Once open, scrub/follow/pause/go-live are available no matter how you launched.";
 
@@ -65,6 +82,39 @@ Once open, scrub/follow/pause/go-live are available no matter how you launched."
 fn parse_cli(args: impl Iterator<Item = String>) -> Result<Cli> {
     // Skip argv[0].
     let mut args = args.skip(1).peekable();
+
+    // `sessions [--since <minutes>]`: the headless multi-session sweep.
+    if args.peek().map(String::as_str) == Some("sessions") {
+        args.next();
+        let mut minutes = DEFAULT_SESSION_WINDOW_MINS;
+        let mut root: Option<PathBuf> = None;
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                // Sweeping an arbitrary root is what makes this command
+                // testable: pointing it at a fixture tree exercises discovery
+                // without reading anybody's real transcripts.
+                "--root" => {
+                    let v = args
+                        .next()
+                        .ok_or_else(|| anyhow!("--root requires a directory\n\n{USAGE}"))?;
+                    root = Some(PathBuf::from(v));
+                }
+                "--since" => {
+                    let v = args.next().ok_or_else(|| {
+                        anyhow!("--since requires a number of minutes\n\n{USAGE}")
+                    })?;
+                    minutes = v
+                        .parse::<u64>()
+                        .with_context(|| format!("invalid --since value: {v:?}"))?;
+                }
+                other => bail!("unexpected argument {other:?}\n\n{USAGE}"),
+            }
+        }
+        return Ok(Cli::Sessions {
+            window: std::time::Duration::from_secs(minutes * 60),
+            root,
+        });
+    }
 
     // `inspect <file>` is the one distinct (headless) subcommand.
     if args.peek().map(String::as_str) == Some("inspect") {
@@ -253,6 +303,84 @@ async fn run_inspect(file: PathBuf) -> Result<()> {
     Ok(())
 }
 
+/// Run the `sessions` subcommand: discover every session touched within
+/// `window` and summarize each from its skeleton index.
+///
+/// Prints the two phases' costs separately, because they scale differently and
+/// the distinction is the whole point of the design: discovery is a stat sweep
+/// over every project, summarizing is a byte scan over the survivors — and on a
+/// warm index cache the second phase reads headers rather than transcripts.
+fn run_sessions(window: std::time::Duration, root: Option<PathBuf>) -> Result<()> {
+    let root = match root {
+        Some(r) => r,
+        None => transcript::claude_projects_root()
+            .ok_or_else(|| anyhow!("no Claude projects directory (is $HOME set?)"))?,
+    };
+    let since = std::time::SystemTime::now()
+        .checked_sub(window)
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+
+    let t0 = std::time::Instant::now();
+    let found = sessions::discover(&root, since);
+    let discover_ms = t0.elapsed().as_secs_f64() * 1e3;
+
+    let mins = window.as_secs() / 60;
+    println!(
+        "{} — sessions touched in the last {mins} min",
+        root.display()
+    );
+    if found.is_empty() {
+        println!("  (none)");
+        return Ok(());
+    }
+
+    let t1 = std::time::Instant::now();
+    let summaries: Vec<_> = found.iter().map(sessions::Summary::of).collect();
+    let index_ms = t1.elapsed().as_secs_f64() * 1e3;
+
+    println!();
+    println!(
+        "{:<10} {:>6} {:>6} {:>8} {:>7} {:>7} {:>6} {:>6}  last activity",
+        "session", "files", "MB", "lines", "prompts", "tools", "spawn", "fail"
+    );
+    for (s, sum) in found.iter().zip(&summaries) {
+        let last = sum
+            .last_activity
+            .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
+            .unwrap_or_else(|| "—".to_string());
+        // A session whose newest bytes are a subagent's is the case the naive
+        // main-file mtime filter drops; mark it so the sweep can be eyeballed.
+        let mark = if s.touched_by_sidecar { " ·sub" } else { "" };
+        let prompts = if sum.ambiguous_prompts > 0 {
+            format!("{}+{}?", sum.prompts, sum.ambiguous_prompts)
+        } else {
+            sum.prompts.to_string()
+        };
+        println!(
+            "{:<10} {:>6} {:>6.1} {:>8} {:>7} {:>7} {:>6} {:>6}  {last}{mark}",
+            &s.session_id[..8.min(s.session_id.len())],
+            sum.files,
+            sum.bytes as f64 / 1e6,
+            sum.lines,
+            prompts,
+            sum.tool_calls,
+            sum.spawns,
+            sum.failures,
+        );
+    }
+
+    let total_mb: f64 = summaries.iter().map(|s| s.bytes as f64).sum::<f64>() / 1e6;
+    let total_files: usize = summaries.iter().map(|s| s.files).sum();
+    println!();
+    println!(
+        "{} session(s), {total_files} file(s), {total_mb:.1} MB",
+        found.len()
+    );
+    println!("  discover (stat sweep): {discover_ms:.1} ms");
+    println!("  index + summarize:     {index_ms:.1} ms");
+    Ok(())
+}
+
 /// Build `SessionInfo` from the main file's untimed flat-metadata (mirrors the
 /// timeline feeder's extraction, for the headless `inspect` path). Latest-wins by
 /// file order; counts accumulate.
@@ -401,6 +529,14 @@ async fn run_tui(cli: Cli) -> Result<()> {
         .await
         .map_err(|_| anyhow!("tailer channel closed before start"))?;
 
+    // Multi-session discovery + the monitor fleet: publishes the rail rows and
+    // keeps a tailer on every live session that is not focused, so the canvas
+    // shows all of them. The focus tailer below still owns the one session with
+    // a timeline; `focus_tx` tells the supervisor which that is.
+    let (focus_tx, focus_rx) = tokio::sync::watch::channel(session_id.clone());
+    let sweep_tx = ui_tx.clone();
+    tokio::spawn(async move { monitor::supervise(sweep_tx, focus_rx).await });
+
     // Spawn the tailer task — owns all files of the watched session.
     tokio::spawn(async move {
         if let Err(e) = tailer::run(tail_rx, ui_tx.clone(), replay, speed).await {
@@ -409,7 +545,7 @@ async fn run_tui(cli: Cli) -> Result<()> {
     });
 
     let app = App::new(session_id, mode);
-    tui::run(app, tail_tx, ui_rx).await
+    tui::run(app, tail_tx, ui_rx, focus_tx).await
 }
 
 #[tokio::main]
@@ -426,6 +562,7 @@ async fn main() -> Result<()> {
     let cli = parse_cli(std::env::args())?;
     match cli {
         Cli::Inspect { file } => run_inspect(file).await,
+        Cli::Sessions { window, root } => run_sessions(window, root),
         other => run_tui(other).await,
     }
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -9,15 +9,14 @@
 //!
 //! A monitored session is folded straight off its live edge into a model that
 //! only ever renders — no [`Timeline`](crate::state::timeline::Timeline), no
-//! playhead, no seeking. Its events are therefore relabelled
-//! ([`UiEvent::MonitorBatch`] / [`UiEvent::MonitorReset`]) before reaching the
-//! App, because the focus tailer's `Batch` for an unfamiliar session id means
-//! "I switched sessions" — a meaning a monitor must never accidentally speak.
+//! playhead, no seeking. That is the ONLY difference between it and the focused
+//! session, and it is the App's decision, not the tailer's: every tailer here
+//! emits the same `Batch`/`SessionReset` events stamped with a `session_id`, and
+//! the App routes on that.
 //!
-//! Each monitor watches a concrete `<uuid>.jsonl`, which the tailer treats as
-//! pinned (`live.rs`: a file target disables the newer-session auto-switch). A
-//! monitor following a project's newest session out from under the supervisor
-//! would leave the fleet's bookkeeping describing sessions nobody is tailing.
+//! Each tailer is pinned to the file it was given and never follows a different
+//! one, so the fleet's bookkeeping always describes the sessions actually being
+//! tailed.
 
 use std::collections::HashMap;
 
@@ -39,23 +38,24 @@ pub const MAX_MONITORED: usize = 8;
 /// Request-channel capacity for a monitor's tailer. One `Watch` is ever sent.
 const REQ_CAP: usize = 1;
 
-/// Event-channel capacity between a monitor's tailer and its relabeller.
-const EVENT_CAP: usize = 32;
-
 /// A running monitor. Dropping it closes the request channel, which is how
 /// [`tailer::run`] is told to shut down.
 struct Monitor {
     _req_tx: mpsc::Sender<TailRequest>,
 }
 
-/// Start a tailer for one session and relabel its events for the App.
+/// Start a tailer pinned to one session's transcript.
+///
+/// Its events go straight to the UI channel: they carry a `session_id`, and the
+/// App routes on that alone. There is no relabelling step and no second channel
+/// — a monitored session and the focused one differ only in which one the App
+/// has decided to focus, which the tailer neither knows nor needs to.
 fn spawn_monitor(row: &RailRow, ui_tx: mpsc::Sender<UiEvent>) -> Monitor {
     let (req_tx, req_rx) = mpsc::channel(REQ_CAP);
-    let (mon_tx, mut mon_rx) = mpsc::channel(EVENT_CAP);
 
-    // The tailer itself, live (never replay — a monitor follows an edge).
+    // Live, never replay — a monitor follows an edge.
     tokio::spawn(async move {
-        let _ = tailer::run(req_rx, mon_tx, false, 1.0).await;
+        let _ = tailer::run(req_rx, ui_tx, false, 1.0).await;
     });
 
     // Pin it to this session's file. The channel has room for exactly this.
@@ -63,28 +63,6 @@ fn spawn_monitor(row: &RailRow, ui_tx: mpsc::Sender<UiEvent>) -> Monitor {
     let req = req_tx.clone();
     tokio::spawn(async move {
         let _ = req.send(TailRequest::Watch(path)).await;
-    });
-
-    // Relabel. `ReplayLoaded` cannot occur (live mode) and an `Error` from a
-    // monitor is dropped rather than surfaced: it belongs to a session the user
-    // is not looking at, and the status bar speaks for the focused one.
-    tokio::spawn(async move {
-        while let Some(event) = mon_rx.recv().await {
-            let relabelled = match event {
-                UiEvent::Batch {
-                    session_id,
-                    updates,
-                } => UiEvent::MonitorBatch {
-                    session_id,
-                    updates,
-                },
-                UiEvent::SessionReset { session_id } => UiEvent::MonitorReset { session_id },
-                _ => continue,
-            };
-            if ui_tx.send(relabelled).await.is_err() {
-                return;
-            }
-        }
     });
 
     Monitor { _req_tx: req_tx }
@@ -113,12 +91,32 @@ fn wanted(rows: &[RailRow], focus: &str, now: chrono::DateTime<chrono::Utc>) -> 
 /// Runs until the UI channel closes. Subsumes the plain discovery sweep — the
 /// rows it publishes and the fleet it manages come from the same scan, so they
 /// can never describe different workspaces.
-pub async fn supervise(ui_tx: mpsc::Sender<UiEvent>, focused: watch::Receiver<String>) {
+pub async fn supervise(ui_tx: mpsc::Sender<UiEvent>, mut focused: watch::Receiver<String>) {
     let mut monitors: HashMap<String, Monitor> = HashMap::new();
     let mut ticker = tokio::time::interval(sessions::SWEEP_INTERVAL);
 
     loop {
-        ticker.tick().await;
+        // React to a focus change immediately, not on the next sweep. The App
+        // switches focus the moment the user asks; until this fleet notices,
+        // the newly focused session still has a monitor on it, and BOTH tailers
+        // feed the App events for it — which the App can no longer tell apart,
+        // because telling them apart is exactly the distinction this design
+        // removed. Waking on the change keeps that window to nothing.
+        tokio::select! {
+            _ = ticker.tick() => {}
+            changed = focused.changed() => {
+                if changed.is_err() {
+                    return;
+                }
+                let focus = focused.borrow().clone();
+                if monitors.remove(&focus).is_some() {
+                    // Its model is the focused one's now; the App replaced it
+                    // when it switched, so nothing to tell it here.
+                    continue;
+                }
+                continue;
+            }
+        }
 
         // Discovery is blocking and touches every project directory, so it goes
         // on the blocking pool rather than occupying a runtime worker.
@@ -148,7 +146,7 @@ pub async fn supervise(ui_tx: mpsc::Sender<UiEvent>, focused: watch::Receiver<St
         for id in stale {
             monitors.remove(&id);
             if ui_tx
-                .send(UiEvent::MonitorReset { session_id: id })
+                .send(UiEvent::SessionReset { session_id: id })
                 .await
                 .is_err()
             {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -120,6 +120,7 @@ fn retired(
 pub async fn supervise(ui_tx: mpsc::Sender<UiEvent>, mut focused: watch::Receiver<String>) {
     let mut monitors: HashMap<String, Monitor> = HashMap::new();
     let mut ticker = tokio::time::interval(sessions::SWEEP_INTERVAL);
+    let mut sweeper = sessions::Sweeper::default();
 
     loop {
         // React to a focus change immediately, not on the next sweep. The App
@@ -145,14 +146,23 @@ pub async fn supervise(ui_tx: mpsc::Sender<UiEvent>, mut focused: watch::Receive
         }
 
         // Discovery is blocking and touches every project directory, so it goes
-        // on the blocking pool rather than occupying a runtime worker.
-        let Ok(rows) =
-            tokio::task::spawn_blocking(|| sessions::sweep(sessions::SWEEP_WINDOW)).await
+        // on the blocking pool rather than occupying a runtime worker. The
+        // sweeper rides along so each tick can skip what it can prove has not
+        // changed since the last one.
+        let mut owned = sweeper;
+        let Ok((returned, rows)) = tokio::task::spawn_blocking(move || {
+            let rows = owned.rows(sessions::SWEEP_WINDOW);
+            (owned, rows)
+        })
+        .await
         else {
             // The scan panicked; try again next tick rather than killing the
-            // rail and the canvas for the rest of the run.
+            // rail and the canvas for the rest of the run. Its cache went with
+            // it, so start a cold one.
+            sweeper = sessions::Sweeper::default();
             continue;
         };
+        sweeper = returned;
 
         if ui_tx.send(UiEvent::Sessions(rows.clone())).await.is_err() {
             return;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -175,9 +175,7 @@ mod tests {
             project: "p".to_string(),
             main_path: PathBuf::from(format!("/p/{id}.jsonl")),
             agents: 1,
-            tool_calls: 0,
             failures: 0,
-            prompts: 0,
             last_activity: Some(now - chrono::Duration::seconds(ago)),
             sidecar_active: false,
         }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -85,6 +85,32 @@ fn wanted(rows: &[RailRow], focus: &str, now: chrono::DateTime<chrono::Utc>) -> 
         .collect()
 }
 
+/// Which monitors to stop, and whether each one's session should also be taken
+/// off the canvas (`true`).
+///
+/// The distinction is the whole point. A monitor stops for two unrelated
+/// reasons, and only one of them is a retirement:
+///
+/// * the session went quiet or vanished — retire it, or its subtree lingers on
+///   the canvas forever with nothing feeding it;
+/// * the user focused it — do NOT retire it. The App reads a `SessionReset` for
+///   the focused session as a truncation and rebuilds it from nothing, dropping
+///   the model, the `Timeline` and the snapshot ladder that the focus tailer has
+///   just backfilled. Focus can win this race: [`supervise`] wakes on the focus
+///   change, but a sweep tick that is ready at the same instant is chosen at
+///   random, and it sees the new focus in `wanted` either way.
+fn retired(
+    monitors: &HashMap<String, Monitor>,
+    wanted: &[RailRow],
+    focus: &str,
+) -> Vec<(String, bool)> {
+    monitors
+        .keys()
+        .filter(|id| !wanted.iter().any(|r| &&r.session_id == id))
+        .map(|id| (id.clone(), id != focus))
+        .collect()
+}
+
 /// Sweep discovery on an interval, publish the rail rows, and keep the monitor
 /// fleet matching what is live.
 ///
@@ -138,13 +164,11 @@ pub async fn supervise(ui_tx: mpsc::Sender<UiEvent>, mut focused: watch::Receive
         // Stop monitors for sessions that went quiet, vanished, or became the
         // focused one — and tell the App to take each off the canvas, or its
         // subtree would linger forever with nothing feeding it.
-        let stale: Vec<String> = monitors
-            .keys()
-            .filter(|id| !wanted.iter().any(|r| &&r.session_id == id))
-            .cloned()
-            .collect();
-        for id in stale {
+        for (id, retire) in retired(&monitors, &wanted, &focus) {
             monitors.remove(&id);
+            if !retire {
+                continue;
+            }
             if ui_tx
                 .send(UiEvent::SessionReset { session_id: id })
                 .await
@@ -197,6 +221,33 @@ mod tests {
             .map(|r| r.session_id)
             .collect();
         assert_eq!(ids, vec!["live".to_string()]);
+    }
+
+    /// A monitor for a session the user just focused must stop WITHOUT a
+    /// `SessionReset` — the App reads that as a truncation of the focused
+    /// session and throws away the model, timeline and ladder the focus tailer
+    /// has just backfilled.
+    #[test]
+    fn focusing_a_monitored_session_stops_it_without_retiring_it() {
+        let n = now();
+        let (tx, _rx) = mpsc::channel(1);
+        let mut monitors: HashMap<String, Monitor> = HashMap::new();
+        monitors.insert(
+            "focused".to_string(),
+            Monitor {
+                _req_tx: tx.clone(),
+            },
+        );
+        monitors.insert("gone".to_string(), Monitor { _req_tx: tx });
+
+        // Neither is wanted: one because it is the focus, one because it died.
+        let wanted = wanted(&[row("other", 1, n)], "focused", n);
+        let mut out = retired(&monitors, &wanted, "focused");
+        out.sort();
+        assert_eq!(
+            out,
+            vec![("focused".to_string(), false), ("gone".to_string(), true)]
+        );
     }
 
     #[test]

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,0 +1,222 @@
+//! Monitor tailers: one per live session that is not the focused one.
+//!
+//! The canvas shows every live session, so every live session needs its
+//! transcripts tailed — not just the one being scrubbed. This module owns that
+//! fleet: it sweeps discovery on an interval, decides which sessions deserve a
+//! tailer, and starts and stops them as sessions come and go.
+//!
+//! # Monitors are not the focus tailer
+//!
+//! A monitored session is folded straight off its live edge into a model that
+//! only ever renders — no [`Timeline`](crate::state::timeline::Timeline), no
+//! playhead, no seeking. Its events are therefore relabelled
+//! ([`UiEvent::MonitorBatch`] / [`UiEvent::MonitorReset`]) before reaching the
+//! App, because the focus tailer's `Batch` for an unfamiliar session id means
+//! "I switched sessions" — a meaning a monitor must never accidentally speak.
+//!
+//! Each monitor watches a concrete `<uuid>.jsonl`, which the tailer treats as
+//! pinned (`live.rs`: a file target disables the newer-session auto-switch). A
+//! monitor following a project's newest session out from under the supervisor
+//! would leave the fleet's bookkeeping describing sessions nobody is tailing.
+
+use std::collections::HashMap;
+
+use tokio::sync::{mpsc, watch};
+
+use crate::sessions;
+use crate::state::rail::{RailRow, RailStatus};
+use crate::tailer::{self, TailRequest, UiEvent};
+
+/// Most sessions monitored at once.
+///
+/// Each costs a task, a model, and a subtree on the canvas. Real concurrency
+/// tops out at a handful — beyond that the canvas is unreadable anyway and the
+/// rail is the better view — so the cap protects against a pathological
+/// workspace (a scripted fleet, a restored backup) rather than normal use.
+/// Sessions beyond it stay in the rail; they are simply not drawn.
+pub const MAX_MONITORED: usize = 8;
+
+/// Request-channel capacity for a monitor's tailer. One `Watch` is ever sent.
+const REQ_CAP: usize = 1;
+
+/// Event-channel capacity between a monitor's tailer and its relabeller.
+const EVENT_CAP: usize = 32;
+
+/// A running monitor. Dropping it closes the request channel, which is how
+/// [`tailer::run`] is told to shut down.
+struct Monitor {
+    _req_tx: mpsc::Sender<TailRequest>,
+}
+
+/// Start a tailer for one session and relabel its events for the App.
+fn spawn_monitor(row: &RailRow, ui_tx: mpsc::Sender<UiEvent>) -> Monitor {
+    let (req_tx, req_rx) = mpsc::channel(REQ_CAP);
+    let (mon_tx, mut mon_rx) = mpsc::channel(EVENT_CAP);
+
+    // The tailer itself, live (never replay — a monitor follows an edge).
+    tokio::spawn(async move {
+        let _ = tailer::run(req_rx, mon_tx, false, 1.0).await;
+    });
+
+    // Pin it to this session's file. The channel has room for exactly this.
+    let path = row.main_path.clone();
+    let req = req_tx.clone();
+    tokio::spawn(async move {
+        let _ = req.send(TailRequest::Watch(path)).await;
+    });
+
+    // Relabel. `ReplayLoaded` cannot occur (live mode) and an `Error` from a
+    // monitor is dropped rather than surfaced: it belongs to a session the user
+    // is not looking at, and the status bar speaks for the focused one.
+    tokio::spawn(async move {
+        while let Some(event) = mon_rx.recv().await {
+            let relabelled = match event {
+                UiEvent::Batch {
+                    session_id,
+                    updates,
+                } => UiEvent::MonitorBatch {
+                    session_id,
+                    updates,
+                },
+                UiEvent::SessionReset { session_id } => UiEvent::MonitorReset { session_id },
+                _ => continue,
+            };
+            if ui_tx.send(relabelled).await.is_err() {
+                return;
+            }
+        }
+    });
+
+    Monitor { _req_tx: req_tx }
+}
+
+/// Which sessions should have a monitor right now.
+///
+/// **Running only.** The rail lists everything touched in the last day, but the
+/// canvas is for what is happening: folding a model and drawing a subtree for a
+/// session that stopped hours ago costs real memory and screen to say "this is
+/// over". Idle sessions stay one keypress away in the rail.
+fn wanted(rows: &[RailRow], focus: &str, now: chrono::DateTime<chrono::Utc>) -> Vec<RailRow> {
+    rows.iter()
+        .filter(|r| r.status(now) == RailStatus::Running)
+        // The focused session already has the focus tailer. A second tailer on
+        // it would double every append.
+        .filter(|r| r.session_id != focus)
+        .take(MAX_MONITORED)
+        .cloned()
+        .collect()
+}
+
+/// Sweep discovery on an interval, publish the rail rows, and keep the monitor
+/// fleet matching what is live.
+///
+/// Runs until the UI channel closes. Subsumes the plain discovery sweep — the
+/// rows it publishes and the fleet it manages come from the same scan, so they
+/// can never describe different workspaces.
+pub async fn supervise(ui_tx: mpsc::Sender<UiEvent>, focused: watch::Receiver<String>) {
+    let mut monitors: HashMap<String, Monitor> = HashMap::new();
+    let mut ticker = tokio::time::interval(sessions::SWEEP_INTERVAL);
+
+    loop {
+        ticker.tick().await;
+
+        // Discovery is blocking and touches every project directory, so it goes
+        // on the blocking pool rather than occupying a runtime worker.
+        let Ok(rows) =
+            tokio::task::spawn_blocking(|| sessions::sweep(sessions::SWEEP_WINDOW)).await
+        else {
+            // The scan panicked; try again next tick rather than killing the
+            // rail and the canvas for the rest of the run.
+            continue;
+        };
+
+        if ui_tx.send(UiEvent::Sessions(rows.clone())).await.is_err() {
+            return;
+        }
+
+        let focus = focused.borrow().clone();
+        let wanted = wanted(&rows, &focus, chrono::Utc::now());
+
+        // Stop monitors for sessions that went quiet, vanished, or became the
+        // focused one — and tell the App to take each off the canvas, or its
+        // subtree would linger forever with nothing feeding it.
+        let stale: Vec<String> = monitors
+            .keys()
+            .filter(|id| !wanted.iter().any(|r| &&r.session_id == id))
+            .cloned()
+            .collect();
+        for id in stale {
+            monitors.remove(&id);
+            if ui_tx
+                .send(UiEvent::MonitorReset { session_id: id })
+                .await
+                .is_err()
+            {
+                return;
+            }
+        }
+
+        for row in &wanted {
+            if !monitors.contains_key(&row.session_id) {
+                monitors.insert(row.session_id.clone(), spawn_monitor(row, ui_tx.clone()));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn row(id: &str, ago: i64, now: chrono::DateTime<chrono::Utc>) -> RailRow {
+        RailRow {
+            session_id: id.to_string(),
+            project: "p".to_string(),
+            main_path: PathBuf::from(format!("/p/{id}.jsonl")),
+            agents: 1,
+            tool_calls: 0,
+            failures: 0,
+            prompts: 0,
+            last_activity: Some(now - chrono::Duration::seconds(ago)),
+            sidecar_active: false,
+        }
+    }
+
+    fn now() -> chrono::DateTime<chrono::Utc> {
+        "2026-08-26T12:00:00Z".parse().unwrap()
+    }
+
+    #[test]
+    fn only_running_unfocused_sessions_are_monitored() {
+        let n = now();
+        let rows = vec![
+            row("focused", 1, n),
+            row("live", 5, n),
+            // Past the liveness threshold: in the rail, off the canvas.
+            row("stale", crate::state::rail::RAIL_IDLE_SECS + 60, n),
+        ];
+        let ids: Vec<String> = wanted(&rows, "focused", n)
+            .into_iter()
+            .map(|r| r.session_id)
+            .collect();
+        assert_eq!(ids, vec!["live".to_string()]);
+    }
+
+    #[test]
+    fn the_fleet_is_capped() {
+        let n = now();
+        let rows: Vec<_> = (0..MAX_MONITORED + 5)
+            .map(|i| row(&format!("s{i}"), 1, n))
+            .collect();
+        assert_eq!(wanted(&rows, "none", n).len(), MAX_MONITORED);
+    }
+
+    #[test]
+    fn an_undated_session_is_never_monitored() {
+        let n = now();
+        let mut r = row("s", 1, n);
+        r.last_activity = None;
+        assert!(wanted(&[r], "none", n).is_empty());
+    }
+}

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1,0 +1,597 @@
+//! Multi-session discovery: find every session worth watching, accurately.
+//!
+//! The single-session paths ask a project directory for its newest transcript
+//! ([`crate::transcript::latest_session_file`]). Watching *all* live sessions
+//! is a different question — every project directory, every transcript in it,
+//! and the sidecars underneath — where being wrong is worse than being slow:
+//! a missed session is a session the user believes they are watching.
+//!
+//! # Why activity is not the main file's mtime
+//!
+//! A session's recent work often lands entirely in a subagent sidecar while the
+//! main transcript sits untouched — the main agent is blocked on the subagent,
+//! so it writes nothing. Filtering on the main file's mtime alone drops exactly
+//! the sessions a user most wants to see: the ones with agents running right
+//! now. [`SessionRef::last_touched`] is therefore the newest mtime across the
+//! main transcript *and* every sidecar under it.
+//!
+//! # Two phases, and why the first one is sound
+//!
+//! 1. [`discover`] — a stat-only sweep. Cheap enough to run over every project
+//!    on every scan tick.
+//! 2. [`Summary::of`] — the [`crate::index`] skeleton scan over the candidates,
+//!    giving true first/last activity and activity counts with no body parsing.
+//!
+//! Phase 1 filters on mtime, which can only ever *over*-include: appending to a
+//! file always advances its mtime, so no active session can be filtered out.
+//! Phase 2 then reports ground truth from the bytes. The one case mtime gets
+//! wrong is a transcript restored from a backup with its old mtime preserved —
+//! it looks older than its contents. That is a restore, not a live session, so
+//! the window filter excluding it is correct behaviour rather than a miss.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use crate::index::{self, Index, flags};
+use crate::state::rail::{RailRow, project_label};
+use crate::transcript::{self, Entry};
+
+/// One discovered session and everything the stat sweep learned about it.
+#[derive(Debug, Clone)]
+pub struct SessionRef {
+    /// The session uuid (the main transcript's file stem).
+    pub session_id: String,
+    /// `~/.claude/projects/<sanitized-cwd>` — the session's project directory.
+    pub project_dir: PathBuf,
+    /// The main `<uuid>.jsonl`.
+    pub main_path: PathBuf,
+    /// Newest mtime across the main transcript and every sidecar. See the
+    /// module docs for why the main file alone is not enough.
+    pub last_touched: SystemTime,
+    /// Whether [`last_touched`](Self::last_touched) came from a sidecar rather
+    /// than the main transcript — i.e. the visible work is a subagent's.
+    pub touched_by_sidecar: bool,
+    /// Total bytes across the main transcript and every sidecar.
+    pub bytes: u64,
+    /// Sidecar transcripts found (direct subagents, workflow subagents,
+    /// journals).
+    pub sidecar_count: usize,
+}
+
+impl SessionRef {
+    /// Every transcript file belonging to this session, main first.
+    ///
+    /// Re-scans the sidecar directories, so a file created since [`discover`]
+    /// ran is picked up. Journals are included: a workflow's completion ledger
+    /// is session activity like any other.
+    pub fn files(&self) -> Vec<PathBuf> {
+        let mut out = vec![self.main_path.clone()];
+        let Some(subs) = transcript::subagents_dir(&self.main_path) else {
+            return out;
+        };
+        out.extend(
+            transcript::scan_subagent_files(&subs, None)
+                .into_iter()
+                .map(|f| f.transcript),
+        );
+        for wf_id in transcript::scan_workflow_ids(&subs) {
+            let dir = transcript::workflow_dir(&subs, &wf_id);
+            out.extend(
+                transcript::scan_subagent_files(&dir, Some(&wf_id))
+                    .into_iter()
+                    .map(|f| f.transcript),
+            );
+            let journal = transcript::workflow_journal(&subs, &wf_id);
+            if journal.is_file() {
+                out.push(journal);
+            }
+        }
+        out
+    }
+}
+
+/// Newest mtime and total size across a session's sidecars, plus how many there
+/// are. Returns `None` when the session has no `subagents/` directory at all.
+fn sidecar_stats(main_path: &Path) -> Option<(SystemTime, u64, usize)> {
+    let subs = transcript::subagents_dir(main_path)?;
+    if !subs.is_dir() {
+        return None;
+    }
+    let mut newest = SystemTime::UNIX_EPOCH;
+    let mut bytes = 0u64;
+    let mut count = 0usize;
+
+    // A closure rather than recursion: the sidecar layout is exactly two levels
+    // (`subagents/` and `subagents/workflows/<id>/`), so a general directory
+    // walk would be scope the format does not have.
+    let mut visit = |dir: &Path| {
+        let Ok(read) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in read.flatten() {
+            let Ok(meta) = entry.metadata() else { continue };
+            if !meta.is_file() {
+                continue;
+            }
+            if entry.path().extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            count += 1;
+            bytes += meta.len();
+            if let Ok(m) = meta.modified() {
+                newest = newest.max(m);
+            }
+        }
+    };
+
+    visit(&subs);
+    for wf_id in transcript::scan_workflow_ids(&subs) {
+        visit(&transcript::workflow_dir(&subs, &wf_id));
+    }
+
+    (count > 0).then_some((newest, bytes, count))
+}
+
+/// Stat one main transcript into a [`SessionRef`].
+fn session_ref(project_dir: &Path, main_path: PathBuf) -> Option<SessionRef> {
+    let meta = std::fs::metadata(&main_path).ok()?;
+    if !meta.is_file() {
+        return None;
+    }
+    let main_mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+    let mut last_touched = main_mtime;
+    let mut bytes = meta.len();
+    let mut sidecar_count = 0;
+    let mut touched_by_sidecar = false;
+
+    if let Some((sidecar_mtime, sidecar_bytes, count)) = sidecar_stats(&main_path) {
+        bytes += sidecar_bytes;
+        sidecar_count = count;
+        if sidecar_mtime > last_touched {
+            last_touched = sidecar_mtime;
+            touched_by_sidecar = true;
+        }
+    }
+
+    Some(SessionRef {
+        session_id: transcript::session_id_from_path(&main_path),
+        project_dir: project_dir.to_path_buf(),
+        main_path,
+        last_touched,
+        touched_by_sidecar,
+        bytes,
+        sidecar_count,
+    })
+}
+
+/// Every session under `root` touched at or after `since`, newest first.
+///
+/// `root` is normally [`transcript::claude_projects_root`]. Unreadable project
+/// directories are skipped rather than failing the sweep — a permissions
+/// problem in one project must not blind the user to every other.
+pub fn discover(root: &Path, since: SystemTime) -> Vec<SessionRef> {
+    let Ok(projects) = std::fs::read_dir(root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for project in projects.flatten() {
+        let dir = project.path();
+        if !dir.is_dir() {
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !transcript::is_session_file(&path) {
+                continue;
+            }
+            // Stat the main file first and skip the sidecar sweep for anything
+            // far outside the window — but only when the main file itself is
+            // old AND has no sidecar directory to check, which `session_ref`
+            // resolves. The cheap rejection is the extension/uuid filter above.
+            if let Some(s) = session_ref(&dir, path)
+                && s.last_touched >= since
+            {
+                out.push(s);
+            }
+        }
+    }
+    out.sort_by_key(|s| std::cmp::Reverse(s.last_touched));
+    out
+}
+
+/// Every session in the default projects root touched within `window`.
+pub fn discover_recent(window: std::time::Duration) -> Vec<SessionRef> {
+    let Some(root) = transcript::claude_projects_root() else {
+        return Vec::new();
+    };
+    let since = SystemTime::now()
+        .checked_sub(window)
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    discover(&root, since)
+}
+
+/// What a session looks like from its skeleton index alone — enough to render a
+/// session list row, with no transcript body parsed.
+///
+/// Every field is folded from [`index::Rec`]s, so building one costs a stat and
+/// a header read on a warm cache.
+#[derive(Debug, Clone, Default)]
+pub struct Summary {
+    pub session_id: String,
+    /// Earliest and latest timestamp across every file. Ground truth from the
+    /// bytes, unlike [`SessionRef::last_touched`], which is the mtime proxy.
+    pub first_activity: Option<chrono::DateTime<chrono::Utc>>,
+    pub last_activity: Option<chrono::DateTime<chrono::Utc>>,
+    /// Indexed lines across every file.
+    pub lines: usize,
+    /// Lines the model would fold onto the timeline (excludes flat metadata).
+    pub timeline_items: usize,
+    /// Human prompts the index can vouch for (`origin.kind == "human"`).
+    pub prompts: usize,
+    /// Legacy `user` lines with no `origin` field, where prompt-ness needs the
+    /// body. Non-zero means [`prompts`](Self::prompts) is a lower bound — the
+    /// index reports the gap rather than guessing across it.
+    pub ambiguous_prompts: usize,
+    pub tool_calls: usize,
+    pub spawns: usize,
+    pub failures: usize,
+    /// Distinct `agentId`s seen across the sidecars — the session's agent count
+    /// without folding a model.
+    pub agents: usize,
+    /// Bytes indexed across every file.
+    pub bytes: u64,
+    /// Files indexed (main + sidecars).
+    pub files: usize,
+    /// The working directory the session ran in, read from the first
+    /// envelope-bearing line of the main transcript.
+    ///
+    /// The one field here that costs a parsed body — exactly one line per
+    /// session. Worth it: the alternative is guessing the project name from the
+    /// `~/.claude/projects` directory name, which is a sanitized cwd and not
+    /// invertible (see [`project_label`]). A session's cwd never changes, so
+    /// the first line that has one is as good as any.
+    pub cwd: Option<String>,
+}
+
+impl Summary {
+    /// Fold every record of every file belonging to `session`.
+    ///
+    /// Files that cannot be opened are skipped: a sidecar deleted between
+    /// discovery and indexing is normal (a workflow cleaning up), not an error.
+    pub fn of(session: &SessionRef) -> Summary {
+        let mut s = Summary {
+            session_id: session.session_id.clone(),
+            ..Default::default()
+        };
+        let mut agent_keys = std::collections::HashSet::new();
+
+        for (n, path) in session.files().iter().enumerate() {
+            let Ok((idx, map)) = index::open(path) else {
+                continue;
+            };
+            // `files()` yields the main transcript first.
+            if n == 0 {
+                s.cwd = first_cwd(&idx, &map);
+            }
+            s.files += 1;
+            s.bytes += map.len() as u64;
+            s.fold(&idx, &mut agent_keys);
+        }
+        s.agents = agent_keys.len();
+        s
+    }
+
+    /// Fold one file's records in.
+    fn fold(&mut self, idx: &Index, agent_keys: &mut std::collections::HashSet<u32>) {
+        for rec in &idx.recs {
+            self.lines += 1;
+            if rec.kind.is_timeline_item() {
+                self.timeline_items += 1;
+            }
+            if let Some(ts) = rec.ts() {
+                self.first_activity = Some(self.first_activity.map_or(ts, |f| f.min(ts)));
+                self.last_activity = Some(self.last_activity.map_or(ts, |l| l.max(ts)));
+            }
+            if rec.flags & flags::HUMAN_ORIGIN != 0 {
+                self.prompts += 1;
+            } else if rec.flags & flags::AMBIGUOUS_PROMPT != 0 {
+                self.ambiguous_prompts += 1;
+            }
+            if rec.agent_key != 0 {
+                agent_keys.insert(rec.agent_key);
+            }
+            self.tool_calls += rec.tool_uses as usize;
+            self.spawns += rec.spawns as usize;
+            self.failures += rec.failures as usize;
+        }
+    }
+}
+
+/// The `cwd` of the first envelope-bearing line, parsed properly.
+///
+/// Scans records (free) for the first line that can carry an envelope and
+/// parses just that one. Stops at the first line that yields a cwd; a
+/// transcript whose early lines predate the field falls through to `None`
+/// rather than scanning the whole file, since the field's absence is a
+/// property of the session's Claude Code version, not of the line.
+fn first_cwd(idx: &Index, bytes: &[u8]) -> Option<String> {
+    let rec = idx.recs.iter().find(|r| r.kind.has_envelope())?;
+    let entry = std::str::from_utf8(rec.slice(bytes))
+        .ok()
+        .and_then(transcript::parse_line)?;
+    match entry {
+        Entry::User(e) => e.envelope.cwd,
+        Entry::Assistant(e) => e.envelope.cwd,
+        Entry::System(e) => e.envelope.cwd,
+        Entry::Attachment(e) => e.envelope.cwd,
+        _ => None,
+    }
+}
+
+/// Build the rail row for a discovered session.
+///
+/// The project label prefers the recorded `cwd`'s last component and falls back
+/// to the (lossy) project-directory name only when the transcript has none.
+pub fn rail_row(session: &SessionRef, summary: &Summary) -> RailRow {
+    let project = summary
+        .cwd
+        .as_deref()
+        .map(Path::new)
+        .and_then(Path::file_name)
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| {
+            let dir = session
+                .project_dir
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            project_label(&dir)
+        });
+
+    RailRow {
+        session_id: session.session_id.clone(),
+        project,
+        main_path: session.main_path.clone(),
+        // `Summary::agents` counts distinct sidecar `agentId`s; the main agent
+        // has none, and it is always there.
+        agents: summary.agents + 1,
+        tool_calls: summary.tool_calls,
+        failures: summary.failures,
+        prompts: summary.prompts,
+        last_activity: summary.last_activity,
+        sidecar_active: session.touched_by_sidecar,
+    }
+}
+
+/// Discover and summarize every session touched within `window`, as rail rows.
+pub fn sweep(window: std::time::Duration) -> Vec<RailRow> {
+    discover_recent(window)
+        .iter()
+        .map(|s| rail_row(s, &Summary::of(s)))
+        .collect()
+}
+
+/// How far back the rail looks. A day: long enough that "what was I running
+/// this morning?" is answerable, short enough that the sweep stays a stat sweep
+/// over a handful of candidates rather than the whole history.
+pub const SWEEP_WINDOW: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
+
+/// How often the rail re-sweeps. Matches the tailer's newer-session scan
+/// cadence (`SWITCH_SCAN_EVERY`, ~2 s): the rail and the auto-switch are
+/// answering the same question about the same directories, so they should not
+/// disagree for longer than one of them takes to notice.
+pub const SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// A scratch project tree: `<root>/<project>/<uuid>.jsonl` plus sidecars.
+    struct Fixture {
+        root: PathBuf,
+    }
+
+    impl Fixture {
+        fn new(tag: &str) -> Fixture {
+            let root = std::env::temp_dir().join(format!(
+                "zoetrope-sessions-{}-{}-{tag}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0)
+            ));
+            std::fs::create_dir_all(&root).unwrap();
+            Fixture { root }
+        }
+
+        /// Write a main transcript for `uuid` under project `project`.
+        fn session(&self, project: &str, uuid: &str, lines: &str) -> PathBuf {
+            let dir = self.root.join(project);
+            std::fs::create_dir_all(&dir).unwrap();
+            let path = dir.join(format!("{uuid}.jsonl"));
+            std::fs::write(&path, lines).unwrap();
+            path
+        }
+
+        /// Write a direct-subagent sidecar under a session.
+        fn sidecar(&self, main: &Path, agent_id: &str, lines: &str) -> PathBuf {
+            let subs = transcript::subagents_dir(main).unwrap();
+            std::fs::create_dir_all(&subs).unwrap();
+            let path = subs.join(format!("agent-{agent_id}.jsonl"));
+            std::fs::write(&path, lines).unwrap();
+            path
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn user_line(uuid: &str, ts: &str, agent: Option<&str>) -> String {
+        let agent = agent.map_or(String::new(), |a| format!(",\"agentId\":\"{a}\""));
+        format!(
+            "{{\"type\":\"user\",\"uuid\":\"{uuid}\",\"parentUuid\":null,\
+             \"timestamp\":\"{ts}\",\"origin\":{{\"kind\":\"human\"}}{agent},\
+             \"message\":{{\"role\":\"user\",\"content\":\"hi\"}}}}\n"
+        )
+    }
+
+    /// Set a file's mtime by rewriting it — portable, and enough to order two
+    /// files in time without reaching for a platform-specific utimes call.
+    fn touch(path: &Path) {
+        let content = std::fs::read(path).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn discovers_sessions_across_every_project() {
+        let f = Fixture::new("across");
+        f.session(
+            "proj-a",
+            "aaaaaaaa-1111-2222-3333-444444444444",
+            &user_line("u1", "2026-06-01T09:00:00.000Z", None),
+        );
+        f.session(
+            "proj-b",
+            "bbbbbbbb-1111-2222-3333-444444444444",
+            &user_line("u1", "2026-06-01T09:00:00.000Z", None),
+        );
+        // A second session in the same project must not shadow the first: the
+        // single-session path takes only the newest, this one takes both.
+        f.session(
+            "proj-a",
+            "cccccccc-1111-2222-3333-444444444444",
+            &user_line("u1", "2026-06-01T09:00:00.000Z", None),
+        );
+
+        let found = discover(&f.root, SystemTime::UNIX_EPOCH);
+        assert_eq!(found.len(), 3, "every session in every project");
+    }
+
+    #[test]
+    fn ignores_non_transcript_files() {
+        let f = Fixture::new("filter");
+        let dir = f.root.join("proj");
+        std::fs::create_dir_all(&dir).unwrap();
+        // The sidecars that live next to real transcripts, none of which is one.
+        for name in [
+            "skill-injections.jsonl",
+            "sessions-index.json",
+            "notes.txt",
+            "not-a-uuid.jsonl",
+        ] {
+            std::fs::write(dir.join(name), "{}\n").unwrap();
+        }
+        f.session("proj", "dddddddd-1111-2222-3333-444444444444", "{}\n");
+
+        let found = discover(&f.root, SystemTime::UNIX_EPOCH);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].session_id, "dddddddd-1111-2222-3333-444444444444");
+    }
+
+    #[test]
+    fn a_session_active_only_in_a_subagent_is_still_found() {
+        // The case the main-file mtime filter gets wrong: the main agent is
+        // blocked on a subagent, so only the sidecar is being written.
+        let f = Fixture::new("sidecar-activity");
+        let main = f.session(
+            "proj",
+            "eeeeeeee-1111-2222-3333-444444444444",
+            &user_line("u1", "2026-06-01T09:00:00.000Z", None),
+        );
+        let main_mtime = std::fs::metadata(&main).unwrap().modified().unwrap();
+
+        let sidecar = f.sidecar(
+            &main,
+            "a1000000000000001",
+            &user_line("s1", "2026-06-01T09:05:00.000Z", Some("a1000000000000001")),
+        );
+        touch(&sidecar);
+        let sidecar_mtime = std::fs::metadata(&sidecar).unwrap().modified().unwrap();
+
+        let found = discover(&f.root, SystemTime::UNIX_EPOCH);
+        assert_eq!(found.len(), 1);
+        let s = &found[0];
+        assert_eq!(s.sidecar_count, 1);
+        assert!(
+            s.last_touched >= sidecar_mtime.min(main_mtime),
+            "activity is the newest across all files"
+        );
+        // Filtering from just after the main file's mtime must still find it.
+        let since = main_mtime + Duration::from_nanos(1);
+        if sidecar_mtime > main_mtime {
+            assert_eq!(
+                discover(&f.root, since).len(),
+                1,
+                "sidecar activity keeps the session in the window"
+            );
+            assert!(s.touched_by_sidecar);
+        }
+    }
+
+    #[test]
+    fn the_window_excludes_old_sessions() {
+        let f = Fixture::new("window");
+        f.session("proj", "ffffffff-1111-2222-3333-444444444444", "{}\n");
+        let future = SystemTime::now() + Duration::from_secs(3600);
+        assert!(discover(&f.root, future).is_empty());
+        assert_eq!(discover(&f.root, SystemTime::UNIX_EPOCH).len(), 1);
+    }
+
+    #[test]
+    fn summary_counts_across_main_and_sidecars() {
+        let f = Fixture::new("summary");
+        let main = f.session(
+            "proj",
+            "12345678-1111-2222-3333-444444444444",
+            &format!(
+                "{}{}",
+                user_line("u1", "2026-06-01T09:00:00.000Z", None),
+                // An assistant turn with two tool calls, one of them a spawn.
+                "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":\"u1\",\
+                 \"timestamp\":\"2026-06-01T09:00:10.000Z\",\"message\":{\"role\":\"assistant\",\
+                 \"content\":[{\"type\":\"tool_use\",\"id\":\"t1\",\"name\":\"Read\",\"input\":{}},\
+                 {\"type\":\"tool_use\",\"id\":\"t2\",\"name\":\"Agent\",\"input\":{}}]}}\n"
+            ),
+        );
+        f.sidecar(
+            &main,
+            "a1000000000000001",
+            &user_line("s1", "2026-06-01T09:01:00.000Z", Some("a1000000000000001")),
+        );
+
+        let found = discover(&f.root, SystemTime::UNIX_EPOCH);
+        let s = Summary::of(&found[0]);
+
+        assert_eq!(s.files, 2, "main + sidecar");
+        assert_eq!(s.lines, 3);
+        assert_eq!(s.tool_calls, 2);
+        assert_eq!(s.spawns, 1);
+        assert_eq!(s.agents, 1, "the sidecar's agentId");
+        assert_eq!(
+            s.prompts, 2,
+            "one in the main transcript, one in the sidecar"
+        );
+        assert_eq!(s.ambiguous_prompts, 0);
+        assert_eq!(
+            s.first_activity
+                .unwrap()
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            "2026-06-01T09:00:00.000Z"
+        );
+        assert_eq!(
+            s.last_activity
+                .unwrap()
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            "2026-06-01T09:01:00.000Z",
+            "the newest activity is the subagent's"
+        );
+    }
+}

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -100,23 +100,36 @@ fn sidecars(main_path: &Path) -> Option<Sidecars> {
     if !subs.is_dir() {
         return None;
     }
+    sidecars_in(scan_sidecar_paths(&subs))
+}
 
-    let mut paths: Vec<PathBuf> = transcript::scan_subagent_files(&subs, None)
+/// Walk `subs` for the files that belong to a session.
+///
+/// Which files count is [`transcript::scan_subagent_files`]'s rule — the
+/// `agent-<id>.jsonl` pairs plus each workflow's journal — not "every `.jsonl`
+/// here", so the stats describe exactly the files that get indexed.
+fn scan_sidecar_paths(subs: &Path) -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = transcript::scan_subagent_files(subs, None)
         .into_iter()
         .map(|f| f.transcript)
         .collect();
-    for wf_id in transcript::scan_workflow_ids(&subs) {
-        let dir = transcript::workflow_dir(&subs, &wf_id);
+    for wf_id in transcript::scan_workflow_ids(subs) {
+        let dir = transcript::workflow_dir(subs, &wf_id);
         paths.extend(
             transcript::scan_subagent_files(&dir, Some(&wf_id))
                 .into_iter()
                 .map(|f| f.transcript),
         );
-        let journal = transcript::workflow_journal(&subs, &wf_id);
+        let journal = transcript::workflow_journal(subs, &wf_id);
         if journal.is_file() {
             paths.push(journal);
         }
     }
+    paths
+}
+
+/// Stat a known set of sidecar paths into the aggregate the sweep needs.
+fn sidecars_in(paths: Vec<PathBuf>) -> Option<Sidecars> {
     if paths.is_empty() {
         return None;
     }
@@ -140,8 +153,18 @@ fn sidecars(main_path: &Path) -> Option<Sidecars> {
     })
 }
 
-/// Stat one main transcript into a [`SessionRef`].
+/// Stat one main transcript into a [`SessionRef`], walking its sidecars.
 fn session_ref(project_dir: &Path, main_path: PathBuf) -> Option<SessionRef> {
+    let found = sidecars(&main_path);
+    session_ref_with(project_dir, main_path, found)
+}
+
+/// [`session_ref`] with the sidecar stats already in hand.
+fn session_ref_with(
+    project_dir: &Path,
+    main_path: PathBuf,
+    found: Option<Sidecars>,
+) -> Option<SessionRef> {
     let meta = std::fs::metadata(&main_path).ok()?;
     if !meta.is_file() {
         return None;
@@ -152,7 +175,7 @@ fn session_ref(project_dir: &Path, main_path: PathBuf) -> Option<SessionRef> {
     let mut sidecar_paths = Vec::new();
     let mut touched_by_sidecar = false;
 
-    if let Some(found) = sidecars(&main_path) {
+    if let Some(found) = found {
         bytes += found.bytes;
         sidecar_paths = found.paths;
         if found.newest > last_touched {
@@ -195,10 +218,11 @@ pub fn discover(root: &Path, since: SystemTime) -> Vec<SessionRef> {
             if !transcript::is_session_file(&path) {
                 continue;
             }
-            // Stat the main file first and skip the sidecar sweep for anything
-            // far outside the window — but only when the main file itself is
-            // old AND has no sidecar directory to check, which `session_ref`
-            // resolves. The cheap rejection is the extension/uuid filter above.
+            // Every session is stat-walked, in-window or not: a session's
+            // activity can be entirely in a sidecar (see the module docs), and
+            // that is invisible without statting them. The cheap rejection is
+            // the extension/uuid filter above; [`Sweeper`] is what stops a
+            // repeating sweep from re-walking the tree it already knows.
             if let Some(s) = session_ref(&dir, path)
                 && s.last_touched >= since
             {
@@ -373,11 +397,157 @@ pub fn rail_row(session: &SessionRef, summary: &Summary) -> RailRow {
 }
 
 /// Discover and summarize every session touched within `window`, as rail rows.
+///
+/// One-shot: every sweep pays the full walk and the full index fold. The
+/// supervisor repeats this every [`SWEEP_INTERVAL`] and should hold a
+/// [`Sweeper`] instead, which reuses what has not changed.
 pub fn sweep(window: std::time::Duration) -> Vec<RailRow> {
-    discover_recent(window)
-        .iter()
-        .map(|s| rail_row(s, &Summary::of(s)))
-        .collect()
+    Sweeper::default().rows(window)
+}
+
+/// What the previous sweep learned about one session.
+struct Cached {
+    /// Sidecar paths, and the subagents-dir mtime they were scanned under.
+    /// Re-walking the tree is only needed when that mtime moves; the files
+    /// themselves are re-stated every sweep, since an append shows up nowhere
+    /// else.
+    dir_mtime: Option<SystemTime>,
+    sidecars: Vec<PathBuf>,
+    /// The `(last_touched, bytes)` the summary was folded under. Any append to
+    /// any file of the session moves at least one of the two.
+    folded: (SystemTime, u64),
+    summary: Summary,
+}
+
+/// A repeating discovery sweep that remembers the last one.
+///
+/// The sweep runs every [`SWEEP_INTERVAL`] for as long as the program is up,
+/// over every session touched in the last [`SWEEP_WINDOW`], while almost
+/// nothing changes between two ticks. Recomputing everything each time meant
+/// re-walking every session's sidecar tree and re-folding every session's
+/// skeleton index — decoding, and on any growth rewriting, the whole on-disk
+/// cache — a few times a minute, for sessions that had not been written to in
+/// hours.
+///
+/// So each tick keeps what it can prove is unchanged:
+///
+/// * the sidecar file LIST, while the subagents directory's mtime is unmoved;
+/// * the folded [`Summary`], while the session's newest mtime and total size
+///   are both unmoved.
+///
+/// What is never skipped is the stat of each file — freshness is exactly what
+/// a sweep exists to learn, and an append to a sidecar changes nothing else.
+#[derive(Default)]
+pub struct Sweeper {
+    seen: std::collections::HashMap<PathBuf, Cached>,
+}
+
+impl Sweeper {
+    /// Discover and summarize every session touched within `window`, reusing
+    /// whatever the previous sweep established is still current.
+    pub fn rows(&mut self, window: std::time::Duration) -> Vec<RailRow> {
+        let Some(root) = transcript::claude_projects_root() else {
+            return Vec::new();
+        };
+        let since = SystemTime::now()
+            .checked_sub(window)
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        self.rows_in(&root, since)
+    }
+
+    /// [`rows`](Self::rows) against an explicit root and cutoff.
+    fn rows_in(&mut self, root: &Path, since: SystemTime) -> Vec<RailRow> {
+        let found = self.discover(root, since);
+        let mut rows = Vec::with_capacity(found.len());
+        let mut live: std::collections::HashSet<PathBuf> =
+            std::collections::HashSet::with_capacity(found.len());
+
+        for session in &found {
+            let key = (session.last_touched, session.bytes);
+            let entry = self.seen.get(&session.main_path);
+            let summary = match entry {
+                Some(c) if c.folded == key => c.summary.clone(),
+                _ => Summary::of(session),
+            };
+            rows.push(rail_row(session, &summary));
+            if let Some(c) = self.seen.get_mut(&session.main_path) {
+                c.folded = key;
+                c.summary = summary;
+            }
+            live.insert(session.main_path.clone());
+        }
+
+        // Sessions that fell out of the window keep no state — the cache
+        // tracks the sweep, not the history.
+        self.seen.retain(|path, _| live.contains(path));
+        rows
+    }
+
+    /// [`discover`], but taking each session's sidecar list from the last sweep
+    /// while the subagents directory is unchanged.
+    fn discover(&mut self, root: &Path, since: SystemTime) -> Vec<SessionRef> {
+        let Ok(projects) = std::fs::read_dir(root) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        for project in projects.flatten() {
+            let dir = project.path();
+            if !dir.is_dir() {
+                continue;
+            }
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !transcript::is_session_file(&path) {
+                    continue;
+                }
+                if let Some(s) = self.session_ref(&dir, path)
+                    && s.last_touched >= since
+                {
+                    out.push(s);
+                }
+            }
+        }
+        out.sort_by_key(|s| std::cmp::Reverse(s.last_touched));
+        out
+    }
+
+    fn session_ref(&mut self, project_dir: &Path, main_path: PathBuf) -> Option<SessionRef> {
+        let subs = transcript::subagents_dir(&main_path);
+        let dir_mtime = subs
+            .as_ref()
+            .and_then(|d| std::fs::metadata(d).ok())
+            .filter(|m| m.is_dir())
+            .and_then(|m| m.modified().ok());
+
+        let cached = self.seen.get(&main_path);
+        let found = match (&subs, cached) {
+            // The directory has not gained or lost a file since the last
+            // sweep, so its list still describes it — stat those paths.
+            (Some(_), Some(c)) if c.dir_mtime == dir_mtime && dir_mtime.is_some() => {
+                sidecars_in(c.sidecars.clone())
+            }
+            _ => sidecars(&main_path),
+        };
+        let session = session_ref_with(project_dir, main_path, found)?;
+
+        let entry = self
+            .seen
+            .entry(session.main_path.clone())
+            .or_insert(Cached {
+                dir_mtime,
+                sidecars: Vec::new(),
+                folded: (SystemTime::UNIX_EPOCH, u64::MAX),
+                summary: Summary::default(),
+            });
+        entry.dir_mtime = dir_mtime;
+        if entry.sidecars != session.sidecars {
+            entry.sidecars = session.sidecars.clone();
+        }
+        Some(session)
+    }
 }
 
 /// How far back the rail looks. A day: long enough that "what was I running
@@ -385,10 +555,11 @@ pub fn sweep(window: std::time::Duration) -> Vec<RailRow> {
 /// over a handful of candidates rather than the whole history.
 pub const SWEEP_WINDOW: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
 
-/// How often the rail re-sweeps. Matches the tailer's newer-session scan
-/// cadence (`SWITCH_SCAN_EVERY`, ~2 s): the rail and the auto-switch are
-/// answering the same question about the same directories, so they should not
-/// disagree for longer than one of them takes to notice.
+/// How often the rail re-sweeps. Discovery is the ONLY thing that notices a
+/// session appearing or going quiet — the tailer never re-targets itself — so
+/// this interval is the whole latency between a session starting and the user
+/// seeing it. Two seconds keeps that imperceptible; [`Sweeper`] is what keeps
+/// repeating it cheap.
 pub const SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
 
 #[cfg(test)]
@@ -540,6 +711,54 @@ mod tests {
             );
             assert!(s.touched_by_sidecar);
         }
+    }
+
+    /// The sweep repeats every couple of seconds forever, so it caches — and a
+    /// cache that misses new activity would be worse than the cost it saves.
+    /// Growth must still show up on the very next tick, whether it lands in the
+    /// main transcript or in a sidecar that did not exist before.
+    #[test]
+    fn a_repeated_sweep_still_sees_new_activity() {
+        let f = Fixture::new("sweeper");
+        let main = f.session(
+            "proj",
+            "abcdabcd-1111-2222-3333-444444444444",
+            &user_line("u1", "2026-06-01T09:00:00.000Z", None),
+        );
+
+        let mut sweeper = Sweeper::default();
+        let first = sweeper.rows_in(&f.root, SystemTime::UNIX_EPOCH);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].agents, 1, "main only");
+
+        // A repeat tick over an untouched tree reports the same thing.
+        let again = sweeper.rows_in(&f.root, SystemTime::UNIX_EPOCH);
+        assert_eq!(again[0].agents, 1);
+        assert_eq!(again[0].last_activity, first[0].last_activity);
+
+        // A brand-new sidecar: the file list itself is out of date.
+        f.sidecar(
+            &main,
+            "a1000000000000001",
+            &user_line("s1", "2026-06-01T09:05:00.000Z", Some("a1000000000000001")),
+        );
+        let grown = sweeper.rows_in(&f.root, SystemTime::UNIX_EPOCH);
+        assert_eq!(grown[0].agents, 2, "a new sidecar must be picked up");
+        assert!(
+            grown[0].last_activity > first[0].last_activity,
+            "the sidecar's newer activity must reach the row"
+        );
+
+        // An append to a file that already existed moves neither the session's
+        // file list nor its directory mtimes — only the file's own.
+        let mut lines = std::fs::read_to_string(&main).unwrap();
+        lines.push_str(&user_line("u2", "2026-06-01T10:00:00.000Z", None));
+        std::fs::write(&main, lines).unwrap();
+        let appended = sweeper.rows_in(&f.root, SystemTime::UNIX_EPOCH);
+        assert!(
+            appended[0].last_activity > grown[0].last_activity,
+            "an append to an existing file must not be cached away"
+        );
     }
 
     #[test]

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -54,82 +54,90 @@ pub struct SessionRef {
     /// Total bytes across the main transcript and every sidecar.
     pub bytes: u64,
     /// Sidecar transcripts found (direct subagents, workflow subagents,
-    /// journals).
-    pub sidecar_count: usize,
+    /// journals), captured by the same walk that produced the stats above.
+    pub sidecars: Vec<PathBuf>,
 }
 
 impl SessionRef {
     /// Every transcript file belonging to this session, main first.
     ///
-    /// Re-scans the sidecar directories, so a file created since [`discover`]
-    /// ran is picked up. Journals are included: a workflow's completion ledger
-    /// is session activity like any other.
+    /// The sidecars come from the sweep that discovered the session rather than
+    /// a fresh directory walk — indexing them would otherwise re-enumerate the
+    /// very directories discovery just read, twice per session per sweep. A
+    /// sidecar created since then is picked up by the next sweep.
     pub fn files(&self) -> Vec<PathBuf> {
-        let mut out = vec![self.main_path.clone()];
-        let Some(subs) = transcript::subagents_dir(&self.main_path) else {
-            return out;
-        };
-        out.extend(
-            transcript::scan_subagent_files(&subs, None)
-                .into_iter()
-                .map(|f| f.transcript),
-        );
-        for wf_id in transcript::scan_workflow_ids(&subs) {
-            let dir = transcript::workflow_dir(&subs, &wf_id);
-            out.extend(
-                transcript::scan_subagent_files(&dir, Some(&wf_id))
-                    .into_iter()
-                    .map(|f| f.transcript),
-            );
-            let journal = transcript::workflow_journal(&subs, &wf_id);
-            if journal.is_file() {
-                out.push(journal);
-            }
-        }
+        let mut out = Vec::with_capacity(self.sidecars.len() + 1);
+        out.push(self.main_path.clone());
+        out.extend(self.sidecars.iter().cloned());
         out
+    }
+
+    /// Sidecar transcripts found for this session.
+    pub fn sidecar_count(&self) -> usize {
+        self.sidecars.len()
     }
 }
 
-/// Newest mtime and total size across a session's sidecars, plus how many there
-/// are. Returns `None` when the session has no `subagents/` directory at all.
-fn sidecar_stats(main_path: &Path) -> Option<(SystemTime, u64, usize)> {
+/// Everything one walk of a session's sidecar tree yields.
+struct Sidecars {
+    paths: Vec<PathBuf>,
+    newest: SystemTime,
+    bytes: u64,
+}
+
+/// Walk a session's sidecar tree once, collecting the transcripts AND their
+/// stats together.
+///
+/// One walk rather than two: discovery needs the newest mtime and total size,
+/// summarizing needs the file list, and re-deriving one from a second
+/// `read_dir` of the same directories is the sweep's largest avoidable cost.
+///
+/// Which files count is [`transcript::scan_subagent_files`]'s rule — the
+/// `agent-<id>.jsonl` pairs plus each workflow's journal — not "every `.jsonl`
+/// here", so the stats describe exactly the files that get indexed.
+fn sidecars(main_path: &Path) -> Option<Sidecars> {
     let subs = transcript::subagents_dir(main_path)?;
     if !subs.is_dir() {
         return None;
     }
-    let mut newest = SystemTime::UNIX_EPOCH;
-    let mut bytes = 0u64;
-    let mut count = 0usize;
 
-    // A closure rather than recursion: the sidecar layout is exactly two levels
-    // (`subagents/` and `subagents/workflows/<id>/`), so a general directory
-    // walk would be scope the format does not have.
-    let mut visit = |dir: &Path| {
-        let Ok(read) = std::fs::read_dir(dir) else {
-            return;
-        };
-        for entry in read.flatten() {
-            let Ok(meta) = entry.metadata() else { continue };
-            if !meta.is_file() {
-                continue;
-            }
-            if entry.path().extension().and_then(|e| e.to_str()) != Some("jsonl") {
-                continue;
-            }
-            count += 1;
-            bytes += meta.len();
-            if let Ok(m) = meta.modified() {
-                newest = newest.max(m);
-            }
-        }
-    };
-
-    visit(&subs);
+    let mut paths: Vec<PathBuf> = transcript::scan_subagent_files(&subs, None)
+        .into_iter()
+        .map(|f| f.transcript)
+        .collect();
     for wf_id in transcript::scan_workflow_ids(&subs) {
-        visit(&transcript::workflow_dir(&subs, &wf_id));
+        let dir = transcript::workflow_dir(&subs, &wf_id);
+        paths.extend(
+            transcript::scan_subagent_files(&dir, Some(&wf_id))
+                .into_iter()
+                .map(|f| f.transcript),
+        );
+        let journal = transcript::workflow_journal(&subs, &wf_id);
+        if journal.is_file() {
+            paths.push(journal);
+        }
+    }
+    if paths.is_empty() {
+        return None;
     }
 
-    (count > 0).then_some((newest, bytes, count))
+    let mut newest = SystemTime::UNIX_EPOCH;
+    let mut bytes = 0u64;
+    for path in &paths {
+        let Ok(meta) = std::fs::metadata(path) else {
+            continue;
+        };
+        bytes += meta.len();
+        if let Ok(m) = meta.modified() {
+            newest = newest.max(m);
+        }
+    }
+
+    Some(Sidecars {
+        paths,
+        newest,
+        bytes,
+    })
 }
 
 /// Stat one main transcript into a [`SessionRef`].
@@ -141,14 +149,14 @@ fn session_ref(project_dir: &Path, main_path: PathBuf) -> Option<SessionRef> {
     let main_mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
     let mut last_touched = main_mtime;
     let mut bytes = meta.len();
-    let mut sidecar_count = 0;
+    let mut sidecar_paths = Vec::new();
     let mut touched_by_sidecar = false;
 
-    if let Some((sidecar_mtime, sidecar_bytes, count)) = sidecar_stats(&main_path) {
-        bytes += sidecar_bytes;
-        sidecar_count = count;
-        if sidecar_mtime > last_touched {
-            last_touched = sidecar_mtime;
+    if let Some(found) = sidecars(&main_path) {
+        bytes += found.bytes;
+        sidecar_paths = found.paths;
+        if found.newest > last_touched {
+            last_touched = found.newest;
             touched_by_sidecar = true;
         }
     }
@@ -160,7 +168,7 @@ fn session_ref(project_dir: &Path, main_path: PathBuf) -> Option<SessionRef> {
         last_touched,
         touched_by_sidecar,
         bytes,
-        sidecar_count,
+        sidecars: sidecar_paths,
     })
 }
 
@@ -358,9 +366,7 @@ pub fn rail_row(session: &SessionRef, summary: &Summary) -> RailRow {
         // `Summary::agents` counts distinct sidecar `agentId`s; the main agent
         // has none, and it is always there.
         agents: summary.agents + 1,
-        tool_calls: summary.tool_calls,
         failures: summary.failures,
-        prompts: summary.prompts,
         last_activity: summary.last_activity,
         sidecar_active: session.touched_by_sidecar,
     }
@@ -519,7 +525,7 @@ mod tests {
         let found = discover(&f.root, SystemTime::UNIX_EPOCH);
         assert_eq!(found.len(), 1);
         let s = &found[0];
-        assert_eq!(s.sidecar_count, 1);
+        assert_eq!(s.sidecar_count(), 1);
         assert!(
             s.last_touched >= sidecar_mtime.min(main_mtime),
             "activity is the newest across all files"

--- a/src/state/graph.rs
+++ b/src/state/graph.rs
@@ -277,25 +277,33 @@ fn edge_id(child: &str) -> String {
     format!("e-{child}")
 }
 
+/// Remove several of a session's agents in ONE pass.
+///
+/// Bulk, not a loop of single removals: `Flow::remove_node` costs O(nodes plus
+/// edges) every time — it shifts every lookup index and rebuilds the edge
+/// lookup per call — so removing k of them is quadratic. `retain_nodes` makes a
+/// single pass over each vec and drops the connected edges itself.
+pub fn remove_agents(flow: &mut AgentFlow, session: &str, agents: &[String]) {
+    if agents.is_empty() {
+        return;
+    }
+    let doomed: std::collections::HashSet<String> =
+        agents.iter().map(|a| node_id(session, a)).collect();
+    flow.retain_nodes(|n| !doomed.contains(&n.id));
+}
+
 /// Remove every node and edge belonging to `session`.
 ///
 /// Used when a session stops being watched: its subtree leaves the canvas
 /// without disturbing the others, which a whole-flow rebuild would (it drops
 /// every node position the user arranged).
 pub fn remove_session(flow: &mut AgentFlow, session: &str) -> bool {
-    let doomed: Vec<String> = flow
-        .nodes()
-        .filter(|n| split_node_id(&n.id).is_some_and(|(s, _)| s == session))
-        .map(|n| n.id.clone())
-        .collect();
-    let removed = !doomed.is_empty();
-    for id in doomed {
-        // Edges are keyed off the child node id, so removing the node's edge by
-        // the same derivation keeps the two in step.
-        flow.remove_edge(&edge_id(&id));
-        flow.remove_node(&id);
+    let belongs = |id: &str| split_node_id(id).is_some_and(|(s, _)| s == session);
+    let present = flow.nodes().any(|n| belongs(&n.id));
+    if present {
+        flow.retain_nodes(|n| !belongs(&n.id));
     }
-    removed
+    present
 }
 
 /// Apply the Sugiyama vertical layout to `flow`.
@@ -533,17 +541,6 @@ fn pack(flow: &mut AgentFlow, boxes: &[SessionBox]) {
         })
         .collect();
     flow.set_node_positions(moved.iter().map(|(id, pos)| (id, *pos)));
-}
-
-/// Restore saved positions onto whichever nodes still exist (used after a
-/// backward-seek rebuild to carry the user's manual arrangement across — and to
-/// avoid a layout jump, since a rebuilt subset would otherwise re-place from
-/// scratch). Nodes absent from `positions` keep their fresh local placement.
-pub fn restore_positions(
-    flow: &mut AgentFlow,
-    positions: &std::collections::HashMap<String, (f64, f64)>,
-) {
-    flow.set_node_positions(positions.iter().map(|(id, &pos)| (id, pos)));
 }
 
 #[cfg(test)]

--- a/src/state/graph.rs
+++ b/src/state/graph.rs
@@ -28,6 +28,14 @@ pub const ID_SEP: char = '/';
 
 /// The `Flow` node id for `agent` within `session`.
 pub fn node_id(session: &str, agent: &str) -> String {
+    // The round trip through `split_node_id` relies on neither half containing
+    // the separator. That holds for every id the format produces, but it was
+    // only ever stated in a comment — a differently-sourced id would corrupt
+    // the parse silently rather than fail here.
+    debug_assert!(
+        !session.contains(ID_SEP) && !agent.contains(ID_SEP),
+        "node id parts must not contain {ID_SEP:?}: {session} / {agent}"
+    );
     format!("{session}{ID_SEP}{agent}")
 }
 
@@ -444,7 +452,10 @@ pub fn repack_if_overlapping(flow: &mut AgentFlow) -> bool {
     if boxes.len() < 2 || !sessions_overlap(&boxes) {
         return false;
     }
-    pack_sessions(flow);
+    // Hand the measurements on rather than letting `pack_sessions` re-take
+    // them: this runs after every structural change, for every session, and
+    // measuring walks every node on the canvas.
+    pack(flow, &boxes);
     true
 }
 
@@ -473,15 +484,22 @@ pub fn pack_sessions(flow: &mut AgentFlow) {
     if boxes.len() < 2 {
         return;
     }
+    pack(flow, &boxes);
+}
 
+/// Place already-measured session boxes and move their nodes to match.
+fn pack(flow: &mut AgentFlow, boxes: &[SessionBox]) {
     // Sessions are few (the monitor fleet is capped), so trying every row count
     // is cheaper than reasoning about which one is best.
+    if boxes.len() < 2 {
+        return;
+    }
     let total_width: f64 = boxes.iter().map(|b| b.width + SESSION_GUTTER).sum();
     let widest = boxes.iter().fold(0.0f64, |m, b| m.max(b.width));
     let best = (1..=boxes.len())
         .map(|rows| {
             let target = (total_width / rows as f64).max(widest);
-            let (placed, w, h) = shelf_pack(&boxes, target);
+            let (placed, w, h) = shelf_pack(boxes, target);
             // Compare SCREEN shape, not world-unit shape.
             let aspect = if h > 0.0 {
                 w / (h * CELL_ASPECT)

--- a/src/state/graph.rs
+++ b/src/state/graph.rs
@@ -296,7 +296,7 @@ pub fn remove_session(flow: &mut AgentFlow, session: &str) -> bool {
 /// the per-agent diffing in [`sync`].
 pub fn relayout(flow: &mut AgentFlow) {
     flow.apply_layout(Sugiyama::vertical());
-    spread_sessions(flow);
+    pack_sessions(flow);
 }
 
 /// Where a newly-appearing session root goes: clear of everything on the
@@ -315,64 +315,203 @@ fn next_root_x(flow: &AgentFlow) -> f64 {
 /// look like one tree with an odd branch.
 const SESSION_GUTTER: f64 = MAIN_NODE_DIMS.0;
 
-/// Lay each session's tree out beside the previous one.
+/// Vertical gap between two rows of sessions.
 ///
-/// **Required after every Sugiyama pass.** rust-sugiyama lays out each
-/// weakly-connected component in its own coordinate space, and rataflow applies
-/// each component's coordinates verbatim — it iterates `for (result, _, _)`,
-/// discarding exactly the per-component width and height that would let it
-/// offset them. With one session that is invisible (one component). With
-/// several it stacks every session's tree at the origin, overlapping.
+/// Smaller in world units than [`SESSION_GUTTER`] on purpose: a terminal cell
+/// is about twice as tall as it is wide, so a vertical gap costs roughly twice
+/// the apparent space of a horizontal one the same size. One card height reads
+/// on screen about as wide as the horizontal gutter does.
+const SESSION_ROW_GUTTER: f64 = MAIN_NODE_DIMS.1;
+
+/// How much taller than wide a terminal cell renders.
 ///
-/// Sessions keep their first-seen order (the flow's node order), so a session
-/// appearing does not reshuffle the ones already on screen; it appends to the
-/// right. Vertical positions are left alone: every root is rank 0, so leaving
-/// `y` as Sugiyama produced it is what keeps the roots on one line.
-fn spread_sessions(flow: &mut AgentFlow) {
-    // Per session, in first-seen order: its node ids and horizontal extent.
+/// World units map 1:1 to cells, so a 30x7 card takes 30 columns and 7 rows —
+/// but those rows are about twice as tall as the columns are wide. A layout
+/// that reasons about shape has to convert, or it will "square up" an
+/// arrangement that then renders twice as tall as intended.
+const CELL_ASPECT: f64 = 2.0;
+
+/// Width-to-height ratio the packer aims the whole arrangement at, in SCREEN
+/// proportions (i.e. after [`CELL_ASPECT`]). Terminals are wide, so this is
+/// wider than square.
+const TARGET_ASPECT: f64 = 2.0;
+
+/// One session's extent on the canvas.
+struct SessionBox {
+    session: String,
+    left: f64,
+    top: f64,
+    width: f64,
+    height: f64,
+}
+
+/// Measure every session's bounding box, in first-seen (flow node) order.
+fn session_boxes(flow: &AgentFlow) -> Vec<SessionBox> {
     let mut order: Vec<String> = Vec::new();
-    let mut extent: std::collections::HashMap<String, (f64, f64)> =
+    let mut bounds: std::collections::HashMap<String, (f64, f64, f64, f64)> =
         std::collections::HashMap::new();
 
     for node in flow.nodes() {
         let Some((session, _)) = split_node_id(&node.id) else {
             continue;
         };
-        let (left, right) = (node.position.x, node.position.x + node.width);
-        match extent.get_mut(session) {
-            Some(span) => {
-                span.0 = span.0.min(left);
-                span.1 = span.1.max(right);
+        let (l, t) = (node.position.x, node.position.y);
+        let (r, b) = (l + node.width, t + node.height);
+        match bounds.get_mut(session) {
+            Some(bb) => {
+                bb.0 = bb.0.min(l);
+                bb.1 = bb.1.min(t);
+                bb.2 = bb.2.max(r);
+                bb.3 = bb.3.max(b);
             }
             None => {
                 order.push(session.to_string());
-                extent.insert(session.to_string(), (left, right));
+                bounds.insert(session.to_string(), (l, t, r, b));
             }
         }
     }
-    if order.len() < 2 {
+
+    order
+        .into_iter()
+        .filter_map(|session| {
+            let &(l, t, r, b) = bounds.get(&session)?;
+            Some(SessionBox {
+                session,
+                left: l,
+                top: t,
+                width: r - l,
+                height: b - t,
+            })
+        })
+        .collect()
+}
+
+/// Shelf-pack `boxes` into rows no wider than `target_width`, returning each
+/// session's new top-left corner plus the overall extent.
+///
+/// First-fit in the given order and never reordering: a session keeps its place
+/// relative to those that appeared before it, so a new one cannot reshuffle
+/// what is already on screen.
+fn shelf_pack(boxes: &[SessionBox], target_width: f64) -> (Vec<(f64, f64)>, f64, f64) {
+    let mut placed = Vec::with_capacity(boxes.len());
+    let (mut cursor_x, mut row_y, mut row_height) = (0.0f64, 0.0f64, 0.0f64);
+    let (mut widest, mut total_height) = (0.0f64, 0.0f64);
+
+    for bb in boxes {
+        // Wrap when this session would overflow the row — but never wrap a row
+        // that is still empty, or a session wider than the target could never
+        // be placed at all.
+        if cursor_x > 0.0 && cursor_x + bb.width > target_width {
+            row_y += row_height + SESSION_ROW_GUTTER;
+            cursor_x = 0.0;
+            row_height = 0.0;
+        }
+        placed.push((cursor_x, row_y));
+        cursor_x += bb.width + SESSION_GUTTER;
+        row_height = row_height.max(bb.height);
+        widest = widest.max(cursor_x - SESSION_GUTTER);
+        total_height = row_y + row_height;
+    }
+
+    (placed, widest, total_height)
+}
+
+/// Whether any two sessions' bounding boxes intersect.
+fn sessions_overlap(boxes: &[SessionBox]) -> bool {
+    boxes.iter().enumerate().any(|(i, a)| {
+        boxes[i + 1..].iter().any(|b| {
+            a.left < b.left + b.width
+                && b.left < a.left + a.width
+                && a.top < b.top + b.height
+                && b.top < a.top + a.height
+        })
+    })
+}
+
+/// Repack only if sessions have grown into each other. Returns whether it did.
+///
+/// Called on every structural change, but deliberately does nothing while the
+/// canvas is tidy. A session's tree WIDENS as it spawns agents — local
+/// placement puts new nodes beside their siblings — so a session that was
+/// clear of its neighbour at layout time can grow into it, and layout is never
+/// automatic here, so nothing would separate them until the user pressed `r`.
+///
+/// Gating on actual overlap is what lets that be fixed without also undoing a
+/// session the user dragged somewhere deliberately: a drag that does not
+/// collide is left exactly where it was put.
+pub fn repack_if_overlapping(flow: &mut AgentFlow) -> bool {
+    let boxes = session_boxes(flow);
+    if boxes.len() < 2 || !sessions_overlap(&boxes) {
+        return false;
+    }
+    pack_sessions(flow);
+    true
+}
+
+/// Lay every session's tree out in shelf-packed rows.
+///
+/// **Required after anything that changes what is on the canvas.** rataflow
+/// applies each weakly-connected component's Sugiyama coordinates verbatim — it
+/// iterates `for (result, _, _)`, discarding exactly the per-component width and
+/// height that would let it offset them — so without this every session's tree
+/// stacks at the origin.
+///
+/// Rows rather than one long line, because the canvas is a screen and not a
+/// ribbon: a single row grows sideways forever and wastes the whole vertical
+/// half. The row width is picked by trying every row count and keeping whichever
+/// overall shape lands closest to [`TARGET_ASPECT`] once [`CELL_ASPECT`] is
+/// accounted for.
+///
+/// Only ever moves whole sessions. Positions WITHIN a session are left exactly
+/// as they were, so a Sugiyama pass, the incremental local placement in
+/// [`sync`], and any arrangement the user dragged all survive — which is what
+/// makes this safe to run on every structural change instead of only when the
+/// user asks for a tidy. That in turn is what stops a session that GROWS from
+/// overlapping its neighbour: it is repacked as soon as it gains a node.
+pub fn pack_sessions(flow: &mut AgentFlow) {
+    let boxes = session_boxes(flow);
+    if boxes.len() < 2 {
         return;
     }
 
-    // Shift each session so the trees sit side by side, the first one keeping
-    // the origin the single-session layout would have given it.
-    let mut cursor = extent.get(&order[0]).map_or(0.0, |e| e.0);
-    let mut shift: std::collections::HashMap<String, f64> =
-        std::collections::HashMap::with_capacity(order.len());
-    for session in &order {
-        let Some(&(left, right)) = extent.get(session) else {
-            continue;
-        };
-        shift.insert(session.clone(), cursor - left);
-        cursor += (right - left) + SESSION_GUTTER;
-    }
+    // Sessions are few (the monitor fleet is capped), so trying every row count
+    // is cheaper than reasoning about which one is best.
+    let total_width: f64 = boxes.iter().map(|b| b.width + SESSION_GUTTER).sum();
+    let widest = boxes.iter().fold(0.0f64, |m, b| m.max(b.width));
+    let best = (1..=boxes.len())
+        .map(|rows| {
+            let target = (total_width / rows as f64).max(widest);
+            let (placed, w, h) = shelf_pack(&boxes, target);
+            // Compare SCREEN shape, not world-unit shape.
+            let aspect = if h > 0.0 {
+                w / (h * CELL_ASPECT)
+            } else {
+                f64::MAX
+            };
+            ((aspect - TARGET_ASPECT).abs(), placed)
+        })
+        .min_by(|a, b| a.0.total_cmp(&b.0));
+
+    let Some((_, placed)) = best else {
+        return;
+    };
+
+    // Translate each session as a unit.
+    let shift: std::collections::HashMap<&str, (f64, f64)> = boxes
+        .iter()
+        .zip(&placed)
+        .map(|(bb, &(x, y))| (bb.session.as_str(), (x - bb.left, y - bb.top)))
+        .collect();
 
     let moved: Vec<(String, (f64, f64))> = flow
         .nodes()
         .filter_map(|node| {
             let (session, _) = split_node_id(&node.id)?;
-            let dx = shift.get(session)?;
-            Some((node.id.clone(), (node.position.x + dx, node.position.y)))
+            let &(dx, dy) = shift.get(session)?;
+            Some((
+                node.id.clone(),
+                (node.position.x + dx, node.position.y + dy),
+            ))
         })
         .collect();
     flow.set_node_positions(moved.iter().map(|(id, pos)| (id, *pos)));
@@ -494,6 +633,126 @@ mod tests {
         assert_eq!(root_y(S), root_y("s2"));
     }
 
+    /// Build `n` sessions, each with `subs` subagents, synced into one flow.
+    fn flow_with_sessions(n: usize, subs: usize) -> AgentFlow {
+        let mut flow = new_flow();
+        for i in 0..n {
+            let mut m = SessionModel::new(format!("s{i}"));
+            for k in 0..subs {
+                m.apply_meta(&format!("a{i}_{k}"), None, &meta());
+            }
+            sync(&mut flow, &m, false);
+        }
+        relayout(&mut flow);
+        flow
+    }
+
+    /// Every session's bounding box, keyed by session id.
+    fn boxes_of(flow: &AgentFlow) -> std::collections::HashMap<String, (f64, f64, f64, f64)> {
+        session_boxes(flow)
+            .into_iter()
+            .map(|b| (b.session, (b.left, b.top, b.width, b.height)))
+            .collect()
+    }
+
+    fn any_overlap(flow: &AgentFlow) -> bool {
+        sessions_overlap(&session_boxes(flow))
+    }
+
+    /// Many sessions must wrap into rows rather than growing one endless
+    /// ribbon sideways — and the rows must not overlap each other either.
+    #[test]
+    fn many_sessions_wrap_into_rows() {
+        let flow = flow_with_sessions(8, 3);
+        let boxes = session_boxes(&flow);
+        assert_eq!(boxes.len(), 8);
+        assert!(
+            !sessions_overlap(&boxes),
+            "packed sessions must not overlap"
+        );
+
+        let rows: std::collections::BTreeSet<i64> = boxes.iter().map(|b| b.top as i64).collect();
+        assert!(
+            rows.len() > 1,
+            "eight sessions should occupy more than one row, got tops {rows:?}"
+        );
+
+        // And the result should read wider than tall on screen, not the reverse.
+        let width = boxes.iter().fold(0.0f64, |m, b| m.max(b.left + b.width));
+        let height = boxes.iter().fold(0.0f64, |m, b| m.max(b.top + b.height));
+        assert!(
+            width > height * CELL_ASPECT,
+            "arrangement is taller than wide on screen: {width} x {height}"
+        );
+    }
+
+    /// Packing must be idempotent: it runs on every structural change, so a
+    /// second pass that moved anything would make the canvas drift.
+    #[test]
+    fn packing_twice_changes_nothing() {
+        let mut flow = flow_with_sessions(5, 2);
+        let before = boxes_of(&flow);
+        pack_sessions(&mut flow);
+        assert_eq!(boxes_of(&flow), before);
+        assert!(
+            !repack_if_overlapping(&mut flow),
+            "tidy canvas needs no repack"
+        );
+    }
+
+    /// The growth bug: a session that gains agents widens, and with layout
+    /// never automatic it would sit on top of its neighbour until the user
+    /// pressed `r`.
+    #[test]
+    fn a_growing_session_stops_overlapping_its_neighbour() {
+        let mut flow = new_flow();
+        let mut a = SessionModel::new("s0".into());
+        a.apply_meta("a0", None, &meta());
+        let mut b = SessionModel::new("s1".into());
+        b.apply_meta("b0", None, &meta());
+        sync(&mut flow, &a, false);
+        sync(&mut flow, &b, false);
+        relayout(&mut flow);
+        assert!(!any_overlap(&flow));
+
+        // `s0` spawns a fan of subagents. Local placement fans them sideways,
+        // straight into where `s1` sits.
+        for k in 1..8 {
+            a.apply_meta(&format!("a{k}"), None, &meta());
+        }
+        sync(&mut flow, &a, false);
+        assert!(
+            any_overlap(&flow),
+            "precondition: unchecked growth should collide"
+        );
+
+        assert!(repack_if_overlapping(&mut flow));
+        assert!(!any_overlap(&flow), "repack must separate them");
+    }
+
+    /// Repacking moves whole sessions, never rearranges one internally — so a
+    /// Sugiyama pass, local placement and a user's drag all survive it.
+    #[test]
+    fn packing_preserves_arrangement_within_a_session() {
+        let mut flow = flow_with_sessions(4, 3);
+        let relative = |flow: &AgentFlow| -> Vec<(String, f64, f64)> {
+            let boxes = boxes_of(flow);
+            let mut out: Vec<_> = flow
+                .nodes()
+                .filter_map(|n| {
+                    let (session, _) = split_node_id(&n.id)?;
+                    let &(left, top, _, _) = boxes.get(session)?;
+                    Some((n.id.clone(), n.position.x - left, n.position.y - top))
+                })
+                .collect();
+            out.sort_by(|a, b| a.0.cmp(&b.0));
+            out
+        };
+        let before = relative(&flow);
+        pack_sessions(&mut flow);
+        assert_eq!(relative(&flow), before, "intra-session offsets changed");
+    }
+
     /// A session appearing while the canvas is live must not land on top of
     /// one already there. Layout is never automatic, so incremental placement —
     /// not a Sugiyama pass — is what has to get this right.
@@ -534,7 +793,7 @@ mod tests {
             .map(|n| (n.id.clone(), n.position.x, n.position.y))
             .collect();
 
-        spread_sessions(&mut flow);
+        pack_sessions(&mut flow);
         let after: Vec<_> = flow
             .nodes()
             .map(|n| (n.id.clone(), n.position.x, n.position.y))

--- a/src/state/graph.rs
+++ b/src/state/graph.rs
@@ -9,7 +9,7 @@
 use rataflow::{Edge, Flow, Handle, HandlePosition, Node, Reconnectable, Sugiyama, Theme};
 use ratatui::style::Color;
 
-use super::session::{AgentInfo, AgentKind, AgentStatus, SessionModel};
+use super::session::{AgentInfo, AgentKind, AgentStatus, MAIN_ID, SessionModel};
 use crate::ui::edges::AgentEdge;
 use crate::ui::nodes::{AgentNode, MAIN_NODE_DIMS, SUB_NODE_DIMS};
 
@@ -186,22 +186,29 @@ pub fn sync(flow: &mut AgentFlow, model: &SessionModel, relayout: bool) -> bool 
             // Local placement: below the parent, fanned past prior siblings.
             // Overwritten by Sugiyama when `relayout` runs; kept verbatim in
             // Manual so existing nodes never move underneath the user.
-            let pos = info
+            // Only `main` is a session root. An agent whose `parent` is still
+            // unset is an ORPHAN — its transcript folded before its meta — so
+            // it hangs off its own session's root instead. Parking it at
+            // `next_root_x` like a root would strand it past everything on the
+            // canvas, and `session_boxes` would then stretch its session's box
+            // across the whole width and shove every other tree aside.
+            let anchor = info
                 .parent
                 .as_deref()
+                .or_else(|| (id != MAIN_ID).then_some(MAIN_ID))
                 .map(|p| node_id(&model.session_id, p))
-                .and_then(|p| flow.node(&p))
+                .and_then(|p| flow.node(&p));
+            let pos = anchor
                 .map(|parent| {
                     (
                         parent.position.x + siblings as f64 * (w + LOCAL_H_GAP),
                         parent.position.y + parent.height + LOCAL_V_GAP,
                     )
                 })
-                // A parentless node is a session root. Layout is never
-                // automatic here (see `resync`), so a root cannot wait for a
-                // Sugiyama pass to be placed — at the origin it would land on
-                // top of the first session's root until the user pressed `r`.
-                // Park it clear of everything already on the canvas instead.
+                // A real root. Layout is never automatic here (see `resync`),
+                // so it cannot wait for a Sugiyama pass to be placed — at the
+                // origin it would land on top of the first session's root
+                // until the user pressed `r`. Park it clear of the canvas.
                 .unwrap_or_else(|| (next_root_x(flow), 0.0));
             // Read-only monitor: nodes are selectable (detail panel) and
             // draggable (manual arrangement) — but never deletable and never
@@ -571,6 +578,43 @@ mod tests {
         let mut m = SessionModel::new(S.into());
         m.apply_meta("abc123", None, &meta());
         m
+    }
+
+    /// An agent whose meta hasn't folded yet has no `parent`, but it is NOT a
+    /// session root: parked like one it lands past every other session's tree,
+    /// and its own session's box then spans the canvas and displaces the rest.
+    #[test]
+    fn a_parentless_subagent_hangs_off_its_session_root() {
+        let mut flow = new_flow();
+        sync(&mut flow, &SessionModel::new(S.into()), false);
+        // A second session claims the space to the right.
+        sync(&mut flow, &SessionModel::new("s2".into()), false);
+        let s2_right = {
+            let n = flow.node(&node_id("s2", "main")).unwrap();
+            n.position.x + n.width
+        };
+
+        let mut m = SessionModel::new(S.into());
+        m.agents
+            .insert("orph".to_string(), AgentInfo::new(AgentKind::Subagent));
+        m.spawn_order.push_back("orph".to_string());
+        sync(&mut flow, &m, false);
+
+        let root = flow.node(&n("main")).unwrap();
+        let (root_x, root_bottom) = (root.position.x, root.position.y + root.height);
+        let orphan = flow.node(&n("orph")).unwrap();
+        assert_eq!(
+            orphan.position.x, root_x,
+            "orphan left its session's column"
+        );
+        assert!(
+            orphan.position.y >= root_bottom,
+            "orphan must sit below the root"
+        );
+        assert!(
+            orphan.position.x < s2_right,
+            "orphan was parked past another session's tree"
+        );
     }
 
     /// A labelled root names its project instead of saying "claude", and the

--- a/src/state/graph.rs
+++ b/src/state/graph.rs
@@ -27,14 +27,16 @@ pub type AgentFlow = Flow<AgentNode, AgentEdge>;
 pub const ID_SEP: char = '/';
 
 /// The `Flow` node id for `agent` within `session`.
+///
+/// Only the session half has to avoid [`ID_SEP`] — [`split_node_id`] splits at
+/// the FIRST one, so an agent id containing it still round-trips. That matters
+/// because agent ids are read out of transcripts the tool does not own, and
+/// asserting on their content would turn a hostile file into a debug-build
+/// panic. A session id is a file stem, which cannot contain a path separator.
 pub fn node_id(session: &str, agent: &str) -> String {
-    // The round trip through `split_node_id` relies on neither half containing
-    // the separator. That holds for every id the format produces, but it was
-    // only ever stated in a comment — a differently-sourced id would corrupt
-    // the parse silently rather than fail here.
     debug_assert!(
-        !session.contains(ID_SEP) && !agent.contains(ID_SEP),
-        "node id parts must not contain {ID_SEP:?}: {session} / {agent}"
+        !session.contains(ID_SEP),
+        "session id must not contain {ID_SEP:?}: {session}"
     );
     format!("{session}{ID_SEP}{agent}")
 }
@@ -615,6 +617,14 @@ mod tests {
             orphan.position.x < s2_right,
             "orphan was parked past another session's tree"
         );
+    }
+
+    /// Agent ids come out of transcripts the tool does not own, so one holding
+    /// the separator must round-trip rather than panic a debug build.
+    #[test]
+    fn an_agent_id_containing_the_separator_still_round_trips() {
+        let id = node_id(S, "a/b");
+        assert_eq!(split_node_id(&id), Some((S, "a/b")));
     }
 
     /// A labelled root names its project instead of saying "claude", and the

--- a/src/state/graph.rs
+++ b/src/state/graph.rs
@@ -17,6 +17,28 @@ use crate::ui::nodes::{AgentNode, MAIN_NODE_DIMS, SUB_NODE_DIMS};
 /// edges (no labels — liveness reads from color alone).
 pub type AgentFlow = Flow<AgentNode, AgentEdge>;
 
+/// Separator between the session and the within-session agent id in a `Flow`
+/// node id.
+///
+/// Node ids must be unique across the WHOLE flow, but every
+/// [`SessionModel`] names its root `"main"` — so a flow holding more than one
+/// session needs the session in the id or the roots collide. Session ids are
+/// UUIDs and agent ids are hex/workflow tokens, so neither can contain this.
+pub const ID_SEP: char = '/';
+
+/// The `Flow` node id for `agent` within `session`.
+pub fn node_id(session: &str, agent: &str) -> String {
+    format!("{session}{ID_SEP}{agent}")
+}
+
+/// Split a `Flow` node id back into `(session, agent)`.
+///
+/// `None` for an id that was not produced by [`node_id`] — callers treat that
+/// as "not one of ours" rather than guessing which half is which.
+pub fn split_node_id(id: &str) -> Option<(&str, &str)> {
+    id.split_once(ID_SEP)
+}
+
 /// Build an empty, fully-configured `Flow` for zoetrope.
 ///
 /// Config: `with_deselect_on_pane_click(false)`, `deselect_on_drag = false`
@@ -42,9 +64,12 @@ pub fn new_flow() -> AgentFlow {
 }
 
 /// Title line for a node, given its kind and agent type.
-fn node_title(info: &AgentInfo) -> String {
+///
+/// `label` is the session's project name, used for the root card so that a
+/// canvas of several sessions names them instead of repeating "claude".
+fn node_title(info: &AgentInfo, label: Option<&str>) -> String {
     match info.kind {
-        AgentKind::Main => "claude".to_string(),
+        AgentKind::Main => label.unwrap_or("claude").to_string(),
         AgentKind::WorkflowGroup => info
             .agent_type
             .clone()
@@ -67,9 +92,12 @@ fn node_dims(kind: AgentKind) -> (f64, f64) {
 /// Whether a node's content already mirrors the agent — allocation-free
 /// comparison so unchanged agents skip [`build_content`]'s String clones on
 /// every sync (the steady state for almost all agents on almost all ticks).
-fn content_matches(info: &AgentInfo, node: &AgentNode) -> bool {
+fn content_matches(info: &AgentInfo, node: &AgentNode, label: Option<&str>) -> bool {
     let title_ok = match info.kind {
-        AgentKind::Main => node.title == "claude",
+        // Compared against the SAME label `node_title` would produce — a
+        // literal "claude" here would mismatch every sync once the session is
+        // labelled, rebuilding every root card's content on every frame.
+        AgentKind::Main => node.title == label.unwrap_or("claude"),
         AgentKind::WorkflowGroup => node.title == info.agent_type.as_deref().unwrap_or("workflow"),
         AgentKind::Subagent => node.title == info.agent_type.as_deref().unwrap_or("subagent"),
     };
@@ -83,9 +111,9 @@ fn content_matches(info: &AgentInfo, node: &AgentNode) -> bool {
 }
 
 /// Build the [`AgentNode`] content mirrored from an [`AgentInfo`].
-fn build_content(info: &AgentInfo) -> AgentNode {
+fn build_content(info: &AgentInfo, label: Option<&str>) -> AgentNode {
     AgentNode {
-        title: node_title(info),
+        title: node_title(info, label),
         description: info.description.clone(),
         status: info.status,
         tool_count: info.tool_calls.len(),
@@ -120,12 +148,15 @@ pub fn sync(flow: &mut AgentFlow, model: &SessionModel, relayout: bool) -> bool 
         let Some(info) = model.agent(id) else {
             continue;
         };
-        if let Some(existing) = flow.node_content_mut(id) {
+        // Model ids are session-local; flow ids are not. This is the ONLY place
+        // the two namespaces meet.
+        let nid = node_id(&model.session_id, id);
+        if let Some(existing) = flow.node_content_mut(&nid) {
             // Steady state: only rebuild (String clones) when something
             // visible changed — the per-second status tick and per-batch
             // syncs walk every agent, and most are unchanged.
-            if !content_matches(info, existing) {
-                *existing = build_content(info);
+            if !content_matches(info, existing, model.label.as_deref()) {
+                *existing = build_content(info, model.label.as_deref());
             }
         } else {
             // Sibling index for local placement — computed only for the rare
@@ -142,7 +173,7 @@ pub fn sync(flow: &mut AgentFlow, model: &SessionModel, relayout: bool) -> bool 
                         .count()
                 })
                 .unwrap_or(0);
-            let content = build_content(info);
+            let content = build_content(info, model.label.as_deref());
             let (w, h) = node_dims(info.kind);
             // Local placement: below the parent, fanned past prior siblings.
             // Overwritten by Sugiyama when `relayout` runs; kept verbatim in
@@ -150,19 +181,25 @@ pub fn sync(flow: &mut AgentFlow, model: &SessionModel, relayout: bool) -> bool 
             let pos = info
                 .parent
                 .as_deref()
-                .and_then(|p| flow.node(p))
+                .map(|p| node_id(&model.session_id, p))
+                .and_then(|p| flow.node(&p))
                 .map(|parent| {
                     (
                         parent.position.x + siblings as f64 * (w + LOCAL_H_GAP),
                         parent.position.y + parent.height + LOCAL_V_GAP,
                     )
                 })
-                .unwrap_or((0.0, 0.0));
+                // A parentless node is a session root. Layout is never
+                // automatic here (see `resync`), so a root cannot wait for a
+                // Sugiyama pass to be placed — at the origin it would land on
+                // top of the first session's root until the user pressed `r`.
+                // Park it clear of everything already on the canvas instead.
+                .unwrap_or_else(|| (next_root_x(flow), 0.0));
             // Read-only monitor: nodes are selectable (detail panel) and
             // draggable (manual arrangement) — but never deletable and never
             // connection sources. Enforced at the DTO level, not just the key
             // whitelist, so no input path can mutate the graph.
-            let node = Node::new(id.clone(), pos, (w, h), content)
+            let node = Node::new(nid.clone(), pos, (w, h), content)
                 .with_deletable(false)
                 .with_connectable(false)
                 .with_handles(vec![
@@ -185,7 +222,9 @@ pub fn sync(flow: &mut AgentFlow, model: &SessionModel, relayout: bool) -> bool 
             continue;
         };
         let animated = info.status == AgentStatus::Running;
-        let edge_id = edge_id(id);
+        let nid = node_id(&model.session_id, id);
+        let parent_nid = node_id(&model.session_id, parent);
+        let edge_id = edge_id(&nid);
         // Edge already present (the steady state on every sync): just refresh
         // animation — probing via `edge_content_mut` first avoids building a
         // throwaway Edge (three String clones) per agent per sync only for
@@ -199,7 +238,7 @@ pub fn sync(flow: &mut AgentFlow, model: &SessionModel, relayout: bool) -> bool 
             content.running = animated;
             flow.set_edge_animated(&edge_id, animated);
         } else {
-            let edge = Edge::new(edge_id.clone(), parent.clone(), id.clone())
+            let edge = Edge::new(edge_id.clone(), parent_nid, nid)
                 .with_animated(animated)
                 .with_selectable(false)
                 .with_deletable(false)
@@ -230,12 +269,113 @@ fn edge_id(child: &str) -> String {
     format!("e-{child}")
 }
 
+/// Remove every node and edge belonging to `session`.
+///
+/// Used when a session stops being watched: its subtree leaves the canvas
+/// without disturbing the others, which a whole-flow rebuild would (it drops
+/// every node position the user arranged).
+pub fn remove_session(flow: &mut AgentFlow, session: &str) -> bool {
+    let doomed: Vec<String> = flow
+        .nodes()
+        .filter(|n| split_node_id(&n.id).is_some_and(|(s, _)| s == session))
+        .map(|n| n.id.clone())
+        .collect();
+    let removed = !doomed.is_empty();
+    for id in doomed {
+        // Edges are keyed off the child node id, so removing the node's edge by
+        // the same derivation keeps the two in step.
+        flow.remove_edge(&edge_id(&id));
+        flow.remove_node(&id);
+    }
+    removed
+}
+
 /// Apply the Sugiyama vertical layout to `flow`.
 ///
 /// Split out so it can be called explicitly and unit-tested independently of
 /// the per-agent diffing in [`sync`].
 pub fn relayout(flow: &mut AgentFlow) {
     flow.apply_layout(Sugiyama::vertical());
+    spread_sessions(flow);
+}
+
+/// Where a newly-appearing session root goes: clear of everything on the
+/// canvas, or the origin when it is the first.
+fn next_root_x(flow: &AgentFlow) -> f64 {
+    flow.nodes()
+        .map(|n| n.position.x + n.width)
+        .reduce(f64::max)
+        .map_or(0.0, |right| right + SESSION_GUTTER)
+}
+
+/// Horizontal gap between two sessions' trees, in world units.
+///
+/// A whole main card wide ([`MAIN_NODE_DIMS`]), so the gutter between sessions
+/// always reads wider than the gaps *inside* one — otherwise two adjacent trees
+/// look like one tree with an odd branch.
+const SESSION_GUTTER: f64 = MAIN_NODE_DIMS.0;
+
+/// Lay each session's tree out beside the previous one.
+///
+/// **Required after every Sugiyama pass.** rust-sugiyama lays out each
+/// weakly-connected component in its own coordinate space, and rataflow applies
+/// each component's coordinates verbatim — it iterates `for (result, _, _)`,
+/// discarding exactly the per-component width and height that would let it
+/// offset them. With one session that is invisible (one component). With
+/// several it stacks every session's tree at the origin, overlapping.
+///
+/// Sessions keep their first-seen order (the flow's node order), so a session
+/// appearing does not reshuffle the ones already on screen; it appends to the
+/// right. Vertical positions are left alone: every root is rank 0, so leaving
+/// `y` as Sugiyama produced it is what keeps the roots on one line.
+fn spread_sessions(flow: &mut AgentFlow) {
+    // Per session, in first-seen order: its node ids and horizontal extent.
+    let mut order: Vec<String> = Vec::new();
+    let mut extent: std::collections::HashMap<String, (f64, f64)> =
+        std::collections::HashMap::new();
+
+    for node in flow.nodes() {
+        let Some((session, _)) = split_node_id(&node.id) else {
+            continue;
+        };
+        let (left, right) = (node.position.x, node.position.x + node.width);
+        match extent.get_mut(session) {
+            Some(span) => {
+                span.0 = span.0.min(left);
+                span.1 = span.1.max(right);
+            }
+            None => {
+                order.push(session.to_string());
+                extent.insert(session.to_string(), (left, right));
+            }
+        }
+    }
+    if order.len() < 2 {
+        return;
+    }
+
+    // Shift each session so the trees sit side by side, the first one keeping
+    // the origin the single-session layout would have given it.
+    let mut cursor = extent.get(&order[0]).map_or(0.0, |e| e.0);
+    let mut shift: std::collections::HashMap<String, f64> =
+        std::collections::HashMap::with_capacity(order.len());
+    for session in &order {
+        let Some(&(left, right)) = extent.get(session) else {
+            continue;
+        };
+        shift.insert(session.clone(), cursor - left);
+        cursor += (right - left) + SESSION_GUTTER;
+    }
+
+    let moved: Vec<(String, (f64, f64))> = flow
+        .nodes()
+        .filter_map(|node| {
+            let (session, _) = split_node_id(&node.id)?;
+            let dx = shift.get(session)?;
+            Some((node.id.clone(), (node.position.x + dx, node.position.y)))
+        })
+        .collect();
+    flow.set_node_positions(moved.iter().map(|(id, pos)| (id, *pos)));
 }
 
 /// Restore saved positions onto whichever nodes still exist (used after a
@@ -254,17 +394,200 @@ mod tests {
     use super::*;
     use crate::transcript::SubagentMeta;
 
-    /// A model with main + one direct subagent (running).
-    fn model_with_subagent() -> SessionModel {
-        let mut m = SessionModel::new("s1".into());
-        let meta = SubagentMeta {
+    /// The session id every test model uses.
+    const S: &str = "s1";
+
+    /// Flow node id for a `s1` agent — the tests reach into the flow, which
+    /// speaks session-qualified ids.
+    fn n(agent: &str) -> String {
+        node_id(S, agent)
+    }
+
+    fn meta() -> SubagentMeta {
+        SubagentMeta {
             agent_type: Some("guide".into()),
             description: Some("research".into()),
             tool_use_id: Some("ag1".into()),
             stopped_by_user: None,
-        };
-        m.apply_meta("abc123", None, &meta);
+        }
+    }
+
+    /// A model with main + one direct subagent (running).
+    fn model_with_subagent() -> SessionModel {
+        let mut m = SessionModel::new(S.into());
+        m.apply_meta("abc123", None, &meta());
         m
+    }
+
+    /// A labelled root names its project instead of saying "claude", and the
+    /// label must round-trip through `content_matches` — otherwise every root
+    /// card is rebuilt on every sync forever.
+    #[test]
+    fn a_session_label_names_the_root_card_and_is_stable() {
+        let mut model = model_with_subagent();
+        model.label = Some("zoetrope".into());
+        let mut flow = new_flow();
+        sync(&mut flow, &model, false);
+
+        assert_eq!(flow.node_content_mut(&n("main")).unwrap().title, "zoetrope");
+        // The subagent keeps its own title — only roots take the label.
+        assert_eq!(flow.node_content_mut(&n("abc123")).unwrap().title, "guide");
+
+        let info = model.agent("main").unwrap();
+        let node = flow.node_content_mut(&n("main")).unwrap();
+        assert!(
+            content_matches(info, node, model.label.as_deref()),
+            "a labelled root must compare equal to itself"
+        );
+        // An unlabelled session still reads "claude".
+        let plain = SessionModel::new("s3".into());
+        let mut flow2 = new_flow();
+        sync(&mut flow2, &plain, false);
+        assert_eq!(
+            flow2
+                .node_content_mut(&node_id("s3", "main"))
+                .unwrap()
+                .title,
+            "claude"
+        );
+    }
+
+    /// Two sessions' trees must not overlap after a layout pass.
+    ///
+    /// This is the failure rataflow hands us for free: it applies each
+    /// connected component's Sugiyama coordinates verbatim, so without
+    /// `spread_sessions` both trees land on top of each other at the origin.
+    #[test]
+    fn sessions_are_laid_out_side_by_side() {
+        let mut flow = new_flow();
+        let a = model_with_subagent();
+        let mut b = SessionModel::new("s2".into());
+        b.apply_meta("def456", None, &meta());
+        sync(&mut flow, &a, false);
+        sync(&mut flow, &b, false);
+        relayout(&mut flow);
+
+        // Horizontal extent of one session's nodes.
+        let span = |session: &str| {
+            flow.nodes()
+                .filter(|n| split_node_id(&n.id).is_some_and(|(s, _)| s == session))
+                .fold((f64::MAX, f64::MIN), |(lo, hi), n| {
+                    (lo.min(n.position.x), hi.max(n.position.x + n.width))
+                })
+        };
+        let (a_lo, a_hi) = span(S);
+        let (b_lo, b_hi) = span("s2");
+
+        assert!(a_lo < a_hi && b_lo < b_hi, "both sessions have nodes");
+        assert!(
+            b_lo >= a_hi,
+            "session trees overlap: s1 spans {a_lo}..{a_hi}, s2 spans {b_lo}..{b_hi}"
+        );
+        assert!(
+            b_lo - a_hi >= SESSION_GUTTER,
+            "the gutter between sessions must read wider than the gaps inside one"
+        );
+
+        // The roots stay on one line — they are all rank 0, and a reader scans
+        // across them.
+        let root_y = |session: &str| flow.node(&node_id(session, "main")).unwrap().position.y;
+        assert_eq!(root_y(S), root_y("s2"));
+    }
+
+    /// A session appearing while the canvas is live must not land on top of
+    /// one already there. Layout is never automatic, so incremental placement —
+    /// not a Sugiyama pass — is what has to get this right.
+    #[test]
+    fn a_new_session_root_lands_clear_of_the_canvas() {
+        let mut flow = new_flow();
+        let a = model_with_subagent();
+        sync(&mut flow, &a, false);
+        relayout(&mut flow);
+
+        // A second session shows up. No relayout — just the incremental sync
+        // the live path runs.
+        let mut b = SessionModel::new("s2".into());
+        b.apply_meta("def456", None, &meta());
+        sync(&mut flow, &b, false);
+
+        let a_right = flow
+            .nodes()
+            .filter(|n| split_node_id(&n.id).is_some_and(|(s, _)| s == S))
+            .fold(f64::MIN, |hi, n| hi.max(n.position.x + n.width));
+        let b_root = flow.node(&node_id("s2", "main")).unwrap().position.x;
+        assert!(
+            b_root >= a_right,
+            "the new root landed at {b_root}, inside the existing tree ending at {a_right}"
+        );
+    }
+
+    /// A single session must lay out exactly as it always did — the spreading
+    /// pass is a no-op below two sessions, so nothing shifts for the common case.
+    #[test]
+    fn one_session_is_unaffected_by_spreading() {
+        let model = model_with_subagent();
+        let mut flow = new_flow();
+        sync(&mut flow, &model, false);
+        flow.apply_layout(Sugiyama::vertical());
+        let before: Vec<_> = flow
+            .nodes()
+            .map(|n| (n.id.clone(), n.position.x, n.position.y))
+            .collect();
+
+        spread_sessions(&mut flow);
+        let after: Vec<_> = flow
+            .nodes()
+            .map(|n| (n.id.clone(), n.position.x, n.position.y))
+            .collect();
+        assert_eq!(before, after);
+    }
+
+    /// Two sessions projected into ONE flow must not fight over a node id.
+    ///
+    /// Every `SessionModel` names its root `"main"`, so before node ids carried
+    /// the session, the second session's root was a duplicate-id no-op: its
+    /// agents then hung off the FIRST session's root, silently merging two
+    /// unrelated sessions into one tree.
+    #[test]
+    fn two_sessions_share_a_flow_without_their_roots_colliding() {
+        let mut flow = new_flow();
+        let a = model_with_subagent();
+        let mut b = SessionModel::new("s2".into());
+        b.apply_meta("def456", None, &meta());
+
+        sync(&mut flow, &a, false);
+        sync(&mut flow, &b, false);
+
+        // Four distinct nodes: two roots, two subagents.
+        assert_eq!(flow.nodes().count(), 4);
+        for id in [
+            node_id(S, "main"),
+            node_id(S, "abc123"),
+            node_id("s2", "main"),
+            node_id("s2", "def456"),
+        ] {
+            assert!(flow.node(&id).is_some(), "{id} missing");
+        }
+
+        // Each subagent's edge lands on ITS OWN root, not the other session's.
+        let parent_of = |child: &str| {
+            flow.edges()
+                .iter()
+                .find(|e| e.target == child)
+                .map(|e| e.source.clone())
+        };
+        assert_eq!(parent_of(&node_id(S, "abc123")), Some(node_id(S, "main")));
+        assert_eq!(
+            parent_of(&node_id("s2", "def456")),
+            Some(node_id("s2", "main"))
+        );
+
+        // And the ids round-trip, which is what selection relies on.
+        assert_eq!(
+            split_node_id(&node_id("s2", "def456")),
+            Some(("s2", "def456"))
+        );
+        assert_eq!(split_node_id("unqualified"), None);
     }
 
     #[test]
@@ -273,8 +596,8 @@ mod tests {
         let mut flow = new_flow();
         let structural = sync(&mut flow, &model, true);
         assert!(structural);
-        assert!(flow.node_content_mut("main").is_some());
-        assert!(flow.node_content_mut("abc123").is_some());
+        assert!(flow.node_content_mut(&n("main")).is_some());
+        assert!(flow.node_content_mut(&n("abc123")).is_some());
         // One edge main -> abc123.
         assert_eq!(flow.edges().len(), 1);
     }
@@ -300,10 +623,10 @@ mod tests {
         let model = model_with_subagent();
         let mut flow = new_flow();
         sync(&mut flow, &model, true);
-        flow.select_node("abc123");
+        flow.select_node(&n("abc123"));
         assert_eq!(
-            flow.selected_nodes().next().map(|n| n.id.clone()),
-            Some("abc123".to_string())
+            flow.selected_nodes().next().map(|node| node.id.clone()),
+            Some(n("abc123"))
         );
 
         // Re-sync after a non-structural change (e.g. a tool call added).
@@ -313,8 +636,8 @@ mod tests {
         }
         sync(&mut flow, &model2, true);
         assert_eq!(
-            flow.selected_nodes().next().map(|n| n.id.clone()),
-            Some("abc123".to_string())
+            flow.selected_nodes().next().map(|node| node.id.clone()),
+            Some(n("abc123"))
         );
     }
 
@@ -324,7 +647,7 @@ mod tests {
         let mut flow = new_flow();
         sync(&mut flow, &model, true);
         // Running subagent -> animated edge.
-        let edge_id = edge_id("abc123");
+        let edge_id = edge_id(&n("abc123"));
         let animated = flow
             .edges()
             .iter()
@@ -376,8 +699,8 @@ mod tests {
         let mut flow = new_flow();
         // Initial layout (camera engaged).
         sync(&mut flow, &model, true);
-        let main_pos = flow.node("main").unwrap().position;
-        let first_sub = flow.node("abc123").unwrap().position;
+        let main_pos = flow.node(&n("main")).unwrap().position;
+        let first_sub = flow.node(&n("abc123")).unwrap().position;
 
         // Camera now Manual: a second subagent arrives, relayout deferred.
         let meta2 = SubagentMeta {
@@ -391,10 +714,10 @@ mod tests {
         assert!(structural);
 
         // Nothing existing moved...
-        assert_eq!(flow.node("main").unwrap().position, main_pos);
-        assert_eq!(flow.node("abc123").unwrap().position, first_sub);
+        assert_eq!(flow.node(&n("main")).unwrap().position, main_pos);
+        assert_eq!(flow.node(&n("abc123")).unwrap().position, first_sub);
         // ...and the newcomer landed below its parent, not at the origin.
-        let new_pos = flow.node("def456").unwrap().position;
+        let new_pos = flow.node(&n("def456")).unwrap().position;
         assert!(new_pos.y > main_pos.y, "child placed below parent");
         assert_ne!((new_pos.x, new_pos.y), (0.0, 0.0));
     }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod graph;
 pub mod info;
+pub mod rail;
 pub mod session;
 pub mod timeline;
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -640,6 +640,13 @@ impl App {
                 generation,
                 model: self.session.clone(),
             });
+            // This rung folds the prefix as it stands NOW, so every re-sort
+            // recorded so far is already baked into it — including the ones
+            // that predate the whole ladder (a replay load moves every index).
+            // Leaving them pending would make the next prune apply them to
+            // rungs they cannot possibly invalidate, and the ladder would
+            // collapse to a single rung on the first out-of-order batch.
+            self.timeline.take_disturbance();
         }
     }
 
@@ -654,16 +661,27 @@ impl App {
         self.maybe_snapshot(self.timeline.folded, generation);
     }
 
-    /// Discard every rung if the item list has been re-sorted or replaced since
-    /// they were taken. Generation is monotonic, so one stale rung means all of
-    /// them are stale.
+    /// Reconcile the ladder with a re-sorted or replaced item list.
+    ///
+    /// A rung describes `items[0..folded]`, so it survives exactly as long as
+    /// that prefix does. The timeline reports how much of it the re-sorts left
+    /// alone ([`Timeline::take_disturbance`]); rungs below that line are still
+    /// accurate and are re-stamped to the new generation instead of thrown
+    /// away. This is what keeps the ladder alive in a live multi-agent session,
+    /// where a sidecar entry arriving a moment out of order re-sorts the tail
+    /// on most batches — voiding the whole ladder there left every backward
+    /// seek folding from item zero, which is the case it exists for.
     fn drop_stale_rungs(&mut self, generation: u64) {
         if self
             .snapshots
             .last()
             .is_some_and(|s| s.generation != generation)
         {
-            self.snapshots.clear();
+            let stable = self.timeline.take_disturbance();
+            self.snapshots.retain(|s| s.folded <= stable);
+            for rung in &mut self.snapshots {
+                rung.generation = generation;
+            }
         }
     }
 
@@ -1729,15 +1747,13 @@ mod tests {
         );
     }
 
-    /// A re-sort moves existing items, so every rung taken before it describes
-    /// a prefix that no longer exists. They must be discarded, not restored.
-    #[test]
-    fn a_generation_bump_voids_the_ladder() {
+    /// Seed a live App with `n` dated items one second apart, folded to the
+    /// edge so the ladder has rungs.
+    fn app_with_rungs(n: usize, t0: chrono::DateTime<chrono::Utc>) -> App {
         let mut app = App::new("s".to_string(), Mode::Live);
-        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
         app.handle_ui_event(UiEvent::ReplayLoaded {
             session_id: "s".into(),
-            items: (0..SNAPSHOT_STRIDE * 2)
+            items: (0..n)
                 .map(|i| {
                     crate::tailer::ReplayItem::at(
                         Some(t0 + chrono::Duration::seconds(i as i64)),
@@ -1750,16 +1766,86 @@ mod tests {
         });
         app.go_live();
         assert!(!app.snapshots.is_empty(), "rungs were taken");
+        app
+    }
 
-        // Simulate the re-sort that `append_live` performs when a late batch
-        // dates a previously-pending item.
-        app.timeline.generation = app.timeline.generation.wrapping_add(1);
-        app.seek_to_fraction(0.25);
+    /// An undated item sorts to the HEAD, so one arriving shifts every index
+    /// after it: no rung describes its prefix any more, and all must go.
+    #[test]
+    fn an_undated_arrival_voids_the_whole_ladder() {
+        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+        let mut app = app_with_rungs(SNAPSHOT_STRIDE * 2, t0);
+
+        // A meta with no timestamp of its own — the `needs_dating` path.
+        app.handle_ui_event(UiEvent::Batch {
+            session_id: "s".into(),
+            updates: vec![meta_update("late")],
+        });
+        // Only a rung taken at the new edge remains; every rung describing the
+        // old prefix is gone.
+        assert!(
+            app.snapshots
+                .iter()
+                .all(|s| s.folded == app.timeline.folded),
+            "a rung describing the pre-sort prefix survived: {:?}",
+            app.snapshots.iter().map(|s| s.folded).collect::<Vec<_>>()
+        );
+    }
+
+    /// The case the ladder exists for: a live session whose sidecars land a
+    /// moment out of order. The re-sort touches only the tail, so the rungs
+    /// below it still describe their prefix exactly — voiding them wholesale
+    /// sent every backward seek back to folding from item zero.
+    #[test]
+    fn an_out_of_order_batch_keeps_the_rungs_below_it() {
+        let count = SNAPSHOT_STRIDE * 3;
+        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+        let mut app = app_with_rungs(count, t0);
+        let before = app.snapshots.len();
+        assert!(before >= 2, "expected several rungs, got {before}");
+
+        // A sidecar entry timestamped just before the edge: out of order, but
+        // it cannot disturb anything earlier than itself.
+        app.handle_ui_event(UiEvent::Batch {
+            session_id: "s".into(),
+            updates: vec![crate::tailer::Update::Entry {
+                source: crate::tailer::Source::Sub("late".into()),
+                entry: crate::transcript::parse_line(&format!(
+                    r#"{{"type":"assistant","uuid":"u","parentUuid":null,"timestamp":"{}","message":{{"role":"assistant","content":[{{"type":"tool_use","id":"b1","name":"Bash","input":{{}}}}]}}}}"#,
+                    (t0 + chrono::Duration::seconds(count as i64 - 2)).to_rfc3339()
+                ))
+                .unwrap(),
+            }],
+        });
+
+        assert!(
+            app.snapshots.len() >= before - 1,
+            "the untouched prefix lost its rungs: {} -> {}",
+            before,
+            app.snapshots.len()
+        );
         assert!(
             app.snapshots
                 .iter()
                 .all(|s| s.generation == app.timeline.generation),
-            "a stale-generation rung survived the seek"
+            "a surviving rung kept a stale generation stamp"
+        );
+
+        // And a rung is only worth keeping if restoring it is still correct.
+        let target = SNAPSHOT_STRIDE + 5;
+        let total = app.timeline.items.len();
+        app.seek_to_fraction(target as f64 / total as f64);
+        let laddered = app.session.clone();
+        let landed = app.timeline.folded;
+
+        app.snapshots.clear();
+        app.seek_to_fraction(1.0);
+        app.snapshots.clear();
+        app.seek_to_fraction(target as f64 / total as f64);
+        assert_eq!(landed, app.timeline.folded, "both paths land on one item");
+        assert!(
+            laddered == app.session,
+            "a surviving rung diverged from a full rebuild"
         );
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1026,6 +1026,23 @@ impl App {
             // layout stays user-driven (no auto-relayout — see `resync`).
             graph::sync(&mut self.flow, &self.session, false);
         }
+
+        // The monitored sessions share the canvas and their liveness is just as
+        // time-derived, but nothing else ticks them: a quiet one produces no
+        // batches, and `fold_other` only runs when one arrives. Without this
+        // their cards stay green until the supervisor drops the monitor and the
+        // whole subtree vanishes, instead of settling to done.
+        let App { others, flow, .. } = self;
+        let live = chrono::Utc::now();
+        let mut structural = false;
+        for model in others.values_mut() {
+            structural |= Self::project(flow, model, live);
+        }
+        if structural {
+            self.layout_dirty = true;
+            graph::repack_if_overlapping(&mut self.flow);
+        }
+
         if self.camera == Camera::Follow {
             self.track_activity();
         }
@@ -1744,6 +1761,42 @@ mod tests {
         assert!(
             laddered.session == plain.session,
             "ladder restore diverged from a full rebuild"
+        );
+    }
+
+    /// Monitored sessions share the canvas, and their liveness is time-derived
+    /// like the focused one's — but they produce no batches once quiet, so the
+    /// periodic tick is the only thing that can settle them.
+    #[test]
+    fn the_status_tick_settles_monitored_sessions_too() {
+        use crate::state::session::{AgentStatus, MAIN_ID};
+
+        let mut app = App::new("focused".to_string(), Mode::Live);
+
+        // A session whose last entry is long past the idle threshold, but whose
+        // main agent is still marked running — the state a session lands in when
+        // it goes quiet between two monitor batches.
+        let stale = chrono::Utc::now() - chrono::Duration::seconds(600);
+        let mut model = SessionModel::new("other".to_string());
+        model.apply_update(&Update::Entry {
+            source: crate::tailer::Source::Main,
+            entry: crate::transcript::parse_line(&format!(
+                r#"{{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"{}","message":{{"role":"user","content":"hi"}}}}"#,
+                stale.to_rfc3339()
+            ))
+            .unwrap(),
+        });
+        model.agents.get_mut(MAIN_ID).unwrap().status = AgentStatus::Running;
+        app.others.insert("other".to_string(), model);
+
+        let running =
+            |app: &App| app.others["other"].agent(MAIN_ID).unwrap().status == AgentStatus::Running;
+        assert!(running(&app));
+
+        app.status_tick();
+        assert!(
+            !running(&app),
+            "a quiet monitored session must settle on the tick, not linger green"
         );
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1193,6 +1193,14 @@ impl App {
                 // draw, which sees the post-split canvas width. A deselection
                 // clears any not-yet-consumed one.
                 self.pending_center = node_ids.first().cloned();
+                // Selecting a card in a session we are only monitoring used to
+                // do nothing visible: the node highlights, but the detail panel
+                // reads the FOCUSED model and finds no such agent, so it renders
+                // blank with no hint why. Reading a card is a request to look at
+                // that session, so treat it as one.
+                if let Some(id) = node_ids.first() {
+                    self.focus_selected_session(id);
+                }
             }
         }
     }
@@ -1270,45 +1278,128 @@ mod tests {
         assert!(app.others.is_empty());
     }
 
-    /// A monitor batch that arrives after its session became the focused one
-    /// must be ignored: two models projecting onto the same node ids would
-    /// overwrite each other's card content on every sync.
+    /// Selecting a card in a monitored session asks to focus that session,
+    /// rather than highlighting a node whose detail panel can only be blank.
     #[test]
-    fn a_late_monitor_batch_cannot_shadow_the_focused_session() {
-        let mut app = App::new("s".to_string(), Mode::Live);
-        app.handle_ui_event(UiEvent::MonitorBatch {
-            session_id: "s".into(),
+    fn selecting_a_monitored_node_focuses_its_session() {
+        use rataflow::FlowEvent;
+
+        let mut app = App::new("focused".to_string(), Mode::Live);
+        app.handle_ui_event(UiEvent::Batch {
+            session_id: "other".into(),
             updates: vec![meta_update("sub")],
         });
-        assert!(
-            app.others.is_empty(),
-            "no shadow model for the focused session"
+        let n = chrono::Utc::now();
+        app.rail.adopt(vec![crate::state::rail::RailRow {
+            session_id: "other".to_string(),
+            project: "bravo".to_string(),
+            main_path: std::path::PathBuf::from("/p/other.jsonl"),
+            agents: 2,
+            failures: 0,
+            last_activity: Some(n),
+            sidecar_active: false,
+        }]);
+
+        let foreign = graph::node_id("other", "sub");
+        app.process_flow_events(
+            vec![FlowEvent::SelectionChanged {
+                node_ids: vec![foreign.clone()],
+                edge_ids: vec![],
+            }]
+            .into_iter(),
         );
-        assert!(app.session.agent("sub").is_none());
+        assert_eq!(
+            app.pending_watch,
+            Some(std::path::PathBuf::from("/p/other.jsonl")),
+            "reading a monitored card should ask to watch that session"
+        );
+
+        // Selecting inside the focused session is not a switch.
+        app.pending_watch = None;
+        app.process_flow_events(
+            vec![FlowEvent::SelectionChanged {
+                node_ids: vec![graph::node_id("focused", "main")],
+                edge_ids: vec![],
+            }]
+            .into_iter(),
+        );
+        assert_eq!(app.pending_watch, None);
+
+        // Neither is selecting a session discovery has never heard of — there
+        // is no transcript path to watch.
+        app.process_flow_events(
+            vec![FlowEvent::SelectionChanged {
+                node_ids: vec![graph::node_id("unknown", "main")],
+                edge_ids: vec![],
+            }]
+            .into_iter(),
+        );
+        assert_eq!(app.pending_watch, None);
     }
 
+    /// One event pair, routed by `session_id`. The App is the only thing that
+    /// knows which session is focused, so it is the only thing that decides
+    /// whether a batch goes to the timeline or to a monitored model.
     #[test]
-    fn auto_switch_reset_adopts_new_session_id() {
-        // The auto-switch path emits SessionReset stamped with the NEW id, then
-        // the post-switch tailer emits Batches under the NEW id. The App must
-        // adopt the new id so those batches are not dropped by is_current.
-        let mut app = App::new("OLD".into(), Mode::Live);
+    fn batches_route_by_session_id() {
+        let mut app = App::new("focused".to_string(), Mode::Live);
 
-        // Reset carrying the NEW session id (auto-switch signal).
-        app.handle_ui_event(UiEvent::SessionReset {
-            session_id: "NEW".into(),
-        });
-        assert_eq!(app.current_session_id, "NEW");
-
-        // A batch from the new session must be accepted, not dropped.
         app.handle_ui_event(UiEvent::Batch {
-            session_id: "NEW".into(),
-            updates: vec![meta_update("newsub")],
+            session_id: "focused".into(),
+            updates: vec![meta_update("mine")],
         });
+        app.handle_ui_event(UiEvent::Batch {
+            session_id: "other".into(),
+            updates: vec![meta_update("theirs")],
+        });
+
+        assert!(app.session.agent("mine").is_some(), "focused → the model");
         assert!(
-            app.session.agent("newsub").is_some(),
-            "new-session subagent must be present after auto-switch"
+            app.session.agent("theirs").is_none(),
+            "another session must not land in the focused model"
         );
+        assert!(
+            app.others["other"].agent("theirs").is_some(),
+            "→ that session's own model"
+        );
+    }
+
+    /// A reset names the session it is about, and nothing else. It used to be
+    /// able to mean "the focused session is now a different one", which is why
+    /// an unfamiliar id was ambiguous.
+    #[test]
+    fn a_reset_only_touches_the_session_it_names() {
+        let mut app = App::new("focused".to_string(), Mode::Live);
+        app.handle_ui_event(UiEvent::Batch {
+            session_id: "focused".into(),
+            updates: vec![meta_update("mine")],
+        });
+        app.handle_ui_event(UiEvent::Batch {
+            session_id: "other".into(),
+            updates: vec![meta_update("theirs")],
+        });
+
+        // A monitored session rotates: it leaves, the focused one is untouched
+        // and stays focused.
+        app.handle_ui_event(UiEvent::SessionReset {
+            session_id: "other".into(),
+        });
+        assert_eq!(
+            app.current_session_id, "focused",
+            "focus is not the tailer's"
+        );
+        assert!(app.others.is_empty());
+        assert!(app.flow.node(&graph::node_id("other", "theirs")).is_none());
+        assert!(app.session.agent("mine").is_some());
+        assert!(app.flow.node(&graph::node_id("focused", "mine")).is_some());
+
+        // The focused session rotates: its model is rebuilt in place.
+        app.handle_ui_event(UiEvent::SessionReset {
+            session_id: "focused".into(),
+        });
+        assert_eq!(app.current_session_id, "focused");
+        assert!(app.session.agent("mine").is_none(), "rebuilt from scratch");
+        assert!(app.flow.node(&graph::node_id("focused", "mine")).is_none());
     }
 
     #[test]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -238,6 +238,16 @@ pub struct App {
     /// [`pending_seek`](Self::pending_seek) and
     /// [`pending_center`](Self::pending_center).
     pub pending_watch: Option<std::path::PathBuf>,
+    /// The project directory this App was launched against, while it has no
+    /// session of its own yet.
+    ///
+    /// Launching in a project that has never been recorded leaves
+    /// [`current_session_id`](Self::current_session_id) empty until discovery
+    /// names a session. Discovery describes the WHOLE workspace, newest first,
+    /// so the first row it reports usually belongs to some other project —
+    /// adopting it would silently show the user a session they did not ask for.
+    /// Cleared as soon as a session is adopted.
+    awaiting_project: Option<std::path::PathBuf>,
 }
 
 impl App {
@@ -273,6 +283,7 @@ impl App {
             rail: Default::default(),
             snapshots: Vec::new(),
             pending_watch: None,
+            awaiting_project: None,
         }
     }
 
@@ -413,6 +424,14 @@ impl App {
         self.detail_follow = true;
         self.layout_dirty = false;
         self.pending_watch = Some(path);
+    }
+
+    /// Wait for a session to appear in `project` rather than adopting whatever
+    /// discovery reports first. Only meaningful before any session is watched.
+    pub fn await_project(&mut self, project: std::path::PathBuf) {
+        if self.current_session_id.is_empty() {
+            self.awaiting_project = Some(project);
+        }
     }
 
     /// Focus the session a just-selected node belongs to, if it is not already
@@ -577,13 +596,19 @@ impl App {
                 // Not gated on `is_current`: a sweep describes the whole
                 // workspace, not one session, so it is never stale for the
                 // watched one.
-                // Launched on a project with no session yet: adopt the first
-                // one discovery names, so the tailer gets a concrete file and
-                // the canvas has something to show.
+                // Launched on a project with no session yet: adopt the newest
+                // session OF THAT PROJECT once one appears, so the tailer gets
+                // a concrete file and the canvas has something to show. Rows
+                // are workspace-wide and newest-first, so without the project
+                // filter this adopts an unrelated project's session.
                 if self.current_session_id.is_empty()
-                    && let Some(first) = rows.first()
+                    && let Some(project) = self.awaiting_project.clone()
+                    && let Some(row) = rows
+                        .iter()
+                        .find(|r| r.main_path.parent() == Some(project.as_path()))
                 {
-                    let path = first.main_path.clone();
+                    let path = row.main_path.clone();
+                    self.awaiting_project = None;
                     self.watch_session(path);
                 }
                 self.apply_session_labels(&rows);
@@ -1816,6 +1841,43 @@ mod tests {
 
         app.seek_to_fraction(0.25);
         assert_eq!(app.session.label.as_deref(), Some("zoetrope"));
+    }
+
+    /// Launching in a project with nothing recorded must not adopt another
+    /// project's session — discovery is workspace-wide and newest-first, so the
+    /// first row it reports is usually somebody else's work.
+    #[test]
+    fn an_empty_project_waits_for_its_own_session() {
+        use crate::state::rail::RailRow;
+        let n = chrono::Utc::now();
+        let row = |project: &str, id: &str| RailRow {
+            session_id: id.to_string(),
+            project: project.to_string(),
+            main_path: std::path::PathBuf::from(format!("/projects/{project}/{id}.jsonl")),
+            agents: 1,
+            failures: 0,
+            last_activity: Some(n),
+            sidecar_active: false,
+        };
+
+        let mut app = App::new(String::new(), Mode::Live);
+        app.await_project(std::path::PathBuf::from("/projects/mine"));
+
+        // A sweep that only knows about another project changes nothing.
+        app.handle_ui_event(UiEvent::Sessions(vec![row("theirs", "other")]));
+        assert_eq!(app.current_session_id, "");
+        assert_eq!(app.pending_watch, None);
+
+        // Once one of ours appears — still not the newest row — we take it.
+        app.handle_ui_event(UiEvent::Sessions(vec![
+            row("theirs", "other"),
+            row("mine", "ours"),
+        ]));
+        assert_eq!(app.current_session_id, "ours");
+        assert_eq!(
+            app.pending_watch,
+            Some(std::path::PathBuf::from("/projects/mine/ours.jsonl"))
+        );
     }
 
     /// Seed a live App with `n` dated items one second apart, folded to the

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -827,6 +827,11 @@ impl App {
 
         // Keep the model we are replacing, to work out what left the canvas.
         let previous = std::mem::replace(&mut self.session, model);
+        // The label comes from the discovery sweep, not from folding, so a rung
+        // taken before the sweep carries a stale one. Restoring it would rename
+        // the root card back to "claude" on every backward seek until the next
+        // sweep happened to notice.
+        self.session.label = previous.label.clone();
         // Re-folding also rebuilds the ladder above `start`, so a scrub that
         // walks backward repeatedly keeps finding rungs near where it lands.
         self.fold_range(start, target);
@@ -1798,6 +1803,19 @@ mod tests {
             !running(&app),
             "a quiet monitored session must settle on the tick, not linger green"
         );
+    }
+
+    /// The project label is sweep-supplied, not folded, so a rung taken before
+    /// the sweep must not carry an old one back onto the root card.
+    #[test]
+    fn a_backward_seek_keeps_the_session_label() {
+        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+        let mut app = app_with_rungs(SNAPSHOT_STRIDE * 2, t0);
+        // The sweep names the project only after the rungs were taken.
+        app.session.label = Some("zoetrope".to_string());
+
+        app.seek_to_fraction(0.25);
+        assert_eq!(app.session.label.as_deref(), Some("zoetrope"));
     }
 
     /// Seed a live App with `n` dated items one second apart, folded to the

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -731,62 +731,52 @@ impl App {
     /// rebuild: node positions (the user's arrangement / a stable layout) and
     /// the selected node are carried over by id.
     fn rebuild_to(&mut self, target: usize) {
-        // Snapshot view state to carry across the wipe. The FLOW id, not the
-        // local agent id — `select_node` speaks flow ids.
-        let selected = self.selected_node_id();
-        // The camera/viewport (pan + zoom) is the user's — a fresh `Flow` would
-        // reset it to the origin, snapping the graph on every backward seek even
-        // in Manual/Overview. Carry it across.
-        let viewport = self.flow.viewport;
-        let positions: std::collections::HashMap<String, (f64, f64)> = self
-            .flow
-            .nodes()
-            .map(|n| (n.id.clone(), (n.position.x, n.position.y)))
-            .collect();
-
         // Start from the newest ladder rung at or before the target instead of
         // from item zero. Restoring a rung is a clone of a persistent model —
         // O(1) — so the fold that follows is bounded by SNAPSHOT_STRIDE rather
         // than by how far back the user seeked.
         let generation = self.timeline.generation;
-        if self
-            .snapshots
-            .last()
-            .is_some_and(|s| s.generation != generation)
-        {
-            self.snapshots.clear();
-        }
+        self.drop_stale_rungs(generation);
         let resume = self
             .snapshots
             .iter()
             .rev()
             .find(|s| s.folded <= target)
             .map(|s| (s.model.clone(), s.folded));
-
-        let start = match resume {
-            Some((model, folded)) => {
-                self.session = model;
-                folded
-            }
-            None => {
-                self.session = SessionModel::new(self.current_session_id.clone());
-                0
-            }
+        let (model, start) = match resume {
+            Some((model, folded)) => (model, folded),
+            None => (SessionModel::new(self.current_session_id.clone()), 0),
         };
-        self.flow = graph::new_flow();
+
+        // Keep the model we are replacing, to work out what left the canvas.
+        let previous = std::mem::replace(&mut self.session, model);
         // Re-folding also rebuilds the ladder above `start`, so a scrub that
         // walks backward repeatedly keeps finding rungs near where it lands.
         self.fold_range(start, target);
         self.timeline.folded = target;
-        self.resync();
 
-        // Carry the arrangement + selection + viewport across so a seek doesn't
-        // jump the layout or the camera.
-        graph::restore_positions(&mut self.flow, &positions);
-        self.flow.viewport = viewport;
-        if let Some(id) = selected {
-            self.flow.select_node(&id);
-        }
+        // Seeking back can only REMOVE agents (a fold never un-spawns one that
+        // the earlier prefix already had), and `sync` adds and updates but never
+        // removes — so taking those few nodes off the canvas is the whole
+        // difference between here and a full rebuild.
+        //
+        // `OrdMap::diff` skips subtrees the two models share, and they share
+        // almost everything: the new model is a rung cloned from this very
+        // lineage. So this costs what actually changed, not what exists.
+        let departed: Vec<String> = previous
+            .agents
+            .diff(&self.session.agents)
+            .filter_map(|change| match change {
+                imbl::ordmap::DiffItem::Remove(id, _) => Some(id.clone()),
+                _ => None,
+            })
+            .collect();
+        graph::remove_agents(&mut self.flow, &self.current_session_id, &departed);
+
+        // No flow wipe, so node positions, the viewport, the selection and every
+        // OTHER session's subtree survive on their own — none of it has to be
+        // captured and restored around a teardown any more.
+        self.resync();
     }
 
     /// Roll workflow-group status up from children, then project the model onto
@@ -1456,6 +1446,76 @@ mod tests {
     /// forward from it must land on exactly the model a from-scratch rebuild
     /// would produce — otherwise a backward seek silently shows a different
     /// session than the same seek did yesterday.
+    /// Seeking back patches the canvas instead of rebuilding it: agents that do
+    /// not exist yet at the target leave, and everything the old teardown had to
+    /// capture and restore by hand — node positions, the viewport, the
+    /// selection, other sessions' subtrees — survives because nothing is thrown
+    /// away.
+    #[test]
+    fn seeking_back_patches_the_canvas_instead_of_rebuilding_it() {
+        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+        let mut app = App::new("focused".to_string(), Mode::Replay);
+        app.handle_ui_event(UiEvent::ReplayLoaded {
+            session_id: "focused".into(),
+            items: (0..6)
+                .map(|i| {
+                    crate::tailer::ReplayItem::at(
+                        Some(t0 + chrono::Duration::seconds(i as i64)),
+                        meta_update(&format!("sub{i}")),
+                    )
+                })
+                .collect(),
+            speed: 8.0,
+            info: Default::default(),
+        });
+        app.go_live();
+
+        // A second session shares the canvas, and must be untouched by a seek
+        // in the focused one.
+        app.handle_ui_event(UiEvent::MonitorBatch {
+            session_id: "other".into(),
+            updates: vec![meta_update("watched")],
+        });
+
+        let early = graph::node_id("focused", "sub1");
+        let late = graph::node_id("focused", "sub5");
+        let foreign = graph::node_id("other", "watched");
+        assert!(app.flow.node(&late).is_some(), "precondition: sub5 exists");
+
+        // Arrange the canvas the way a user would: drag a node, pan, select.
+        app.flow
+            .set_node_positions(std::iter::once((&early, (123.0, 456.0))));
+        app.flow.zoom_to(2.5);
+        let viewport = app.flow.viewport;
+        app.flow.select_node(&early);
+
+        // Seek back to before sub5 (and sub4, sub3…) were ever spawned.
+        app.seek_to_fraction(2.0 / 6.0);
+
+        assert!(
+            app.flow.node(&late).is_none(),
+            "an agent that does not exist at this playhead must leave the canvas"
+        );
+        assert!(app.session.agent("sub5").is_none(), "and leave the model");
+        assert!(app.flow.node(&early).is_some(), "sub1 predates the target");
+
+        // The three things the old rebuild had to save and restore explicitly.
+        let node = app.flow.node(&early).unwrap();
+        assert_eq!(
+            (node.position.x, node.position.y),
+            (123.0, 456.0),
+            "a dragged position survived the seek"
+        );
+        assert_eq!(app.flow.viewport.zoom, viewport.zoom, "viewport survived");
+        assert_eq!(app.selected_agent_id().as_deref(), Some("sub1"));
+
+        // And the monitored session was never in the focused model's diff.
+        assert!(
+            app.flow.node(&foreign).is_some(),
+            "another session's subtree must not be collateral"
+        );
+    }
+
     #[test]
     fn a_ladder_restore_matches_a_full_rebuild() {
         // Enough items that several rungs are taken.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1635,6 +1635,8 @@ mod tests {
         );
     }
 
+    // Drives `handler::process_flow_events`, which is native-only.
+    #[cfg(feature = "native")]
     #[test]
     fn user_pan_cancels_glide() {
         let mut app = App::new("s".into(), Mode::Live);

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -104,6 +104,37 @@ impl CameraGlide {
     }
 }
 
+/// Items folded between two rungs of the snapshot ladder.
+///
+/// The trade is latency against memory: a backward seek re-folds at most this
+/// many items, and the ladder holds `folded / STRIDE` rungs. Snapshots are
+/// cheap because [`SessionModel`] is built from persistent collections — a rung
+/// shares structure with its neighbours instead of copying the model.
+///
+/// Measured on the pathological bench scale (~31k items, 293 agents), halving
+/// this to 512 bought no measurable seek time but cost ~9 MB of retained
+/// rungs. That is because the fold is no longer what a backward seek spends
+/// its time on: `rebuild_to` still discards the whole `Flow` and re-projects
+/// every node, which dominates whatever the fold costs. Shrink this only once
+/// that is fixed — until then it would buy memory for nothing.
+const SNAPSHOT_STRIDE: usize = 1024;
+
+/// A folded model captured at a known point on the timeline.
+struct Snapshot {
+    /// How many items were folded into `model`.
+    folded: usize,
+    /// The [`Timeline::generation`] this was taken under. A rung from an older
+    /// generation describes a prefix that no longer exists — see the field's
+    /// docs — and must be discarded rather than restored.
+    generation: u64,
+    /// The model as of `folded` items. Restoring it is a clone, which is O(1).
+    ///
+    /// This includes derived projections (liveness, workflow rollups) as they
+    /// stood when the rung was taken, which are meaningless at a different
+    /// playhead — every restore re-runs them via `resync`.
+    model: SessionModel,
+}
+
 /// The central application state, owned by the single UI task.
 pub struct App {
     /// The rendered flow graph (agent cards + step edges).
@@ -198,6 +229,9 @@ pub struct App {
     /// [`UiEvent::Sessions`](crate::tailer::UiEvent::Sessions) sweeps; empty in
     /// the browser frontend, which has no filesystem to sweep.
     pub rail: crate::state::rail::SessionRail,
+    /// Ladder of folded-model snapshots, ascending by `folded`, used to start a
+    /// backward seek near its target instead of re-folding from item zero.
+    snapshots: Vec<Snapshot>,
     /// A session the user asked to focus, queued for the event loop to send to
     /// the tailer as a `Watch`. Queued rather than sent directly because input
     /// handling is synchronous and owns no channel — the same shape as
@@ -237,6 +271,7 @@ impl App {
             pending_center: None,
             pending_seek: None,
             rail: Default::default(),
+            snapshots: Vec::new(),
             pending_watch: None,
         }
     }
@@ -404,6 +439,7 @@ impl App {
                     }
                     self.timeline.append_live(activity);
                     self.timeline.folded = self.timeline.items.len();
+                    self.note_fold();
                     self.commit_fold(structural);
                 } else {
                     // Scrubbed back: new live data extends the (sorted) timeline
@@ -460,6 +496,10 @@ impl App {
                 self.others.remove(&session_id);
                 self.current_session_id = session_id.clone();
                 self.session = SessionModel::new(session_id);
+                // A different session (or a truncated one) shares nothing with
+                // the rungs we hold, and a fresh `Timeline` restarts the
+                // generation counter — so they cannot be told apart by it.
+                self.snapshots.clear();
                 // A reset is a fresh live timeline (only live emits resets — the
                 // initial announce, truncation, or auto-switch). Replay arrives
                 // via ReplayLoaded, never a reset.
@@ -507,12 +547,67 @@ impl App {
         if target <= self.timeline.folded {
             return;
         }
-        let mut structural = false;
-        for i in self.timeline.folded..target {
-            structural |= self.session.apply_update(&self.timeline.items[i].update);
-        }
+        let structural = self.fold_range(self.timeline.folded, target);
         self.timeline.folded = target;
         self.commit_fold(structural);
+    }
+
+    /// Fold `items[from..to]` into the model, taking a ladder rung every
+    /// [`SNAPSHOT_STRIDE`] items. Returns whether anything structural changed.
+    ///
+    /// Rungs are taken INSIDE the loop, not after it: a jump straight to the
+    /// live edge folds the whole timeline in one call, and a ladder that only
+    /// recorded where each fold *ended* would hold a single rung at the edge —
+    /// useless for seeking backward, which needs a rung at or before its target.
+    fn fold_range(&mut self, from: usize, to: usize) -> bool {
+        let generation = self.timeline.generation;
+        self.drop_stale_rungs(generation);
+        let mut structural = false;
+        for i in from..to {
+            structural |= self.session.apply_update(&self.timeline.items[i].update);
+            let folded = i + 1;
+            let last = self.snapshots.last().map_or(0, |s| s.folded);
+            if folded >= last + SNAPSHOT_STRIDE {
+                self.snapshots.push(Snapshot {
+                    folded,
+                    generation,
+                    model: self.session.clone(),
+                });
+            }
+        }
+        structural
+    }
+
+    /// Record a ladder rung for a fold that did not go through
+    /// [`fold_range`](Self::fold_range) — the live `Batch` path, which applies
+    /// updates directly (the model is order-independent) and jumps `folded` to
+    /// the edge. Successive batches leave rungs roughly a stride apart, which
+    /// is what a later backward seek restores from.
+    fn note_fold(&mut self) {
+        let generation = self.timeline.generation;
+        self.drop_stale_rungs(generation);
+        let folded = self.timeline.folded;
+        let last = self.snapshots.last().map_or(0, |s| s.folded);
+        if folded >= last + SNAPSHOT_STRIDE {
+            self.snapshots.push(Snapshot {
+                folded,
+                generation,
+                model: self.session.clone(),
+            });
+        }
+    }
+
+    /// Discard every rung if the item list has been re-sorted or replaced since
+    /// they were taken. Generation is monotonic, so one stale rung means all of
+    /// them are stale.
+    fn drop_stale_rungs(&mut self, generation: u64) {
+        if self
+            .snapshots
+            .last()
+            .is_some_and(|s| s.generation != generation)
+        {
+            self.snapshots.clear();
+        }
     }
 
     /// Post-apply step shared by `fold_to` (forward, index-based — replay pacing
@@ -612,9 +707,7 @@ impl App {
         if target < self.timeline.folded {
             self.rebuild_to(target);
         } else {
-            for i in self.timeline.folded..target {
-                self.session.apply_update(&self.timeline.items[i].update);
-            }
+            self.fold_range(self.timeline.folded, target);
             self.timeline.folded = target;
             self.resync();
         }
@@ -653,12 +746,39 @@ impl App {
             .map(|n| (n.id.clone(), (n.position.x, n.position.y)))
             .collect();
 
-        // Fresh model + flow, re-fold the prefix.
-        self.session = SessionModel::new(self.current_session_id.clone());
-        self.flow = graph::new_flow();
-        for i in 0..target {
-            self.session.apply_update(&self.timeline.items[i].update);
+        // Start from the newest ladder rung at or before the target instead of
+        // from item zero. Restoring a rung is a clone of a persistent model —
+        // O(1) — so the fold that follows is bounded by SNAPSHOT_STRIDE rather
+        // than by how far back the user seeked.
+        let generation = self.timeline.generation;
+        if self
+            .snapshots
+            .last()
+            .is_some_and(|s| s.generation != generation)
+        {
+            self.snapshots.clear();
         }
+        let resume = self
+            .snapshots
+            .iter()
+            .rev()
+            .find(|s| s.folded <= target)
+            .map(|s| (s.model.clone(), s.folded));
+
+        let start = match resume {
+            Some((model, folded)) => {
+                self.session = model;
+                folded
+            }
+            None => {
+                self.session = SessionModel::new(self.current_session_id.clone());
+                0
+            }
+        };
+        self.flow = graph::new_flow();
+        // Re-folding also rebuilds the ladder above `start`, so a scrub that
+        // walks backward repeatedly keeps finding rungs near where it lands.
+        self.fold_range(start, target);
         self.timeline.folded = target;
         self.resync();
 
@@ -1312,6 +1432,102 @@ mod tests {
         );
         assert_eq!(app.camera, Camera::Manual);
         assert!(app.camera_glide.is_none(), "user pan must cancel the glide");
+    }
+
+    /// The ladder is only allowed to be FASTER. Restoring a rung and folding
+    /// forward from it must land on exactly the model a from-scratch rebuild
+    /// would produce — otherwise a backward seek silently shows a different
+    /// session than the same seek did yesterday.
+    #[test]
+    fn a_ladder_restore_matches_a_full_rebuild() {
+        // Enough items that several rungs are taken.
+        let count = SNAPSHOT_STRIDE * 3 + 17;
+        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+        let items = |n: usize| -> Vec<crate::tailer::ReplayItem> {
+            (0..n)
+                .map(|i| {
+                    crate::tailer::ReplayItem::at(
+                        Some(t0 + chrono::Duration::seconds(i as i64)),
+                        // Re-touch earlier agents as well as adding new ones, so
+                        // the fold is not purely insert-only.
+                        meta_update(&format!("sub{}", i % (n / 4).max(1))),
+                    )
+                })
+                .collect()
+        };
+
+        let load = |app: &mut App| {
+            app.handle_ui_event(UiEvent::ReplayLoaded {
+                session_id: "s".into(),
+                items: items(count),
+                speed: 8.0,
+                info: Default::default(),
+            });
+            app.go_live();
+        };
+
+        let target = SNAPSHOT_STRIDE * 2 + 5;
+
+        // With the ladder: fold to the edge (taking rungs), then seek back.
+        let mut laddered = App::new("s".to_string(), Mode::Replay);
+        load(&mut laddered);
+        assert!(
+            laddered.snapshots.len() >= 3,
+            "expected several rungs, got {}",
+            laddered.snapshots.len()
+        );
+        laddered.seek_to_fraction(target as f64 / count as f64);
+        let restored_from = laddered.timeline.folded;
+
+        // Without: same App, same seek, but the ladder emptied first so
+        // `rebuild_to` has to fold from item zero.
+        let mut plain = App::new("s".to_string(), Mode::Replay);
+        load(&mut plain);
+        plain.snapshots.clear();
+        plain.seek_to_fraction(target as f64 / count as f64);
+
+        assert_eq!(
+            restored_from, plain.timeline.folded,
+            "both paths must land on the same item"
+        );
+        assert!(
+            laddered.session == plain.session,
+            "ladder restore diverged from a full rebuild"
+        );
+    }
+
+    /// A re-sort moves existing items, so every rung taken before it describes
+    /// a prefix that no longer exists. They must be discarded, not restored.
+    #[test]
+    fn a_generation_bump_voids_the_ladder() {
+        let mut app = App::new("s".to_string(), Mode::Live);
+        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+        app.handle_ui_event(UiEvent::ReplayLoaded {
+            session_id: "s".into(),
+            items: (0..SNAPSHOT_STRIDE * 2)
+                .map(|i| {
+                    crate::tailer::ReplayItem::at(
+                        Some(t0 + chrono::Duration::seconds(i as i64)),
+                        meta_update(&format!("sub{i}")),
+                    )
+                })
+                .collect(),
+            speed: 8.0,
+            info: Default::default(),
+        });
+        app.go_live();
+        assert!(!app.snapshots.is_empty(), "rungs were taken");
+
+        // Simulate the re-sort that `append_live` performs when a late batch
+        // dates a previously-pending item.
+        app.timeline.generation = app.timeline.generation.wrapping_add(1);
+        app.seek_to_fraction(0.25);
+        assert!(
+            app.snapshots
+                .iter()
+                .all(|s| s.generation == app.timeline.generation),
+            "a stale-generation rung survived the seek"
+        );
     }
 
     #[test]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -821,6 +821,8 @@ impl App {
         }
         if structural {
             self.layout_dirty = true;
+            // A session that just gained a node may now overlap its neighbour.
+            graph::repack_if_overlapping(&mut self.flow);
         }
         structural
     }
@@ -856,6 +858,7 @@ impl App {
         model.recompute_liveness(Some(now));
         if graph::sync(&mut self.flow, model, false) {
             self.layout_dirty = true;
+            graph::repack_if_overlapping(&mut self.flow);
         }
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -112,11 +112,10 @@ impl CameraGlide {
 /// shares structure with its neighbours instead of copying the model.
 ///
 /// Measured on the pathological bench scale (~31k items, 293 agents), halving
-/// this to 512 bought no measurable seek time but cost ~9 MB of retained
-/// rungs. That is because the fold is no longer what a backward seek spends
-/// its time on: `rebuild_to` still discards the whole `Flow` and re-projects
-/// every node, which dominates whatever the fold costs. Shrink this only once
-/// that is fixed — until then it would buy memory for nothing.
+/// this to 512 bought no measurable seek time but cost several MB of retained
+/// rungs — the fold between two rungs is not what a backward seek spends its
+/// time on. Shrink it only against a measurement that says the fold has become
+/// the cost; until then it would buy memory for nothing.
 const SNAPSHOT_STRIDE: usize = 1024;
 
 /// A folded model captured at a known point on the timeline.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -369,15 +369,72 @@ impl App {
     /// there is nowhere to move.
     pub fn focus_session(&mut self, delta: isize) {
         if let Some(path) = self.rail.step_focus(&self.current_session_id, delta) {
-            self.pending_watch = Some(path);
+            self.watch_session(path);
         }
     }
 
     /// Ask to watch the rail row at `index` (a click).
     pub fn focus_session_index(&mut self, index: usize) {
         if let Some(path) = self.rail.focus_index(&self.current_session_id, index) {
-            self.pending_watch = Some(path);
+            self.watch_session(path);
         }
+    }
+
+    /// Switch the focused session to the one at `path`.
+    ///
+    /// The switch happens HERE, not when the tailer reports back. The tailer no
+    /// longer announces which session it attached to — it watches what it is
+    /// told and stamps events with that id — so the App is the only thing that
+    /// knows a switch happened, and the only thing that can reset the timeline
+    /// for it. Doing it here also means the id is right before the first batch
+    /// of the new session arrives, so nothing is dropped or misrouted.
+    fn watch_session(&mut self, path: std::path::PathBuf) {
+        let session_id = crate::transcript::session_id_from_path(&path);
+        if session_id.is_empty() || self.is_current(&session_id) {
+            return;
+        }
+        // The session being left keeps its place on the canvas only if
+        // something still feeds it; the supervisor decides that on its next
+        // sweep. Drop its focused model either way — a monitor will rebuild it.
+        graph::remove_session(&mut self.flow, &self.current_session_id);
+        // The session being entered may already be on the canvas as a monitored
+        // one; the focused model replaces it, and two models projecting the
+        // same node ids would fight over every card's content.
+        self.others.remove(&session_id);
+
+        self.current_session_id = session_id.clone();
+        self.session = SessionModel::new(session_id);
+        self.timeline = Timeline::new();
+        self.snapshots.clear();
+        self.chips.clear();
+        self.camera = Camera::Overview;
+        self.camera_glide = None;
+        self.detail_scroll = 0;
+        self.detail_follow = true;
+        self.layout_dirty = false;
+        self.pending_watch = Some(path);
+    }
+
+    /// Focus the session a just-selected node belongs to, if it is not already
+    /// the focused one.
+    ///
+    /// The switch is queued like any other (`pending_watch`), so the model and
+    /// timeline arrive a frame or two later; the selection itself survives
+    /// because node ids are session-qualified and stable across the switch.
+    fn focus_selected_session(&mut self, node_id: &str) {
+        let Some((session, _)) = graph::split_node_id(node_id) else {
+            return;
+        };
+        if session == self.current_session_id {
+            return;
+        }
+        // Only sessions discovery knows about can be watched — it is the rail
+        // row that carries the transcript path.
+        let Some(row) = self.rail.rows.iter().find(|r| r.session_id == session) else {
+            return;
+        };
+        let path = row.main_path.clone();
+        self.watch_session(path);
     }
 
     /// The rail row for the session being watched, if the rail lists it.
@@ -408,7 +465,12 @@ impl App {
                 session_id,
                 updates,
             } => {
+                // Not the focused session: it is one of the others sharing the
+                // canvas. Same event, routed by id — the App is the only thing
+                // that knows which session is focused, so it is the only thing
+                // that should be deciding this.
                 if !self.is_current(&session_id) {
+                    self.fold_other(&session_id, updates);
                     return;
                 }
                 // Route untimed session-level metadata to the info store; only
@@ -476,35 +538,33 @@ impl App {
                 self.fold_to(target);
             }
             UiEvent::SessionReset { session_id } => {
-                // Truncation/rotation/switch: adopt the new id and rebuild
-                // from scratch so stale nodes don't linger. The tailer's
-                // initial ANNOUNCE arrives as a same-id reset on a still-empty
-                // graph — there is nothing to wipe, and resetting view state
-                // there would clobber a camera/pin choice the user made while
-                // waiting for the session to appear.
+                // A monitored session truncated or rotated: drop it and let its
+                // own tailer re-attach. Never touches the focused session.
+                if !self.is_current(&session_id) {
+                    self.forget_session(&session_id);
+                    return;
+                }
+
+                // The focused session truncated or rotated. Rebuild it from
+                // scratch so stale nodes cannot linger — but take only ITS
+                // subtree off the canvas; the rest belongs to other sessions
+                // that are still being fed.
                 let had_nodes = self
                     .flow
                     .nodes()
                     .any(|n| graph::split_node_id(&n.id).is_some_and(|(s, _)| s == session_id));
-                let genuine = !self.is_current(&session_id) || had_nodes;
-                // Take only the OLD focused session off the canvas — a whole
-                // flow rebuild would drop every OTHER session's nodes too.
-                graph::remove_session(&mut self.flow, &self.current_session_id);
-                // Switching to a session that was being monitored: the focused
-                // model replaces its monitored one, which would otherwise
-                // render the same agents twice.
-                self.others.remove(&session_id);
-                self.current_session_id = session_id.clone();
+                graph::remove_session(&mut self.flow, &session_id);
                 self.session = SessionModel::new(session_id);
-                // A different session (or a truncated one) shares nothing with
-                // the rungs we hold, and a fresh `Timeline` restarts the
-                // generation counter — so they cannot be told apart by it.
+                // The rungs describe a file that no longer exists, and a fresh
+                // `Timeline` restarts the generation counter — so they could not
+                // be told apart by it either.
                 self.snapshots.clear();
-                // A reset is a fresh live timeline (only live emits resets — the
-                // initial announce, truncation, or auto-switch). Replay arrives
-                // via ReplayLoaded, never a reset.
+                // A reset is a fresh live timeline (only live emits resets).
+                // Replay arrives via `ReplayLoaded`, never a reset.
                 self.timeline = Timeline::new();
-                if genuine {
+                // An empty graph means nothing was showing yet, so resetting the
+                // view would clobber a camera choice made while waiting.
+                if had_nodes {
                     self.camera = Camera::Overview;
                     self.detail_scroll = 0;
                     self.detail_follow = true;
@@ -513,20 +573,19 @@ impl App {
                     self.camera_glide = None;
                 }
             }
-            UiEvent::MonitorBatch {
-                session_id,
-                updates,
-            } => {
-                // `fold_other` projects just this session — see its docs.
-                self.fold_other(&session_id, updates);
-            }
-            UiEvent::MonitorReset { session_id } => {
-                self.forget_session(&session_id);
-            }
             UiEvent::Sessions(rows) => {
                 // Not gated on `is_current`: a sweep describes the whole
                 // workspace, not one session, so it is never stale for the
                 // watched one.
+                // Launched on a project with no session yet: adopt the first
+                // one discovery names, so the tailer gets a concrete file and
+                // the canvas has something to show.
+                if self.current_session_id.is_empty()
+                    && let Some(first) = rows.first()
+                {
+                    let path = first.main_path.clone();
+                    self.watch_session(path);
+                }
                 self.apply_session_labels(&rows);
                 self.rail.adopt(rows);
             }
@@ -1174,7 +1233,7 @@ mod tests {
         });
 
         // A monitored session, folded straight off its live edge.
-        app.handle_ui_event(UiEvent::MonitorBatch {
+        app.handle_ui_event(UiEvent::Batch {
             session_id: "other".into(),
             updates: vec![meta_update("sub-b")],
         });
@@ -1203,7 +1262,7 @@ mod tests {
 
         // When it stops being live, it leaves the canvas without disturbing
         // the focused session.
-        app.handle_ui_event(UiEvent::MonitorReset {
+        app.handle_ui_event(UiEvent::SessionReset {
             session_id: "other".into(),
         });
         assert!(!has(&app, "other", "main"));
@@ -1257,11 +1316,16 @@ mod tests {
         let mut app = App::new("s".into(), Mode::Live);
         assert_eq!(app.camera, Camera::Overview);
 
+        // Something is showing, then the session is truncated…
+        app.handle_ui_event(UiEvent::Batch {
+            session_id: "s".into(),
+            updates: vec![meta_update("sub")],
+        });
         app.camera = Camera::Manual; // user took the camera…
         app.handle_ui_event(UiEvent::SessionReset {
-            session_id: "s2".into(),
+            session_id: "s".into(),
         });
-        // …but a fresh session re-engages the default.
+        // …and a session rebuilt from nothing re-engages the default.
         assert_eq!(app.camera, Camera::Overview);
     }
 
@@ -1472,7 +1536,7 @@ mod tests {
 
         // A second session shares the canvas, and must be untouched by a seek
         // in the focused one.
-        app.handle_ui_event(UiEvent::MonitorBatch {
+        app.handle_ui_event(UiEvent::Batch {
             session_id: "other".into(),
             updates: vec![meta_update("watched")],
         });

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1015,12 +1015,6 @@ impl App {
         }
     }
 
-    /// Every watched session id, focused first.
-    pub fn watched_sessions(&self) -> impl Iterator<Item = &str> {
-        std::iter::once(self.current_session_id.as_str())
-            .chain(self.others.keys().map(String::as_str))
-    }
-
     /// Tidy the graph on demand (`r`): run Sugiyama now and reframe for the
     /// current camera. Layout is never automatic (see `resync`),
     /// so this is the user's explicit "rearrange". Forces a pass even when not
@@ -1323,7 +1317,11 @@ mod tests {
         // session's model is untouched by it.
         assert!(app.others.contains_key("other"));
         assert!(app.session.agent("sub-b").is_none());
-        assert_eq!(app.watched_sessions().count(), 2);
+        assert_eq!(
+            1 + app.others.len(),
+            2,
+            "the focused session plus one other"
+        );
 
         // Selecting a monitored node reports no agent in the FOCUSED model —
         // the detail panel reads that model, and would otherwise render blank

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -108,8 +108,19 @@ impl CameraGlide {
 pub struct App {
     /// The rendered flow graph (agent cards + step edges).
     pub flow: AgentFlow,
-    /// The pure domain model the graph is projected from.
+    /// The pure domain model the graph is projected from — the **focused**
+    /// session: the one the timeline, scrubber and detail panel are bound to.
     pub session: SessionModel,
+    /// Models for every other watched session, keyed by session id.
+    ///
+    /// Deliberately separate from [`session`](Self::session) rather than one
+    /// map holding all of them, because the asymmetry is real: the focused
+    /// session has a [`Timeline`] and can be scrubbed, the others are folded
+    /// straight off their live edge and only ever render. Flattening the two
+    /// would mean either giving every session a timeline it never uses, or
+    /// pretending the focused one is not special when every seek path says it
+    /// is. Never contains [`current_session_id`](Self::current_session_id).
+    pub others: std::collections::BTreeMap<String, SessionModel>,
     /// Live vs replay.
     pub mode: Mode,
     /// Play/pause state — freezes the playhead in **both** replay and live (a
@@ -153,6 +164,9 @@ pub struct App {
     /// Screen rect of the scrubber bar from the last render, so the input
     /// handler can map a click/drag on it to a seek. `None` when not drawn.
     pub scrubber_area: Option<ratatui::layout::Rect>,
+    /// Inner rect of the session rail from the last render, so a click can be
+    /// mapped back to a row. `None` when the rail is not drawn.
+    pub rail_area: Option<ratatui::layout::Rect>,
     /// Cached per-column scrubber tallies (head-independent), recomputed only when
     /// the item count or bar width changes — not every frame. See
     /// [`crate::ui::ScrubberTally`].
@@ -180,6 +194,16 @@ pub struct App {
     /// costs ONE seek (a backward seek rebuilds the whole model), not one per
     /// mouse event.
     pub pending_seek: Option<f64>,
+    /// Every live session, and how the workspace is laid out. Populated by
+    /// [`UiEvent::Sessions`](crate::tailer::UiEvent::Sessions) sweeps; empty in
+    /// the browser frontend, which has no filesystem to sweep.
+    pub rail: crate::state::rail::SessionRail,
+    /// A session the user asked to focus, queued for the event loop to send to
+    /// the tailer as a `Watch`. Queued rather than sent directly because input
+    /// handling is synchronous and owns no channel — the same shape as
+    /// [`pending_seek`](Self::pending_seek) and
+    /// [`pending_center`](Self::pending_center).
+    pub pending_watch: Option<std::path::PathBuf>,
 }
 
 impl App {
@@ -189,6 +213,7 @@ impl App {
         App {
             flow: graph::new_flow(),
             session: SessionModel::new(session_id.clone()),
+            others: std::collections::BTreeMap::new(),
             mode,
             is_paused: false,
             current_session_id: session_id,
@@ -203,6 +228,7 @@ impl App {
             camera_glide: None,
             timeline: Timeline::new(),
             scrubber_area: None,
+            rail_area: None,
             scrubber_tally: None,
             era_cache: None,
             last_batch_at: None,
@@ -210,6 +236,8 @@ impl App {
             show_info: false,
             pending_center: None,
             pending_seek: None,
+            rail: Default::default(),
+            pending_watch: None,
         }
     }
 
@@ -297,6 +325,31 @@ impl App {
         }
     }
 
+    /// Ask to watch the session `delta` rows away in the rail.
+    ///
+    /// Queues the switch rather than performing it: the tailer owns which files
+    /// are open, and it reports the change back as a
+    /// [`SessionReset`](crate::tailer::UiEvent::SessionReset), which is what
+    /// moves `current_session_id` and therefore the rail's marker. A no-op when
+    /// there is nowhere to move.
+    pub fn focus_session(&mut self, delta: isize) {
+        if let Some(path) = self.rail.step_focus(&self.current_session_id, delta) {
+            self.pending_watch = Some(path);
+        }
+    }
+
+    /// Ask to watch the rail row at `index` (a click).
+    pub fn focus_session_index(&mut self, index: usize) {
+        if let Some(path) = self.rail.focus_index(&self.current_session_id, index) {
+            self.pending_watch = Some(path);
+        }
+    }
+
+    /// The rail row for the session being watched, if the rail lists it.
+    pub fn focused_row(&self) -> Option<&crate::state::rail::RailRow> {
+        self.rail.focused_row(&self.current_session_id)
+    }
+
     /// Re-pin to the timeline edge ("go live" / jump to end) and resume playback.
     pub fn go_live(&mut self) {
         self.is_paused = false;
@@ -309,10 +362,11 @@ impl App {
 
     /// Fold a tailer [`UiEvent`] into state.
     ///
-    /// Drops events whose `session_id` is not [current](Self::is_current),
-    /// applies batched updates to the [`SessionModel`], re-syncs the graph, and
-    /// re-fits the view on structural changes while the follow camera is
-    /// engaged. Switches the current session id on reset.
+    /// Routes by `session_id` rather than dropping: the canvas shows every
+    /// watched session, so a batch for a session that is not focused folds into
+    /// [`others`](Self::others) instead of being discarded. Only the focused
+    /// session's batches reach the [`Timeline`] — see
+    /// [`fold_other`](Self::fold_other).
     pub fn handle_ui_event(&mut self, event: UiEvent) {
         match event {
             UiEvent::Batch {
@@ -392,10 +446,20 @@ impl App {
                 // graph — there is nothing to wipe, and resetting view state
                 // there would clobber a camera/pin choice the user made while
                 // waiting for the session to appear.
-                let genuine = !self.is_current(&session_id) || self.flow.nodes().count() > 0;
+                let had_nodes = self
+                    .flow
+                    .nodes()
+                    .any(|n| graph::split_node_id(&n.id).is_some_and(|(s, _)| s == session_id));
+                let genuine = !self.is_current(&session_id) || had_nodes;
+                // Take only the OLD focused session off the canvas — a whole
+                // flow rebuild would drop every OTHER session's nodes too.
+                graph::remove_session(&mut self.flow, &self.current_session_id);
+                // Switching to a session that was being monitored: the focused
+                // model replaces its monitored one, which would otherwise
+                // render the same agents twice.
+                self.others.remove(&session_id);
                 self.current_session_id = session_id.clone();
                 self.session = SessionModel::new(session_id);
-                self.flow = graph::new_flow();
                 // A reset is a fresh live timeline (only live emits resets — the
                 // initial announce, truncation, or auto-switch). Replay arrives
                 // via ReplayLoaded, never a reset.
@@ -408,6 +472,23 @@ impl App {
                     self.chips.clear();
                     self.camera_glide = None;
                 }
+            }
+            UiEvent::MonitorBatch {
+                session_id,
+                updates,
+            } => {
+                // `fold_other` projects just this session — see its docs.
+                self.fold_other(&session_id, updates);
+            }
+            UiEvent::MonitorReset { session_id } => {
+                self.forget_session(&session_id);
+            }
+            UiEvent::Sessions(rows) => {
+                // Not gated on `is_current`: a sweep describes the whole
+                // workspace, not one session, so it is never stale for the
+                // watched one.
+                self.apply_session_labels(&rows);
+                self.rail.adopt(rows);
             }
             UiEvent::Error(msg) => {
                 self.last_error = Some(msg);
@@ -559,8 +640,9 @@ impl App {
     /// rebuild: node positions (the user's arrangement / a stable layout) and
     /// the selected node are carried over by id.
     fn rebuild_to(&mut self, target: usize) {
-        // Snapshot view state to carry across the wipe.
-        let selected = self.selected_agent_id();
+        // Snapshot view state to carry across the wipe. The FLOW id, not the
+        // local agent id — `select_node` speaks flow ids.
+        let selected = self.selected_node_id();
         // The camera/viewport (pan + zoom) is the user's — a fresh `Flow` would
         // reset it to the origin, snapping the graph on every backward seek even
         // in Manual/Overview. Carry it across.
@@ -607,11 +689,101 @@ impl App {
         // fanned past siblings) and nothing existing moves until the user asks
         // to tidy (`r`, or re-engaging the camera with `o`/`f`). `layout_dirty`
         // tracks that there is un-applied growth for the on-demand path.
-        let structural = graph::sync(&mut self.flow, &self.session, false);
+        let mut structural = graph::sync(&mut self.flow, &self.session, false);
+        // Every other watched session is on the same canvas. Their liveness is
+        // wall-clock derived (they have no playhead of their own), and their
+        // workflow rollups need the same pass the focused session gets.
+        let now = chrono::Utc::now();
+        for model in self.others.values_mut() {
+            model.recompute_workflow_status();
+            model.recompute_liveness(Some(now));
+            structural |= graph::sync(&mut self.flow, model, false);
+        }
         if structural {
             self.layout_dirty = true;
         }
         structural
+    }
+
+    /// Fold a batch belonging to a session that is NOT focused.
+    ///
+    /// Straight into that session's model — no timeline, so no pacing and no
+    /// seeking. A monitored session is something you watch move, not something
+    /// you scrub; giving it a playhead would mean holding its whole item list
+    /// for a view that only ever shows the live edge.
+    fn fold_other(&mut self, session_id: &str, updates: Vec<crate::tailer::Update>) {
+        // A monitor's batch can still be in flight when its session becomes the
+        // focused one. Folding it here would build a second model projecting
+        // onto the same node ids as the focused model, and the two would
+        // overwrite each other's card content every sync.
+        if self.is_current(session_id) {
+            return;
+        }
+        let now = chrono::Utc::now();
+        let model = self
+            .others
+            .entry(session_id.to_string())
+            .or_insert_with(|| SessionModel::new(session_id.to_string()));
+        for update in &updates {
+            model.apply_update(update);
+        }
+        // Project ONLY this session. Every monitor polls several times a second
+        // and a full `resync` walks every agent of every model, so syncing the
+        // whole canvas per batch scales with sessions squared for no reason —
+        // nothing else changed. Time-derived liveness for the other sessions is
+        // refreshed by `status_tick` regardless.
+        model.recompute_workflow_status();
+        model.recompute_liveness(Some(now));
+        if graph::sync(&mut self.flow, model, false) {
+            self.layout_dirty = true;
+        }
+    }
+
+    /// Name each watched session's root card from the sweep's project names.
+    ///
+    /// The models are folded from transcripts, which do not carry a project
+    /// name; the sweep reads it from each session's `cwd`. Applied on every
+    /// sweep rather than once, because a session can be folded from its batches
+    /// before discovery has ever described it.
+    fn apply_session_labels(&mut self, rows: &[crate::state::rail::RailRow]) {
+        let mut changed = false;
+        for row in rows {
+            let label = Some(row.project.clone());
+            if self.is_current(&row.session_id) {
+                if self.session.label != label {
+                    self.session.label = label;
+                    changed = true;
+                }
+            } else if let Some(model) = self.others.get_mut(&row.session_id)
+                && model.label != label
+            {
+                model.label = label;
+                changed = true;
+            }
+        }
+        // One resync for the whole sweep: it walks every agent of every model,
+        // so doing it per row would scale with sessions squared.
+        if changed {
+            self.resync();
+        }
+    }
+
+    /// Stop watching `session_id`: drop its model and take its subtree off the
+    /// canvas. No-op for the focused session, which is owned elsewhere.
+    pub fn forget_session(&mut self, session_id: &str) {
+        if session_id == self.current_session_id {
+            return;
+        }
+        if self.others.remove(session_id).is_some() {
+            graph::remove_session(&mut self.flow, session_id);
+            self.layout_dirty = true;
+        }
+    }
+
+    /// Every watched session id, focused first.
+    pub fn watched_sessions(&self) -> impl Iterator<Item = &str> {
+        std::iter::once(self.current_session_id.as_str())
+            .chain(self.others.keys().map(String::as_str))
     }
 
     /// Tidy the graph on demand (`r`): run Sugiyama now and reframe for the
@@ -661,15 +833,17 @@ impl App {
     /// is an eased glide (`focus_camera` + per-frame
     /// [`tick_camera`](Self::tick_camera)) rather than a teleport.
     pub fn track_activity(&mut self) {
-        let Some(id) = self.session.last_active_agent_id() else {
+        let Some(agent) = self.session.last_active_agent_id() else {
             return;
         };
+        // Model id → flow id: the camera and selection speak flow ids.
+        let id = self.node_id(&agent);
         self.center_node(&id, true); // Follow: clamp zoom for readability.
         // In Follow the panel narrates the followed agent. `select_node` is quiet
         // (no SelectionChanged), so this never trips the drop-Follow detection in
         // the handler — a user selection, which does fire it, drops to Manual and
         // stops this auto-narration entirely.
-        if self.selected_agent_id().as_deref() != Some(id.as_str()) {
+        if self.selected_agent_id().as_deref() != Some(agent.as_str()) {
             self.flow.select_node(&id);
             self.detail_scroll = 0;
             self.detail_follow = true;
@@ -764,7 +938,23 @@ impl App {
     /// The node id of the currently selected agent, if any (read from the flow
     /// during render; copy it out before borrowing `app` mutably).
     pub fn selected_agent_id(&self) -> Option<String> {
+        let node = self.selected_node_id()?;
+        let (session, agent) = graph::split_node_id(&node)?;
+        // A node from another session has no agent in THIS model; returning its
+        // id would make the detail panel look it up here and come back empty.
+        (session == self.current_session_id).then(|| agent.to_string())
+    }
+
+    /// The selected node's `Flow` id — session-qualified, unlike
+    /// [`selected_agent_id`](Self::selected_agent_id). This is what the camera
+    /// and selection APIs take.
+    pub fn selected_node_id(&self) -> Option<String> {
         self.flow.selected_nodes().next().map(|n| n.id.clone())
+    }
+
+    /// The `Flow` node id for an agent in the session being watched.
+    pub fn node_id(&self, agent: &str) -> String {
+        graph::node_id(&self.current_session_id, agent)
     }
 
     /// Unified play/pause (`space`) that works from any state — **including at a
@@ -838,6 +1028,76 @@ mod tests {
                 stopped_by_user: None,
             },
         }
+    }
+
+    /// The whole point of the canvas: sessions the user is NOT focused on are
+    /// folded and drawn too, each under its own root.
+    #[test]
+    fn the_canvas_shows_every_watched_session() {
+        let mut app = App::new("focused".to_string(), Mode::Live);
+        let t: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+
+        // The focused session, through the timeline as usual.
+        app.handle_ui_event(UiEvent::ReplayLoaded {
+            session_id: "focused".into(),
+            items: vec![crate::tailer::ReplayItem::at(Some(t), meta_update("sub-a"))],
+            speed: 8.0,
+            info: Default::default(),
+        });
+
+        // A monitored session, folded straight off its live edge.
+        app.handle_ui_event(UiEvent::MonitorBatch {
+            session_id: "other".into(),
+            updates: vec![meta_update("sub-b")],
+        });
+
+        fn has(app: &App, session: &str, agent: &str) -> bool {
+            app.flow.node(&graph::node_id(session, agent)).is_some()
+        }
+        assert!(has(&app, "focused", "main"), "focused root");
+        assert!(has(&app, "focused", "sub-a"), "focused subagent");
+        assert!(has(&app, "other", "main"), "monitored root");
+        assert!(has(&app, "other", "sub-b"), "monitored subagent");
+
+        // The monitored session has a model of its own, and the focused
+        // session's model is untouched by it.
+        assert!(app.others.contains_key("other"));
+        assert!(app.session.agent("sub-b").is_none());
+        assert_eq!(app.watched_sessions().count(), 2);
+
+        // Selecting a monitored node reports no agent in the FOCUSED model —
+        // the detail panel reads that model, and would otherwise render blank
+        // for a node that plainly exists.
+        app.flow.select_node(&graph::node_id("other", "sub-b"));
+        assert!(app.selected_agent_id().is_none());
+        app.flow.select_node(&graph::node_id("focused", "sub-a"));
+        assert_eq!(app.selected_agent_id().as_deref(), Some("sub-a"));
+
+        // When it stops being live, it leaves the canvas without disturbing
+        // the focused session.
+        app.handle_ui_event(UiEvent::MonitorReset {
+            session_id: "other".into(),
+        });
+        assert!(!has(&app, "other", "main"));
+        assert!(has(&app, "focused", "main"));
+        assert!(app.others.is_empty());
+    }
+
+    /// A monitor batch that arrives after its session became the focused one
+    /// must be ignored: two models projecting onto the same node ids would
+    /// overwrite each other's card content on every sync.
+    #[test]
+    fn a_late_monitor_batch_cannot_shadow_the_focused_session() {
+        let mut app = App::new("s".to_string(), Mode::Live);
+        app.handle_ui_event(UiEvent::MonitorBatch {
+            session_id: "s".into(),
+            updates: vec![meta_update("sub")],
+        });
+        assert!(
+            app.others.is_empty(),
+            "no shadow model for the focused session"
+        );
+        assert!(app.session.agent("sub").is_none());
     }
 
     #[test]
@@ -1002,7 +1262,10 @@ mod tests {
         let area = ratatui::layout::Rect::new(0, 0, 100, 30);
         let mut buf = ratatui::buffer::Buffer::empty(area);
         (&mut app.flow).render(area, &mut buf);
-        assert!(app.flow.node("sub1").is_some(), "the subagent node exists");
+        assert!(
+            app.flow.node(&app.node_id("sub1")).is_some(),
+            "the subagent node exists"
+        );
 
         // Zoom OUT past the readable band — the clamp WOULD want to snap it in.
         app.flow.zoom_to(0.3);
@@ -1010,7 +1273,8 @@ mod tests {
         assert!(zoom < FOLLOW_ZOOM);
 
         // Manual spatial-nav (clamp_zoom = false) → pans, leaves the zoom alone.
-        app.center_node("sub1", false);
+        let node = app.node_id("sub1");
+        app.center_node(&node, false);
         assert_eq!(
             app.flow.viewport.zoom, zoom,
             "arrow-nav must not touch the user's zoom"
@@ -1018,7 +1282,7 @@ mod tests {
 
         // Follow / explicit center (clamp_zoom = true) → snaps the zoom in for
         // readability — the movement that used to ride along with every arrow.
-        app.center_node("sub1", true);
+        app.center_node(&app.node_id("sub1"), true);
         assert!(
             app.flow.viewport.zoom > zoom,
             "Follow still bumps zoom for readability"
@@ -1074,7 +1338,8 @@ mod tests {
         // Seek to the end: forward fold brings sub2 in. Select it... then sub1.
         app.seek(t2);
         assert!(app.session.agent("sub2").is_some());
-        app.flow.select_node("sub1");
+        let node = app.node_id("sub1");
+        app.flow.select_node(&node);
 
         // Seek back before sub2 existed: rebuild must drop it AND keep selection.
         app.seek("2026-06-05T10:00:05.000Z".parse().unwrap());

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -565,17 +565,23 @@ impl App {
         let mut structural = false;
         for i in from..to {
             structural |= self.session.apply_update(&self.timeline.items[i].update);
-            let folded = i + 1;
-            let last = self.snapshots.last().map_or(0, |s| s.folded);
-            if folded >= last + SNAPSHOT_STRIDE {
-                self.snapshots.push(Snapshot {
-                    folded,
-                    generation,
-                    model: self.session.clone(),
-                });
-            }
+            self.maybe_snapshot(i + 1, generation);
         }
         structural
+    }
+
+    /// Push a rung if `folded` is a full stride past the last one.
+    ///
+    /// Shared by both fold paths so the cadence cannot drift between them.
+    fn maybe_snapshot(&mut self, folded: usize, generation: u64) {
+        let last = self.snapshots.last().map_or(0, |s| s.folded);
+        if folded >= last + SNAPSHOT_STRIDE {
+            self.snapshots.push(Snapshot {
+                folded,
+                generation,
+                model: self.session.clone(),
+            });
+        }
     }
 
     /// Record a ladder rung for a fold that did not go through
@@ -586,15 +592,7 @@ impl App {
     fn note_fold(&mut self) {
         let generation = self.timeline.generation;
         self.drop_stale_rungs(generation);
-        let folded = self.timeline.folded;
-        let last = self.snapshots.last().map_or(0, |s| s.folded);
-        if folded >= last + SNAPSHOT_STRIDE {
-            self.snapshots.push(Snapshot {
-                folded,
-                generation,
-                model: self.session.clone(),
-            });
-        }
+        self.maybe_snapshot(self.timeline.folded, generation);
     }
 
     /// Discard every rung if the item list has been re-sorted or replaced since
@@ -814,11 +812,11 @@ impl App {
         // wall-clock derived (they have no playhead of their own), and their
         // workflow rollups need the same pass the focused session gets.
         let now = chrono::Utc::now();
-        for model in self.others.values_mut() {
-            model.recompute_workflow_status();
-            model.recompute_liveness(Some(now));
-            structural |= graph::sync(&mut self.flow, model, false);
+        let mut others = std::mem::take(&mut self.others);
+        for model in others.values_mut() {
+            structural |= Self::project(&mut self.flow, model, now);
         }
+        self.others = others;
         if structural {
             self.layout_dirty = true;
             // A session that just gained a node may now overlap its neighbour.
@@ -841,11 +839,12 @@ impl App {
         if self.is_current(session_id) {
             return;
         }
-        let now = chrono::Utc::now();
-        let model = self
+        // Taken OUT of the map so the model and the flow can be borrowed at
+        // once; put back below.
+        let mut model = self
             .others
-            .entry(session_id.to_string())
-            .or_insert_with(|| SessionModel::new(session_id.to_string()));
+            .remove(session_id)
+            .unwrap_or_else(|| SessionModel::new(session_id.to_string()));
         for update in &updates {
             model.apply_update(update);
         }
@@ -854,12 +853,28 @@ impl App {
         // whole canvas per batch scales with sessions squared for no reason —
         // nothing else changed. Time-derived liveness for the other sessions is
         // refreshed by `status_tick` regardless.
-        model.recompute_workflow_status();
-        model.recompute_liveness(Some(now));
-        if graph::sync(&mut self.flow, model, false) {
+        let structural = Self::project(&mut self.flow, &mut model, chrono::Utc::now());
+        self.others.insert(session_id.to_string(), model);
+        if structural {
             self.layout_dirty = true;
             graph::repack_if_overlapping(&mut self.flow);
         }
+    }
+
+    /// Re-derive a monitored session's projections and draw it on `flow`.
+    ///
+    /// The order matters: the workflow rollup reads child statuses that
+    /// liveness has yet to set, so it runs first — the same sequence `resync`
+    /// applies to the focused session. Returns whether the canvas gained or
+    /// lost nodes.
+    fn project(
+        flow: &mut graph::AgentFlow,
+        model: &mut SessionModel,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> bool {
+        model.recompute_workflow_status();
+        model.recompute_liveness(Some(now));
+        graph::sync(flow, model, false)
     }
 
     /// Name each watched session's root card from the sweep's project names.

--- a/src/state/rail.rs
+++ b/src/state/rail.rs
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn the_fallback_label_is_lossy_by_construction() {
-        assert_eq!(project_label("-home-elwardi-repo-zoetrope"), "zoetrope");
+        assert_eq!(project_label("-home-u-repo-zoetrope"), "zoetrope");
         // Documented loss: the sanitizer flattened `parametric_pump`, and no
         // rule recovers it from the string. This is why `cwd` is preferred.
         assert_eq!(project_label("-home-u-repo-parametric-pump"), "pump");

--- a/src/state/rail.rs
+++ b/src/state/rail.rs
@@ -42,12 +42,7 @@ pub struct RailRow {
     pub main_path: PathBuf,
     /// Agents in the session, including the main agent.
     pub agents: usize,
-    pub tool_calls: usize,
     pub failures: usize,
-    /// Prompts the index could vouch for. A lower bound on legacy transcripts
-    /// (see `index::flags::AMBIGUOUS_PROMPT`); the rail shows a count, not a
-    /// claim about the era spine, so a lower bound is honest enough here.
-    pub prompts: usize,
     /// Newest timestamp across the session's files.
     pub last_activity: Option<DateTime<Utc>>,
     /// The newest bytes came from a subagent, not the main transcript — the
@@ -205,9 +200,7 @@ mod tests {
             project: project.to_string(),
             main_path: PathBuf::from(format!("/p/{id}.jsonl")),
             agents: 1,
-            tool_calls: 0,
             failures: 0,
-            prompts: 0,
             last_activity: Some(now - chrono::Duration::seconds(ago_secs)),
             sidecar_active: false,
         }

--- a/src/state/rail.rs
+++ b/src/state/rail.rs
@@ -1,0 +1,336 @@
+//! The session rail: every live session at a glance, and which one is focused.
+//!
+//! Deliberately **portable** — no filesystem types beyond `PathBuf`, no
+//! discovery. The native side sweeps the disk ([`crate::sessions`]) and hands
+//! finished rows across as a [`UiEvent`](crate::tailer::UiEvent), exactly the
+//! way transcript batches arrive. The browser frontend simply never populates
+//! it, and the rail renders as absent rather than as a special case.
+//!
+//! A row is built from a skeleton [`Summary`](crate::sessions::Summary), not
+//! from a folded model: an unfocused session costs records, never bodies. The
+//! canvas draws every live session; the rail is the index over them — including
+//! the idle ones the canvas leaves out — and picks which one is focused.
+
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+
+/// A session is "running" if its newest activity is within this window.
+///
+/// The same threshold the graph uses for interactive liveness
+/// (`session::INTERACTIVE_IDLE_SECS`), so a rail row and the agent card for the
+/// same session can never disagree about whether it is alive.
+pub const RAIL_IDLE_SECS: i64 = 120;
+
+/// Whether a session is currently producing output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RailStatus {
+    /// Wrote something within [`RAIL_IDLE_SECS`].
+    Running,
+    /// Quiet, but within the discovery window.
+    Idle,
+}
+
+/// One session's row: everything the rail draws, and the path focusing it
+/// watches.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RailRow {
+    pub session_id: String,
+    /// Display name for the session's project (see [`project_label`]).
+    pub project: String,
+    /// The main transcript — what a focus switch asks the tailer to watch.
+    pub main_path: PathBuf,
+    /// Agents in the session, including the main agent.
+    pub agents: usize,
+    pub tool_calls: usize,
+    pub failures: usize,
+    /// Prompts the index could vouch for. A lower bound on legacy transcripts
+    /// (see `index::flags::AMBIGUOUS_PROMPT`); the rail shows a count, not a
+    /// claim about the era spine, so a lower bound is honest enough here.
+    pub prompts: usize,
+    /// Newest timestamp across the session's files.
+    pub last_activity: Option<DateTime<Utc>>,
+    /// The newest bytes came from a subagent, not the main transcript — the
+    /// main agent is blocked on a subagent, which is worth showing.
+    pub sidecar_active: bool,
+}
+
+impl RailRow {
+    /// Whether this session is running as of `now`.
+    pub fn status(&self, now: DateTime<Utc>) -> RailStatus {
+        match self.last_activity {
+            Some(ts) if (now - ts).num_seconds() <= RAIL_IDLE_SECS => RailStatus::Running,
+            _ => RailStatus::Idle,
+        }
+    }
+
+    /// How long ago this session last wrote, as a compact label (`3s`, `12m`,
+    /// `4h`, `2d`). `—` when undated.
+    pub fn age(&self, now: DateTime<Utc>) -> String {
+        let Some(ts) = self.last_activity else {
+            return "—".to_string();
+        };
+        let secs = (now - ts).num_seconds().max(0);
+        match secs {
+            s if s < 60 => format!("{s}s"),
+            s if s < 3600 => format!("{}m", s / 60),
+            s if s < 86_400 => format!("{}h", s / 3600),
+            s => format!("{}d", s / 86_400),
+        }
+    }
+}
+
+/// The rail's own state: the discovered rows and whether the pane is drawn.
+#[derive(Debug, Clone, Default)]
+pub struct SessionRail {
+    /// Discovered sessions, newest activity first.
+    pub rows: Vec<RailRow>,
+    /// User override for rail visibility: `Some(true)`/`Some(false)` after an
+    /// explicit toggle, `None` while it follows the workspace (see
+    /// [`should_show`](Self::should_show)).
+    pub forced_visible: Option<bool>,
+    /// True once a sweep has landed — distinguishes "no sessions" from "not
+    /// looked yet", which the empty state needs to say honestly.
+    pub swept: bool,
+}
+
+impl SessionRail {
+    /// Replace the rows from a fresh sweep.
+    ///
+    /// The rail holds NO focus of its own: the focused row is whichever row
+    /// matches the session the app is actually watching
+    /// (`App::current_session_id`, which `UiEvent::SessionReset` updates when a
+    /// switch lands). A parallel focus field here could point at a session the
+    /// tailer is not watching — a marker that lies. Deriving it means the
+    /// marker moves when the switch actually takes effect, and a watched
+    /// session that has aged out of the discovery window simply shows no
+    /// marker, which is the truth.
+    pub fn adopt(&mut self, rows: Vec<RailRow>) {
+        self.rows = rows;
+        self.swept = true;
+    }
+
+    /// Index of the row for `current`, if the rail lists it.
+    pub fn focused_index(&self, current: &str) -> Option<usize> {
+        self.rows.iter().position(|r| r.session_id == current)
+    }
+
+    /// The row for `current`, if the rail lists it.
+    pub fn focused_row(&self, current: &str) -> Option<&RailRow> {
+        self.rows.get(self.focused_index(current)?)
+    }
+
+    /// The transcript `delta` rows away from `current`, wrapping.
+    ///
+    /// `None` when there is nowhere else to go (fewer than two rows), so a
+    /// keypress cannot cost a redundant session switch — a switch tears down
+    /// and rebuilds the whole model. A `current` the rail does not list starts
+    /// from the top rather than refusing, so an out-of-window session is never
+    /// a dead end.
+    pub fn step_focus(&self, current: &str, delta: isize) -> Option<PathBuf> {
+        if self.rows.len() < 2 {
+            return None;
+        }
+        let len = self.rows.len() as isize;
+        let next = match self.focused_index(current) {
+            Some(i) => (i as isize + delta).rem_euclid(len) as usize,
+            // Not listed: step in from whichever end the user was heading for.
+            None if delta < 0 => self.rows.len() - 1,
+            None => 0,
+        };
+        self.watch_target(current, next)
+    }
+
+    /// The transcript for row `index` (a rail click), or `None` when that row
+    /// is already the watched session.
+    pub fn focus_index(&self, current: &str, index: usize) -> Option<PathBuf> {
+        self.watch_target(current, index)
+    }
+
+    /// The main transcript of row `index`, unless it is already being watched.
+    fn watch_target(&self, current: &str, index: usize) -> Option<PathBuf> {
+        let row = self.rows.get(index)?;
+        (row.session_id != current).then(|| row.main_path.clone())
+    }
+
+    /// How many rows are running as of `now`.
+    pub fn running(&self, now: DateTime<Utc>) -> usize {
+        self.rows
+            .iter()
+            .filter(|r| r.status(now) == RailStatus::Running)
+            .count()
+    }
+
+    /// Whether to draw the rail.
+    ///
+    /// Off by default when there is nothing to choose between: a lone session
+    /// is what `zoe` has always shown, and spending 30 columns to say so would
+    /// be a regression for the common case. It appears on its own as soon as a
+    /// second session exists, and an explicit toggle overrides either way.
+    pub fn should_show(&self) -> bool {
+        self.forced_visible.unwrap_or(self.rows.len() >= 2)
+    }
+
+    /// Toggle rail visibility, taking over from the automatic rule.
+    pub fn toggle_visible(&mut self) {
+        self.forced_visible = Some(!self.should_show());
+    }
+}
+
+/// Fallback project name, derived from a `~/.claude/projects` directory name.
+///
+/// **Only for sessions whose transcript records no `cwd`.** Those directory
+/// names are a cwd with every non-alphanumeric byte replaced by `-`
+/// (`transcript::sanitize_cwd`), which is not invertible: `parametric_pump`
+/// sanitizes to `parametric-pump`, whose trailing segment is the useless
+/// `pump`. Guessing where the project name starts is not possible from the
+/// string alone, so the native row builder reads the real path out of the
+/// transcript's `cwd` envelope field instead (one parsed line per session) and
+/// only falls back here when there is none.
+pub fn project_label(dir_name: &str) -> String {
+    let trimmed = dir_name.trim_matches('-');
+    match trimmed.rsplit('-').find(|s| !s.is_empty()) {
+        Some(last) => last.to_string(),
+        None => "—".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(id: &str, project: &str, ago_secs: i64, now: DateTime<Utc>) -> RailRow {
+        RailRow {
+            session_id: id.to_string(),
+            project: project.to_string(),
+            main_path: PathBuf::from(format!("/p/{id}.jsonl")),
+            agents: 1,
+            tool_calls: 0,
+            failures: 0,
+            prompts: 0,
+            last_activity: Some(now - chrono::Duration::seconds(ago_secs)),
+            sidecar_active: false,
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        "2026-08-26T12:00:00Z".parse().unwrap()
+    }
+
+    #[test]
+    fn status_and_age_follow_the_graphs_idle_threshold() {
+        let n = now();
+        assert_eq!(row("a", "p", 5, n).status(n), RailStatus::Running);
+        assert_eq!(
+            row("a", "p", RAIL_IDLE_SECS, n).status(n),
+            RailStatus::Running,
+            "the boundary is inclusive, as it is for agent cards"
+        );
+        assert_eq!(
+            row("a", "p", RAIL_IDLE_SECS + 1, n).status(n),
+            RailStatus::Idle
+        );
+
+        assert_eq!(row("a", "p", 5, n).age(n), "5s");
+        assert_eq!(row("a", "p", 300, n).age(n), "5m");
+        assert_eq!(row("a", "p", 7200, n).age(n), "2h");
+        assert_eq!(row("a", "p", 172_800, n).age(n), "2d");
+    }
+
+    #[test]
+    fn the_marker_follows_the_watched_session_across_a_reorder() {
+        let n = now();
+        let mut rail = SessionRail::default();
+        rail.adopt(vec![row("a", "alpha", 5, n), row("b", "beta", 60, n)]);
+        assert_eq!(rail.focused_index("a"), Some(0));
+
+        // A sweep reorders by recency; the marker tracks the SESSION, so it
+        // moves with the row rather than staying at position 0.
+        rail.adopt(vec![row("b", "beta", 1, n), row("a", "alpha", 90, n)]);
+        assert_eq!(rail.focused_index("a"), Some(1));
+        assert_eq!(rail.focused_row("a").unwrap().project, "alpha");
+    }
+
+    #[test]
+    fn a_watched_session_outside_the_window_shows_no_marker() {
+        let n = now();
+        let mut rail = SessionRail::default();
+        rail.adopt(vec![row("a", "alpha", 5, n)]);
+        // The app is watching a replay file that discovery never listed. The
+        // rail must not point at some other session as though it were it.
+        assert_eq!(rail.focused_index("recording"), None);
+        assert!(rail.focused_row("recording").is_none());
+        // ...and stepping from there is still possible, not a dead end.
+        rail.adopt(vec![row("a", "alpha", 5, n), row("b", "beta", 9, n)]);
+        assert_eq!(
+            rail.step_focus("recording", 1),
+            Some(PathBuf::from("/p/a.jsonl"))
+        );
+        assert_eq!(
+            rail.step_focus("recording", -1),
+            Some(PathBuf::from("/p/b.jsonl"))
+        );
+    }
+
+    #[test]
+    fn stepping_focus_wraps_and_never_reports_a_redundant_switch() {
+        let n = now();
+        let mut rail = SessionRail::default();
+        rail.adopt(vec![row("a", "alpha", 1, n)]);
+        assert!(
+            rail.step_focus("a", 1).is_none(),
+            "one row: a keypress must not cost a model rebuild"
+        );
+
+        rail.adopt(vec![
+            row("a", "alpha", 1, n),
+            row("b", "beta", 2, n),
+            row("c", "gamma", 3, n),
+        ]);
+        assert_eq!(
+            rail.step_focus("a", -1),
+            Some(PathBuf::from("/p/c.jsonl")),
+            "wraps backwards"
+        );
+        assert_eq!(
+            rail.step_focus("c", 1),
+            Some(PathBuf::from("/p/a.jsonl")),
+            "wraps forwards"
+        );
+        assert!(
+            rail.focus_index("a", 0).is_none(),
+            "focusing the watched row is not a switch"
+        );
+    }
+
+    #[test]
+    fn the_rail_appears_only_once_there_is_a_choice_to_make() {
+        let n = now();
+        let mut rail = SessionRail::default();
+        assert!(!rail.should_show(), "nothing swept yet");
+        rail.adopt(vec![row("a", "alpha", 1, n)]);
+        assert!(!rail.should_show(), "one session is what zoe always showed");
+        rail.adopt(vec![row("a", "alpha", 1, n), row("b", "beta", 2, n)]);
+        assert!(rail.should_show());
+
+        // An explicit toggle overrides the rule in both directions, and keeps
+        // overriding it as the workspace changes.
+        rail.toggle_visible();
+        assert!(!rail.should_show());
+        rail.adopt(vec![row("a", "alpha", 1, n), row("b", "beta", 2, n)]);
+        assert!(!rail.should_show(), "the override outlives a sweep");
+        rail.toggle_visible();
+        rail.adopt(vec![row("a", "alpha", 1, n)]);
+        assert!(rail.should_show(), "forced on for a lone session");
+    }
+
+    #[test]
+    fn the_fallback_label_is_lossy_by_construction() {
+        assert_eq!(project_label("-home-elwardi-repo-zoetrope"), "zoetrope");
+        // Documented loss: the sanitizer flattened `parametric_pump`, and no
+        // rule recovers it from the string. This is why `cwd` is preferred.
+        assert_eq!(project_label("-home-u-repo-parametric-pump"), "pump");
+        assert_eq!(project_label("-"), "—");
+        assert_eq!(project_label(""), "—");
+    }
+}

--- a/src/state/session.rs
+++ b/src/state/session.rs
@@ -883,41 +883,57 @@ impl SessionModel {
         let Some(reference) = now.or(self.last_activity) else {
             return false;
         };
-        let mut changed = false;
-        for agent in self.agents.values_mut() {
-            let Some(ts) = agent.last_ts else {
-                continue;
-            };
-            // An unresolved tool_call is direct evidence the agent is still
-            // working — stronger than "no transcript line for 120s". Without it,
-            // an agent blocked on a long tool (a 2-minute Bash) looks quiet and
-            // settles to Done/Idle mid-tool, then snaps back when the result
-            // lands. A reliably-terminal agent short-circuits below, so this
-            // can't revive a genuinely finished one.
-            let active = (reference - ts).num_seconds() <= INTERACTIVE_IDLE_SECS
-                || agent
-                    .tool_calls
-                    .iter()
-                    .any(|c| c.state == ToolState::Pending);
-            let next = if agent.is_interactive() {
-                if active {
+        // Two passes: decide in a read-only walk, then write ONLY the agents
+        // whose status actually moved.
+        //
+        // The obvious single `values_mut()` loop takes a mutable borrow of
+        // every agent on every call — and this runs once a second from
+        // `status_tick`, plus on every resync, overwhelmingly finding nothing
+        // to change. That is wasted work with plain maps and actively harmful
+        // with persistent ones, where touching an entry copies it.
+        let pending: Vec<(String, AgentStatus)> = self
+            .agents
+            .iter()
+            .filter_map(|(id, agent)| {
+                let ts = agent.last_ts?;
+                // An unresolved tool_call is direct evidence the agent is still
+                // working — stronger than "no transcript line for 120s". Without
+                // it, an agent blocked on a long tool (a 2-minute Bash) looks
+                // quiet and settles to Done/Idle mid-tool, then snaps back when
+                // the result lands. A reliably-terminal agent short-circuits
+                // below, so this can't revive a genuinely finished one.
+                let active = (reference - ts).num_seconds() <= INTERACTIVE_IDLE_SECS
+                    || agent
+                        .tool_calls
+                        .iter()
+                        .any(|c| c.state == ToolState::Pending);
+                let next = if agent.is_interactive() {
+                    if active {
+                        AgentStatus::Running
+                    } else {
+                        AgentStatus::Idle
+                    }
+                } else if agent.terminal {
+                    // A reliably-completed subagent (sync ack / journal) is terminal.
+                    agent.status
+                } else if active {
+                    // Async agent still producing activity — and REVERSIBLE: a
+                    // long gap (e.g. a subagent running `cargo test`) that
+                    // settled it to Done flips straight back to Running when it
+                    // resumes.
                     AgentStatus::Running
                 } else {
-                    AgentStatus::Idle
-                }
-            } else if agent.terminal {
-                // A reliably-completed subagent (sync ack / journal) is terminal.
-                agent.status
-            } else if active {
-                // Async agent still producing activity — and REVERSIBLE: a long
-                // gap (e.g. a subagent running `cargo test`) that settled it to
-                // Done flips straight back to Running when it resumes.
-                AgentStatus::Running
-            } else {
-                AgentStatus::Done
-            };
-            changed |= agent.status != next;
-            agent.status = next;
+                    AgentStatus::Done
+                };
+                (next != agent.status).then(|| (id.clone(), next))
+            })
+            .collect();
+
+        let changed = !pending.is_empty();
+        for (id, next) in pending {
+            if let Some(agent) = self.agents.get_mut(&id) {
+                agent.status = next;
+            }
         }
         changed
     }
@@ -926,16 +942,31 @@ impl SessionModel {
     /// agent goes `Idle` — the recording is over, nothing is active, and
     /// completion remains unclaimable.
     pub fn end_of_stream(&mut self) {
-        for agent in self.agents.values_mut() {
-            if agent.is_interactive() {
-                // Interactive agents (main/forks) never "complete" — the stream
-                // ending just means they went quiet.
-                agent.status = AgentStatus::Idle;
-            } else if agent.status == AgentStatus::Running {
-                // A subagent still Running at the recording's end has finished
-                // (its async spawn-ack Done was superseded by its own later
-                // activity via `resolve_spawn_status`; now there's no more).
-                agent.status = AgentStatus::Done;
+        // Same two-pass shape as `recompute_liveness`, for the same reason.
+        let pending: Vec<(String, AgentStatus)> = self
+            .agents
+            .iter()
+            .filter_map(|(id, agent)| {
+                let next = if agent.is_interactive() {
+                    // Interactive agents (main/forks) never "complete" — the
+                    // stream ending just means they went quiet.
+                    AgentStatus::Idle
+                } else if agent.status == AgentStatus::Running {
+                    // A subagent still Running at the recording's end has
+                    // finished (its async spawn-ack Done was superseded by its
+                    // own later activity via `resolve_spawn_status`; now there's
+                    // no more).
+                    AgentStatus::Done
+                } else {
+                    return None;
+                };
+                (next != agent.status).then(|| (id.clone(), next))
+            })
+            .collect();
+
+        for (id, next) in pending {
+            if let Some(agent) = self.agents.get_mut(&id) {
+                agent.status = next;
             }
         }
     }

--- a/src/state/session.rs
+++ b/src/state/session.rs
@@ -27,6 +27,13 @@ const INTERACTIVE_IDLE_SECS: i64 = 120;
 /// The full derived view of a session.
 pub struct SessionModel {
     pub session_id: String,
+    /// Human-readable name for this session's project, shown on the root card.
+    ///
+    /// Not derivable from the transcript alone at fold time — it comes from the
+    /// session's `cwd` via the discovery sweep — and every root card would
+    /// otherwise read "claude", which is unreadable the moment the canvas holds
+    /// more than one session.
+    pub label: Option<String>,
     /// Agents keyed by stable node id (`"main"`, `agentId`, or `wf-id`).
     pub agents: BTreeMap<String, AgentInfo>,
     /// Stable spawn order of node ids (insertion order). Drives layout/nav.
@@ -320,6 +327,7 @@ impl SessionModel {
         agents.insert(MAIN_ID.to_string(), AgentInfo::new(AgentKind::Main));
         SessionModel {
             session_id,
+            label: None,
             agents,
             spawn_order: vec![MAIN_ID.to_string()],
             last_activity: None,

--- a/src/state/session.rs
+++ b/src/state/session.rs
@@ -7,7 +7,7 @@
 //! group node. Spawn order is tracked explicitly so layout and navigation are
 //! deterministic.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use imbl::{HashMap, HashSet, OrdMap, Vector};
 
 use chrono::{DateTime, Utc};
 
@@ -25,6 +25,11 @@ pub const MAIN_ID: &str = "main";
 const INTERACTIVE_IDLE_SECS: i64 = 120;
 
 /// The full derived view of a session.
+///
+/// `Clone` is O(1): every growing collection here is persistent
+/// ([`imbl`]), so cloning shares structure rather than copying it. That is what
+/// makes a snapshot cheap enough to keep several of.
+#[derive(Clone, PartialEq)]
 pub struct SessionModel {
     pub session_id: String,
     /// Human-readable name for this session's project, shown on the root card.
@@ -35,15 +40,15 @@ pub struct SessionModel {
     /// more than one session.
     pub label: Option<String>,
     /// Agents keyed by stable node id (`"main"`, `agentId`, or `wf-id`).
-    pub agents: BTreeMap<String, AgentInfo>,
+    pub agents: OrdMap<String, AgentInfo>,
     /// Stable spawn order of node ids (insertion order). Drives layout/nav.
-    pub spawn_order: Vec<String>,
+    pub spawn_order: Vector<String>,
     /// Most recent activity timestamp seen across all files.
     pub last_activity: Option<DateTime<Utc>>,
     /// `runId → (workflowName, summary)` from main-transcript workflow launches,
     /// kept as a FACT rather than applied on arrival: the launch and the group's
     /// first subagent meta can fold in either order, so both sides consult this.
-    workflow_labels: BTreeMap<String, (Option<String>, Option<String>)>,
+    workflow_labels: OrdMap<String, (Option<String>, Option<String>)>,
     /// Completion facts, kept so model state is a function of the fact SET,
     /// not of arrival order — a completion can arrive before its target
     /// exists (live attach applies the main transcript before directory scans
@@ -71,7 +76,7 @@ pub struct SessionModel {
     /// Every plain user prompt in the main transcript, in order — the
     /// session's spine. Tool calls and spawns attribute to a prompt era via
     /// [`Self::prompt_for_ts`] (timestamp-derived, order-independent).
-    pub prompts: Vec<PromptInfo>,
+    pub prompts: Vector<PromptInfo>,
     /// Excerpt of the most recent assistant text in the main transcript.
     /// One logical turn spans several JSONL lines, so the reasoning for a
     /// spawn usually lives on an EARLIER line than the tool_use — this is the
@@ -100,7 +105,7 @@ pub enum LogKind {
 
 /// One user prompt in the main transcript — an era boundary on the session's
 /// timeline.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PromptInfo {
     /// One-line excerpt of the prompt text.
     pub excerpt: String,
@@ -112,7 +117,7 @@ pub struct PromptInfo {
 /// DERIVED from it via [`SessionModel::prompt_for_ts`] — order-independent,
 /// like all era attribution) and the assistant text immediately preceding the
 /// spawning tool call (stored: reasoning is not timestamp-derivable).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct SpawnContext {
     /// Timestamp of the spawning `tool_use` entry.
     pub ts: Option<DateTime<Utc>>,
@@ -195,7 +200,7 @@ pub enum ToolState {
 }
 
 /// One tool invocation within an agent.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ToolCallInfo {
     /// `tool_use.id` — join key for the result.
     pub id: String,
@@ -222,6 +227,11 @@ impl ToolCallInfo {
 }
 
 /// Everything known about one agent node.
+///
+/// Cloned whenever the containing map copy-on-writes the node holding it, so
+/// its own growing collections are persistent too — a plain `Vec` of tool calls
+/// here would make every tool-call append copy the agent's whole history.
+#[derive(Clone, PartialEq)]
 pub struct AgentInfo {
     pub kind: AgentKind,
     /// Interactive category (main-session semantics: no completion evidence
@@ -247,7 +257,7 @@ pub struct AgentInfo {
     pub(crate) terminal: bool,
     pub model: Option<String>,
     /// Tool calls in observed order.
-    pub tool_calls: Vec<ToolCallInfo>,
+    pub tool_calls: Vector<ToolCallInfo>,
     /// tool_use id → index into `tool_calls`, so the per-entry dedup check and
     /// per-result completion are O(1) instead of scanning every prior call
     /// (which made folding a tool-heavy agent quadratic).
@@ -279,7 +289,7 @@ impl AgentInfo {
             status: AgentStatus::Running,
             terminal: false,
             model: None,
-            tool_calls: Vec::new(),
+            tool_calls: Vector::new(),
             tool_index: HashMap::new(),
             output_tokens: 0,
             first_ts: None,
@@ -323,20 +333,20 @@ impl SessionModel {
     /// Create an empty model for the given session id, with the `"main"` agent
     /// pre-seeded as [`AgentStatus::Running`].
     pub fn new(session_id: String) -> Self {
-        let mut agents = BTreeMap::new();
+        let mut agents = OrdMap::new();
         agents.insert(MAIN_ID.to_string(), AgentInfo::new(AgentKind::Main));
         SessionModel {
             session_id,
             label: None,
             agents,
-            spawn_order: vec![MAIN_ID.to_string()],
+            spawn_order: Vector::unit(MAIN_ID.to_string()),
             last_activity: None,
-            workflow_labels: BTreeMap::new(),
+            workflow_labels: OrdMap::new(),
             completed_spawns: HashMap::new(),
             task_terminal: HashMap::new(),
             journal_done: HashSet::new(),
             spawn_context: HashMap::new(),
-            prompts: Vec::new(),
+            prompts: Vector::new(),
             last_main_text: None,
         }
     }
@@ -354,7 +364,7 @@ impl SessionModel {
             info.terminal = true;
         }
         self.agents.insert(id.to_string(), info);
-        self.spawn_order.push(id.to_string());
+        self.spawn_order.push_back(id.to_string());
         true
     }
 
@@ -481,7 +491,7 @@ impl SessionModel {
                         // replay). A genuine repeat at a *different* ts is kept.
                         let dup = self.prompts.iter().any(|p| p.excerpt == ex && p.ts == ts);
                         if !dup {
-                            self.prompts.push(PromptInfo { excerpt: ex, ts });
+                            self.prompts.push_back(PromptInfo { excerpt: ex, ts });
                         }
                     }
                 }
@@ -540,7 +550,7 @@ impl SessionModel {
                 // same cumulative usage; count it once per `requestId`. Lines
                 // with no `requestId` can't be deduped, so they sum per line.
                 match &e.envelope.request_id {
-                    Some(req) if !agent.seen_request_ids.insert(req.clone()) => {}
+                    Some(req) if agent.seen_request_ids.insert(req.clone()).is_some() => {}
                     // Saturating: counts come from untrusted transcript
                     // content; overflow must not panic (debug) or wrap.
                     _ => agent.output_tokens = agent.output_tokens.saturating_add(out),
@@ -576,7 +586,7 @@ impl SessionModel {
                     }
                     let summary = summarize_tool(&name, &tu.input, e.envelope.cwd.as_deref());
                     agent.tool_index.insert(id.clone(), agent.tool_calls.len());
-                    agent.tool_calls.push(ToolCallInfo {
+                    agent.tool_calls.push_back(ToolCallInfo {
                         id: id.clone(),
                         name,
                         summary,
@@ -1214,12 +1224,12 @@ mod tests {
                 }
             };
         let mut m = SessionModel::new("s".into());
-        m.prompts.push(PromptInfo {
+        m.prompts.push_back(PromptInfo {
             excerpt: "review the codebase".into(),
             ts: Some(ts("2026-06-05T10:00:00Z")),
         });
         let main = m.agents.get_mut(MAIN_ID).unwrap();
-        main.tool_calls.push(tool(
+        main.tool_calls.push_back(tool(
             "s1",
             "Agent",
             "hunt bugs",
@@ -1228,7 +1238,7 @@ mod tests {
             ToolState::Ok,
         ));
         // A slow Bash: started 10:10, failed (result) at 10:12.
-        main.tool_calls.push(tool(
+        main.tool_calls.push_back(tool(
             "b1",
             "Bash",
             "cargo test",
@@ -1237,7 +1247,7 @@ mod tests {
             ToolState::Err,
         ));
         // A later SUCCESSFUL non-spawn tool is not a log event.
-        main.tool_calls.push(tool(
+        main.tool_calls.push_back(tool(
             "r1",
             "Read",
             "src/lib.rs",
@@ -1285,7 +1295,7 @@ mod tests {
             .get_mut(MAIN_ID)
             .unwrap()
             .tool_calls
-            .push(ToolCallInfo {
+            .push_back(ToolCallInfo {
                 id: "call1".into(),
                 name: "Agent".into(),
                 summary: Some("hunt bugs".into()),

--- a/src/state/timeline.rs
+++ b/src/state/timeline.rs
@@ -76,6 +76,15 @@ pub struct Timeline {
     /// must re-run dating. Lets `append_live` skip the full date-and-sort for
     /// the common in-order, fully-timed batch.
     undated_agents: HashSet<String>,
+    /// Bumped whenever an item's INDEX may have changed meaning: a bulk
+    /// replay load, or a re-sort that moved already-present items.
+    ///
+    /// Anything that caches a result keyed by item index — the snapshot ladder
+    /// in particular — records the generation it was built under and must
+    /// discard itself when this moves. Without it a snapshot of `items[0..N]`
+    /// silently describes a different prefix after a late batch dates a
+    /// previously-pending item and the whole list re-sorts around it.
+    pub generation: u64,
     /// Skip inactivity: compress dead-air gaps during paced playback (see
     /// `compress_gap`). On by default (review-friendly); toggle off for
     /// faithful real-time pacing. Presentation-only — never affects content.
@@ -137,6 +146,7 @@ impl Timeline {
             gap_progress: 0.0,
             undated_agents: HashSet::new(),
             compress_gaps: true,
+            generation: 0,
         }
     }
 
@@ -155,6 +165,7 @@ impl Timeline {
         self.ended = false;
         self.gap_anchor = start;
         self.gap_progress = 0.0;
+        self.generation = self.generation.wrapping_add(1);
         self.rescan_undated();
     }
 
@@ -211,8 +222,12 @@ impl Timeline {
             self.items.push(item);
         }
         if needs_dating || !in_order {
+            // Existing items can move: an item that was `Pending` sorts ahead
+            // of every dated one and jumps into place once its date resolves,
+            // shifting every index in between. Index-keyed caches are void.
             crate::tailer::date_and_sort_live(&mut self.items);
             self.rescan_undated();
+            self.generation = self.generation.wrapping_add(1);
         }
         if self.items.len() != before {
             self.ended = false;

--- a/src/state/timeline.rs
+++ b/src/state/timeline.rs
@@ -85,6 +85,19 @@ pub struct Timeline {
     /// silently describes a different prefix after a late batch dates a
     /// previously-pending item and the whole list re-sorts around it.
     pub generation: u64,
+    /// How many leading items every generation bump since the last
+    /// [`take_disturbance`](Self::take_disturbance) is known to have left
+    /// alone.
+    ///
+    /// A re-sort is rarely a reshuffle: a late subagent entry inserts among the
+    /// newest items and leaves the long prefix before it exactly where it was.
+    /// `generation` alone cannot say that, so a cache keyed by index would have
+    /// to discard itself wholesale on every out-of-order batch — which, once a
+    /// subagent is writing, is most batches. This is the part that is provably
+    /// still valid; it accumulates as a MINIMUM so a consumer that misses a bump
+    /// (the App only reconciles while following the edge) still sees the worst
+    /// case rather than the last one.
+    stable_prefix: usize,
     /// Skip inactivity: compress dead-air gaps during paced playback (see
     /// `compress_gap`). On by default (review-friendly); toggle off for
     /// faithful real-time pacing. Presentation-only — never affects content.
@@ -147,6 +160,7 @@ impl Timeline {
             undated_agents: HashSet::new(),
             compress_gaps: true,
             generation: 0,
+            stable_prefix: usize::MAX,
         }
     }
 
@@ -166,6 +180,8 @@ impl Timeline {
         self.gap_anchor = start;
         self.gap_progress = 0.0;
         self.generation = self.generation.wrapping_add(1);
+        // Every index means something new — nothing is stable.
+        self.stable_prefix = 0;
         self.rescan_undated();
     }
 
@@ -198,11 +214,15 @@ impl Timeline {
         let mut tail_ts = self.items.last().and_then(|i| i.ts());
         let mut in_order = true;
         let mut needs_dating = false;
+        // Earliest timestamp in this batch: where a re-sort can start moving
+        // things, and so where the untouched prefix ends.
+        let mut earliest_new: Option<DateTime<Utc>> = None;
         for update in updates {
             let item = ReplayItem::live(update);
             match item.ts() {
                 Some(ts) => {
                     self.head = Some(self.head.map_or(ts, |h| h.max(ts)));
+                    earliest_new = Some(earliest_new.map_or(ts, |e: DateTime<Utc>| e.min(ts)));
                     if tail_ts.is_some_and(|t| ts < t) {
                         in_order = false;
                     }
@@ -224,7 +244,21 @@ impl Timeline {
         if needs_dating || !in_order {
             // Existing items can move: an item that was `Pending` sorts ahead
             // of every dated one and jumps into place once its date resolves,
-            // shifting every index in between. Index-keyed caches are void.
+            // shifting every index in between. Index-keyed caches are void
+            // from `stable_prefix` on.
+            let stable = if needs_dating {
+                // Undated items sort to the head, so one arriving (or leaving,
+                // once it dates) shifts every index after it — i.e. all of them.
+                0
+            } else {
+                // Purely an out-of-order batch: the new items are all dated and
+                // land at or after the first item they undercut. Everything
+                // before that is untouched. `<` rather than `<=` keeps this
+                // conservative against the sort's equal-timestamp tie-break.
+                let earliest = earliest_new.expect("an out-of-order batch is dated");
+                self.items[..before].partition_point(|i| i.ts().is_none_or(|t| t < earliest))
+            };
+            self.stable_prefix = self.stable_prefix.min(stable);
             crate::tailer::date_and_sort_live(&mut self.items);
             self.rescan_undated();
             self.generation = self.generation.wrapping_add(1);
@@ -235,6 +269,13 @@ impl Timeline {
         if self.follow_head && was_at_edge {
             self.cursor = self.head;
         }
+    }
+
+    /// How many leading items are still known-good since the last call, then
+    /// reset. Consumers of `generation` pair the two: a bump says *some* index
+    /// changed meaning, this says from where.
+    pub fn take_disturbance(&mut self) -> usize {
+        std::mem::replace(&mut self.stable_prefix, usize::MAX)
     }
 
     /// Recompute which undated items are waiting on future data (the metas /

--- a/src/tailer/live.rs
+++ b/src/tailer/live.rs
@@ -173,10 +173,10 @@ pub(crate) async fn run_live(
 
 /// The shared poll loop: every [`POLL_INTERVAL`] read appended bytes and emit a
 /// [`UiEvent::Batch`], staying responsive to switch/exit requests. Both feeders
-/// end here — live tailing after the announce, replay after the bulk hand-off —
-/// so EVERY session keeps tailing and can pick up new appends ("go live"). Auto-
-/// switch to a newer session fires only when `session.project_dir` is set (live
-/// directory targets), not for a pinned replay file.
+/// end here — live tailing after the target is resolved, replay after the bulk
+/// hand-off — so EVERY session keeps tailing and can pick up new appends ("go
+/// live"). The file is never re-targeted here; only a `Watch` request or a
+/// truncation switches it.
 pub(crate) async fn tail_loop(
     mut session: LiveSession,
     session_id: String,

--- a/src/tailer/live.rs
+++ b/src/tailer/live.rs
@@ -20,22 +20,8 @@ use super::{Flow, Source, TailRequest, UiEvent, Update};
 /// Poll interval for live tailing.
 const POLL_INTERVAL: Duration = Duration::from_millis(200);
 
-/// Run the newer-session auto-switch scan every N poll ticks (~2s at the
-/// 200ms interval). The scan stats every `*.jsonl` in the project dir, which
-/// scales with session HISTORY, not activity — unthrottled it would scan 5×/sec
-/// on long-lived projects for an event that almost never happens.
-const SWITCH_SCAN_EVERY: u32 = 10;
-
-/// Auto-switch only after the current session has been silent this many poll
-/// ticks (~30s at 200ms). Long enough that a normal mid-session lull (a slow
-/// tool call, thinking) never trips it — so the switch fires only when the
-/// session is genuinely done, never flapping between two live ones.
-const SWITCH_IDLE_TICKS: u32 = 150;
-
 /// Tracks all files belonging to one live session.
 pub(crate) struct LiveSession {
-    /// Project directory containing the main file (for newer-session scans).
-    pub(crate) project_dir: Option<PathBuf>,
     /// The main `<uuid>.jsonl` path.
     main_path: PathBuf,
     /// The `<uuid>/subagents` directory (may not exist yet).
@@ -48,11 +34,6 @@ pub(crate) struct LiveSession {
     tracked: HashMap<PathBuf, (Source, TailState)>,
     /// meta.json files already emitted (by absolute path) — emit once.
     seen_meta: std::collections::HashSet<PathBuf>,
-    /// Poll-tick counter, used to throttle the newer-session scan.
-    ticks: u32,
-    /// Consecutive poll ticks with NO activity (no appended bytes anywhere).
-    /// Gates auto-switch so two concurrently-written sessions can't leapfrog.
-    idle_ticks: u32,
     /// Byte offsets captured by a replay bulk snapshot, consumed when each file
     /// is first registered for tailing — so the tail resumes exactly where the
     /// snapshot stopped reading instead of at the live EOF (which would drop
@@ -72,21 +53,17 @@ pub(crate) struct SnapshotSeed {
 
 impl LiveSession {
     /// Build a session rooted at a concrete `<uuid>.jsonl` main file inside
-    /// `project_dir`. `project_dir` drives newer-session auto-switch scans and is
-    /// the watched directory (NOT `main_path.parent()`, which for a workflow or
-    /// nested layout would be wrong — they are the same here, but threading the
-    /// project dir explicitly keeps auto-switch correct).
-    pub(crate) fn new(project_dir: PathBuf, main_path: PathBuf) -> Self {
+    /// A session is pinned to the file it was asked to watch: which session is
+    /// focused is the App's decision, made from discovery, not something the
+    /// tailer may change underneath it.
+    pub(crate) fn new(main_path: PathBuf) -> Self {
         let subagents_dir = transcript::subagents_dir(&main_path).unwrap_or_default();
         Self {
-            project_dir: Some(project_dir),
             main_path,
             subagents_dir,
             main_state: TailState::default(),
             tracked: HashMap::new(),
             seen_meta: std::collections::HashSet::new(),
-            ticks: 0,
-            idle_ticks: 0,
             seed_offsets: HashMap::new(),
         }
     }
@@ -170,41 +147,27 @@ pub(crate) async fn run_live(
     ui_tx: &mpsc::Sender<UiEvent>,
     req_rx: &mut mpsc::Receiver<TailRequest>,
 ) -> Flow {
-    // Resolve the target to a (project_dir, main_file). If a project dir has no
-    // session yet, wait for the first one to appear. A concrete FILE target
-    // PINS to that session (no auto-switch — you named the file you want); only
-    // a directory target follows the newest session in it.
-    let pin = !target.is_dir();
-    let (project_dir, main_path) = match resolve_live_target(target) {
-        Some(pair) => pair,
+    // Resolve the target to the file to watch. A directory resolves to its
+    // newest session ONCE, here — the tailer never revisits that choice, so the
+    // session it watches is the session the App asked for.
+    let main_path = match resolve_live_target(target) {
+        Some((_, main)) => main,
         None => {
             // Directory with no session file yet — poll until one shows up.
             match await_first_session(target, req_rx).await {
-                Ok(main) => (target.to_path_buf(), main),
+                Ok(main) => main,
                 Err(flow) => return flow,
             }
         }
     };
 
-    let mut session = LiveSession::new(project_dir, main_path);
-    if pin {
-        session.project_dir = None;
-    }
+    let session = LiveSession::new(main_path);
     let session_id = session.session_id();
 
-    // Announce the resolved session id so the UI adopts it before any batch
-    // arrives. The UI seeds `current_session_id` from a best-effort up-front
-    // discovery, which can be empty (no session yet) or stale (a newer file
-    // appeared between startup and now); without this announcement those batches
-    // would be dropped by the is_current gate. Idempotent when the id already
-    // matches (reset of an empty model is a no-op). Live tailing backfills the
-    // whole existing file on the first poll (arrival order).
-    let _ = ui_tx
-        .send(UiEvent::SessionReset {
-            session_id: session_id.clone(),
-        })
-        .await;
-
+    // No announce: the App decides which session is focused and already knows
+    // its id before it asks for it. A reset here would be indistinguishable
+    // from a monitored session's own truncation, which is exactly the ambiguity
+    // that used to require a parallel set of Monitor* events.
     tail_loop(session, session_id, ui_tx, req_rx).await
 }
 
@@ -304,34 +267,6 @@ async fn poll_live(
             })
             .await;
     }
-    session.idle_ticks = if had_activity {
-        0
-    } else {
-        session.idle_ticks.saturating_add(1)
-    };
-
-    // --- newer-session auto-switch (throttled — see SWITCH_SCAN_EVERY) ---
-    // Only switch once THIS session has been quiet for a while: otherwise two
-    // sessions written concurrently in one project dir leapfrog each other's
-    // mtime and the watcher flaps between them every scan. An idle current
-    // session + a newer file = the user moved on, so follow.
-    session.ticks = session.ticks.wrapping_add(1);
-    if session.ticks.is_multiple_of(SWITCH_SCAN_EVERY)
-        && session.idle_ticks >= SWITCH_IDLE_TICKS
-        && let Some(dir) = &session.project_dir
-        && let Some(latest) = transcript::latest_session_file(dir)
-        && latest != session.main_path
-    {
-        // Stamp the reset with the NEW session id so the UI adopts the id the
-        // post-switch tailer will stamp its batches with — stamping the OLD id
-        // here would make the UI drop every event of the new session.
-        let new_id = transcript::session_id_from_path(&latest);
-        let _ = ui_tx
-            .send(UiEvent::SessionReset { session_id: new_id })
-            .await;
-        return Some(latest);
-    }
-
     None
 }
 
@@ -471,45 +406,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn auto_switch_follows_a_newer_session_when_idle() {
-        let mut dir = std::env::temp_dir();
-        dir.push(format!("zoetrope_switch_test_{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        // Current session A (empty → no new activity this poll) and a newer
-        // session B. B's id sorts lexicographically greater, so it wins
-        // `latest_session_file`'s deterministic tie-break regardless of mtime.
-        let a = dir.join("11111111-1111-1111-1111-111111111111.jsonl");
-        let b = dir.join("99999999-9999-9999-9999-999999999999.jsonl");
-        std::fs::write(&a, "").unwrap();
-        std::fs::write(&b, "").unwrap();
-
-        let mut session = LiveSession::new(dir.clone(), a.clone());
-        // Quiet long enough to switch, and aligned to the throttled scan tick.
-        session.idle_ticks = SWITCH_IDLE_TICKS;
-        session.ticks = SWITCH_SCAN_EVERY - 1;
-
-        let (tx, mut rx) = mpsc::channel(32);
-        let switched = poll_live(&mut session, "11111111", &tx).await;
-
-        assert_eq!(
-            switched,
-            Some(b.clone()),
-            "an idle session follows the newer file"
-        );
-        // The reset must carry the NEW session id, so the UI adopts the batches
-        // the post-switch tailer will stamp (the OLD id would drop them all).
-        match rx.try_recv() {
-            Ok(UiEvent::SessionReset { session_id }) => assert_ne!(
-                session_id, "11111111-1111-1111-1111-111111111111",
-                "reset carries the new session id, not the old"
-            ),
-            other => panic!("expected a SessionReset for the new session, got {other:?}"),
-        }
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[tokio::test]
     async fn replay_seed_resumes_where_snapshot_stopped() {
         use std::io::Write;
 
@@ -544,8 +440,7 @@ mod tests {
             )
             .unwrap();
 
-        let mut session = LiveSession::new(dir.clone(), main.clone());
-        session.project_dir = None;
+        let mut session = LiveSession::new(main.clone());
         session.seed(seed);
 
         let (tx, mut rx) = mpsc::channel(32);
@@ -585,7 +480,7 @@ mod tests {
         )).unwrap();
 
         let (tx, mut rx) = mpsc::channel(32);
-        let mut session = LiveSession::new(dir.clone(), main.clone());
+        let mut session = LiveSession::new(main.clone());
         assert!(poll_live(&mut session, "55555555", &tx).await.is_none()); // backfill
 
         // Truncate the SUBAGENT file: already-applied content would be
@@ -622,7 +517,7 @@ mod tests {
         std::fs::write(&main, b"{\"type\":\"user\",\"uuid\":\"u1\",\"parentUuid\":null,\"message\":{\"role\":\"user\",\"content\":\"abcdef\"}}\n").unwrap();
 
         let (tx, mut rx) = mpsc::channel(32);
-        let mut session = LiveSession::new(dir.clone(), main.clone());
+        let mut session = LiveSession::new(main.clone());
         poll_live(&mut session, "33333333", &tx).await; // backfill
 
         // Truncate in place (shorter content) — must return the SAME path so

--- a/src/tailer/mod.rs
+++ b/src/tailer/mod.rs
@@ -77,25 +77,19 @@ pub enum UiEvent {
         speed: f64,
         info: crate::state::SessionInfo,
     },
-    /// File truncation/rotation detected — the UI should reset its model.
+    /// File truncation/rotation detected for `session_id` — the UI should drop
+    /// what it has of that session.
+    ///
+    /// Always about the named session and nothing else. It used to be able to
+    /// mean "the focused session is now a different one" (the tailer followed a
+    /// newer file on its own), which made an unfamiliar id ambiguous and forced
+    /// a parallel set of monitor-only events. Which session is focused is now
+    /// the App's decision, so routing on `session_id` alone is unambiguous.
     SessionReset { session_id: String },
     /// A completed multi-session discovery sweep. Carries finished rail rows
     /// (see [`crate::sessions::sweep`]), never raw paths: discovery is native
     /// and blocking, the App is neither, and the rail is portable state.
     Sessions(Vec<crate::state::rail::RailRow>),
-    /// Appends from a **monitored** session — one on the canvas but not
-    /// focused. A distinct variant rather than a [`Batch`](UiEvent::Batch) with
-    /// a different id, because the two mean different things: a `Batch` for an
-    /// unfamiliar id is the focus tailer telling the App it switched sessions,
-    /// while this is another session simply making progress. Conflating them
-    /// made an auto-switch look like monitor traffic and vice versa.
-    MonitorBatch {
-        session_id: String,
-        updates: Vec<Update>,
-    },
-    /// A monitored session was truncated or rotated — drop what we have of it.
-    /// Never a focus change; see [`MonitorBatch`](UiEvent::MonitorBatch).
-    MonitorReset { session_id: String },
     /// A non-fatal error string for display.
     Error(String),
 }

--- a/src/tailer/mod.rs
+++ b/src/tailer/mod.rs
@@ -158,7 +158,8 @@ pub async fn run(
 /// What to do after a live/replay session loop returns.
 #[cfg(feature = "native")]
 pub(crate) enum Flow {
-    /// Switch to a new file (live auto-switch or a `Watch` request).
+    /// Switch to a new file: a `Watch` request, or a re-attach after the
+    /// watched file was truncated or rotated.
     Switch(PathBuf),
     /// The request channel closed — shut down.
     Exit,

--- a/src/tailer/mod.rs
+++ b/src/tailer/mod.rs
@@ -79,6 +79,23 @@ pub enum UiEvent {
     },
     /// File truncation/rotation detected — the UI should reset its model.
     SessionReset { session_id: String },
+    /// A completed multi-session discovery sweep. Carries finished rail rows
+    /// (see [`crate::sessions::sweep`]), never raw paths: discovery is native
+    /// and blocking, the App is neither, and the rail is portable state.
+    Sessions(Vec<crate::state::rail::RailRow>),
+    /// Appends from a **monitored** session — one on the canvas but not
+    /// focused. A distinct variant rather than a [`Batch`](UiEvent::Batch) with
+    /// a different id, because the two mean different things: a `Batch` for an
+    /// unfamiliar id is the focus tailer telling the App it switched sessions,
+    /// while this is another session simply making progress. Conflating them
+    /// made an auto-switch look like monitor traffic and vice versa.
+    MonitorBatch {
+        session_id: String,
+        updates: Vec<Update>,
+    },
+    /// A monitored session was truncated or rotated — drop what we have of it.
+    /// Never a focus change; see [`MonitorBatch`](UiEvent::MonitorBatch).
+    MonitorReset { session_id: String },
     /// A non-fatal error string for display.
     Error(String),
 }

--- a/src/tailer/replay.rs
+++ b/src/tailer/replay.rs
@@ -64,11 +64,10 @@ pub(crate) async fn run_replay(
         return Flow::Exit;
     }
 
-    // Keep tailing the SAME file for appends. Resolve to (dir, file); a replay
-    // target is a concrete file, so disable newer-session auto-switch (you asked
-    // for this file) by clearing project_dir. Tail offsets are seeded from the
-    // byte positions the bulk parse actually consumed — NOT the current EOF —
-    // so lines appended while the bulk parse ran are emitted, not skipped.
+    // Keep tailing the SAME file for appends — a tailer only ever watches the
+    // file it was given. Tail offsets are seeded from the byte positions the
+    // bulk parse actually consumed — NOT the current EOF — so lines appended
+    // while the bulk parse ran are emitted, not skipped.
     let Some((_, main_path)) = resolve_live_target(path) else {
         // Unreadable target: nothing to tail, just wait for a switch/exit.
         return match req_rx.recv().await {

--- a/src/tailer/replay.rs
+++ b/src/tailer/replay.rs
@@ -69,15 +69,14 @@ pub(crate) async fn run_replay(
     // for this file) by clearing project_dir. Tail offsets are seeded from the
     // byte positions the bulk parse actually consumed — NOT the current EOF —
     // so lines appended while the bulk parse ran are emitted, not skipped.
-    let Some((project_dir, main_path)) = resolve_live_target(path) else {
+    let Some((_, main_path)) = resolve_live_target(path) else {
         // Unreadable target: nothing to tail, just wait for a switch/exit.
         return match req_rx.recv().await {
             Some(TailRequest::Watch(p)) => Flow::Switch(p),
             None => Flow::Exit,
         };
     };
-    let mut session = LiveSession::new(project_dir, main_path);
-    session.project_dir = None; // replay pins one file — no auto-switch
+    let mut session = LiveSession::new(main_path);
     session.seed(seed);
 
     tail_loop(session, session_id, ui_tx, req_rx).await

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -690,16 +690,28 @@ pub fn sanitize_cwd(cwd: &std::path::Path) -> String {
 /// whole app sees one consistent root rather than a half-redirected one.
 pub const PROJECTS_ROOT_ENV: &str = "ZOE_PROJECTS_ROOT";
 
+/// The user's home directory, or `None` if it cannot be resolved.
+///
+/// Shared so every dotfile-style root zoetrope reads or writes agrees on where
+/// home is — `std::env::home_dir` with a `$HOME` fallback, both rejecting an
+/// empty value (which would silently resolve to the filesystem root).
+pub fn home_dir() -> Option<std::path::PathBuf> {
+    #[allow(deprecated)]
+    std::env::home_dir()
+        .filter(|h| !h.as_os_str().is_empty())
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .filter(|h| !h.is_empty())
+                .map(std::path::PathBuf::from)
+        })
+}
+
 /// The `~/.claude/projects` root, or whatever [`PROJECTS_ROOT_ENV`] names.
 pub fn claude_projects_root() -> Option<std::path::PathBuf> {
     if let Some(root) = std::env::var_os(PROJECTS_ROOT_ENV).filter(|v| !v.is_empty()) {
         return Some(std::path::PathBuf::from(root));
     }
-    #[allow(deprecated)]
-    let home = std::env::home_dir()
-        .filter(|h| !h.as_os_str().is_empty())
-        .or_else(|| std::env::var_os("HOME").map(std::path::PathBuf::from))?;
-    Some(home.join(".claude").join("projects"))
+    Some(home_dir()?.join(".claude").join("projects"))
 }
 
 /// Absolute path to the `~/.claude/projects/<sanitized-cwd>` directory for a

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -681,8 +681,20 @@ pub fn sanitize_cwd(cwd: &std::path::Path) -> String {
         .collect()
 }
 
-/// The `~/.claude/projects` root, if a home directory can be resolved.
-fn claude_projects_root() -> Option<std::path::PathBuf> {
+/// Environment override for the projects root.
+///
+/// Set it to point zoetrope at a different tree of transcripts. It exists
+/// because the multi-session rail is otherwise only exercisable by running
+/// several real Claude Code sessions at once: with this, a fixture workspace
+/// is a directory. It relocates discovery AND [`project_dir`] together, so the
+/// whole app sees one consistent root rather than a half-redirected one.
+pub const PROJECTS_ROOT_ENV: &str = "ZOE_PROJECTS_ROOT";
+
+/// The `~/.claude/projects` root, or whatever [`PROJECTS_ROOT_ENV`] names.
+pub fn claude_projects_root() -> Option<std::path::PathBuf> {
+    if let Some(root) = std::env::var_os(PROJECTS_ROOT_ENV).filter(|v| !v.is_empty()) {
+        return Some(std::path::PathBuf::from(root));
+    }
     #[allow(deprecated)]
     let home = std::env::home_dir()
         .filter(|h| !h.as_os_str().is_empty())
@@ -1263,6 +1275,38 @@ mod tests {
     }
 
     // --- Subagent path helpers --------------------------------------------
+
+    /// The projects-root override must relocate discovery and `project_dir`
+    /// together — a half-redirected app would list fixture sessions while
+    /// resolving the current project against the real home directory.
+    ///
+    /// Serialized against other env-touching tests by running them in one test
+    /// function: `set_var` is process-global and Rust runs tests in threads.
+    #[test]
+    fn the_projects_root_override_relocates_everything() {
+        let real = claude_projects_root();
+
+        // SAFETY: no other thread reads this variable during this test; the
+        // override is restored before returning.
+        unsafe { std::env::set_var(PROJECTS_ROOT_ENV, "/tmp/zoe-fixture") };
+        assert_eq!(
+            claude_projects_root(),
+            Some(std::path::PathBuf::from("/tmp/zoe-fixture"))
+        );
+        assert_eq!(
+            project_dir(std::path::Path::new("/home/u/repo/app")),
+            Some(std::path::PathBuf::from(
+                "/tmp/zoe-fixture/-home-u-repo-app"
+            ))
+        );
+
+        // Empty is treated as unset, not as the filesystem root.
+        unsafe { std::env::set_var(PROJECTS_ROOT_ENV, "") };
+        assert_eq!(claude_projects_root(), real);
+
+        unsafe { std::env::remove_var(PROJECTS_ROOT_ENV) };
+        assert_eq!(claude_projects_root(), real);
+    }
 
     #[test]
     fn subagents_dir_derivation() {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -31,11 +31,14 @@ const STATUS_TICK: Duration = Duration::from_secs(1);
 /// iteration. Returns when the user quits.
 pub async fn run(
     mut app: App,
-    // Held for the run only to keep the request channel open: the tailer treats a
-    // closed channel as "exit", so dropping this sender would kill tailing. No
-    // input path sends on it (auto-switch is internal to the tailer).
-    _tail_tx: mpsc::Sender<TailRequest>,
+    // Kept open for the whole run: the tailer treats a closed channel as
+    // "exit". Also carries session switches from the rail — the tailer's own
+    // auto-switch remains internal to it.
+    tail_tx: mpsc::Sender<TailRequest>,
     mut ui_rx: mpsc::Receiver<UiEvent>,
+    // Publishes which session is focused, so the monitor supervisor does not
+    // put a second tailer on it (which would double every append).
+    focus_tx: tokio::sync::watch::Sender<String>,
 ) -> anyhow::Result<()> {
     let mut terminal = ratatui::init();
     execute!(stdout(), EnableMouseCapture)?;
@@ -128,6 +131,25 @@ pub async fn run(
         }
         while let Ok(ev) = ui_rx.try_recv() {
             app.handle_ui_event(ev);
+        }
+
+        // A rail focus change reaches the tailer here: input handling is
+        // synchronous and owns no channel, so it queues the request instead
+        // (same shape as `pending_seek`). `try_send` keeps the render loop
+        // non-blocking; on a full channel the request stays queued and goes out
+        // next frame rather than being dropped, because a swallowed switch
+        // leaves the rail marker pointing at a session nobody is watching.
+        if let Some(path) = app.pending_watch.take()
+            && tail_tx.try_send(TailRequest::Watch(path.clone())).is_err()
+        {
+            app.pending_watch = Some(path);
+        }
+
+        // The focus can change without any input — the tailer's own
+        // auto-switch moves it — so publish from the loop rather than from the
+        // key handler.
+        if *focus_tx.borrow() != app.current_session_id {
+            let _ = focus_tx.send(app.current_session_id.clone());
         }
 
         if quit || app.should_quit {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -32,8 +32,8 @@ const STATUS_TICK: Duration = Duration::from_secs(1);
 pub async fn run(
     mut app: App,
     // Kept open for the whole run: the tailer treats a closed channel as
-    // "exit". Also carries session switches from the rail — the tailer's own
-    // auto-switch remains internal to it.
+    // "exit". Also carries session switches — every one of them, since the App
+    // is the only thing that decides which session is watched.
     tail_tx: mpsc::Sender<TailRequest>,
     mut ui_rx: mpsc::Receiver<UiEvent>,
     // Publishes which session is focused, so the monitor supervisor does not
@@ -145,9 +145,9 @@ pub async fn run(
             app.pending_watch = Some(path);
         }
 
-        // The focus can change without any input — the tailer's own
-        // auto-switch moves it — so publish from the loop rather than from the
-        // key handler.
+        // The focus can change without any input — discovery naming the first
+        // session of an empty project, for one — so publish from the loop
+        // rather than from the key handler.
         if *focus_tx.borrow() != app.current_session_id {
             let _ = focus_tx.send(app.current_session_id.clone());
         }

--- a/src/ui/chips.rs
+++ b/src/ui/chips.rs
@@ -33,7 +33,7 @@ use rataflow::Palette;
 use ratatui::buffer::Buffer;
 use ratatui::style::{Modifier, Style};
 
-use crate::state::graph::AgentFlow;
+use crate::state::graph::{self, AgentFlow};
 use crate::state::session::{SessionModel, ToolState};
 
 /// How long a successful chip stays visible AFTER completion. Pending chips
@@ -363,7 +363,10 @@ pub fn render(
         if chip.afterglow.is_some() && age >= ttl(state) {
             continue;
         }
-        let Some((left, _, right, bottom)) = flow.node_terminal_rect(&chip.agent_id) else {
+        // Canvas node ids are session-scoped; a chip carries the model-local
+        // agent id, so qualify it before anchoring.
+        let nid = graph::node_id(&model.session_id, &chip.agent_id);
+        let Some((left, _, right, bottom)) = flow.node_terminal_rect(&nid) else {
             continue;
         };
         // Zoomed far out, a full-size chip dwarfs its card — skip rather than
@@ -443,6 +446,63 @@ mod tests {
     use super::*;
     use crate::state::session::SessionModel;
     use crate::transcript::SubagentMeta;
+
+    /// The overlay anchors on the CANVAS, whose node ids are session-scoped
+    /// (`<session>/<agent>`), while a chip carries the model-local agent id.
+    /// Bridging the two is load-bearing: when it was missing, every anchor
+    /// missed and the entire chip overlay silently stopped rendering — with
+    /// the rest of the suite still green, because nothing drove a chip through
+    /// a real flow.
+    #[test]
+    fn a_chip_reaches_the_screen_over_its_agents_card() {
+        use crate::state::{App, Mode};
+        use crate::tailer::{Source, UiEvent, Update};
+
+        let mut app = App::new("s1".to_string(), Mode::Live);
+        // The first live batch is backfill and seeds silently, so the chip has
+        // to arrive on a later one to animate at all.
+        app.handle_ui_event(UiEvent::Batch {
+            session_id: "s1".to_string(),
+            updates: vec![Update::Entry {
+                source: Source::Main,
+                entry: crate::transcript::parse_line(
+                    r#"{"type":"user","uuid":"u0","parentUuid":null,"timestamp":"2026-06-05T10:00:00.000Z","message":{"role":"user","content":"go"}}"#,
+                )
+                .unwrap(),
+            }],
+        });
+        app.handle_ui_event(UiEvent::Batch {
+            session_id: "s1".to_string(),
+            updates: vec![Update::Entry {
+                source: Source::Main,
+                entry: crate::transcript::parse_line(
+                    r#"{"type":"assistant","uuid":"u1","parentUuid":"u0","timestamp":"2026-06-05T10:00:01.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"b1","name":"Bash","input":{}}]}}"#,
+                )
+                .unwrap(),
+            }],
+        });
+        // Chips animate on the frame tick, not on the batch.
+        app.tick_timeline(std::time::Duration::from_millis(16));
+        assert!(!app.chips.chips.is_empty(), "fixture produced no chip");
+
+        let backend = ratatui::backend::TestBackend::new(120, 32);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::draw(frame, &mut app))
+            .unwrap();
+        let out: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        // The chip body, not the card's own "\u{2692} N tools" row.
+        assert!(
+            out.contains("\u{2692} Bash"),
+            "chip overlay never anchored: {out:?}"
+        );
+    }
 
     /// A model with one subagent carrying `n` tool calls.
     fn model_with_tools(n: usize) -> SessionModel {

--- a/src/ui/chips.rs
+++ b/src/ui/chips.rs
@@ -95,16 +95,18 @@ fn group_state(
     start: usize,
     count: usize,
 ) -> Option<ToolState> {
-    let calls = model
-        .agent(agent_id)?
-        .tool_calls
-        .get(start..start + count)?;
-    if calls.is_empty() {
+    let tool_calls = &model.agent(agent_id)?.tool_calls;
+    // `tool_calls` is a persistent `Vector`, which has no slicing by shared
+    // reference (its `slice` splits the vector in place), so walk the window
+    // instead. Out-of-range is still `None`, matching the previous
+    // `get(range)?` — a truncated run means the model was rebuilt underneath us.
+    if count == 0 || start + count > tool_calls.len() {
         return None;
     }
-    if calls.iter().any(|c| c.state == ToolState::Pending) {
+    let calls = || tool_calls.iter().skip(start).take(count);
+    if calls().any(|c| c.state == ToolState::Pending) {
         Some(ToolState::Pending)
-    } else if calls.iter().any(|c| c.state == ToolState::Err) {
+    } else if calls().any(|c| c.state == ToolState::Err) {
         Some(ToolState::Err)
     } else {
         Some(ToolState::Ok)
@@ -228,8 +230,12 @@ impl ChipTray {
                     i += 1;
                 }
                 let count = i - start;
-                let settled = !calls[start..i]
+                // Window-walk rather than slice: `calls` is a persistent
+                // `Vector` and cannot be sliced through a shared reference.
+                let settled = !calls
                     .iter()
+                    .skip(start)
+                    .take(count)
                     .any(|c| c.state == ToolState::Pending);
                 let prev = prior.get(&(id.clone(), start)).copied();
 
@@ -450,14 +456,16 @@ mod tests {
         m.apply_meta("sub1", None, &meta);
         let agent = m.agents.get_mut("sub1").unwrap();
         for i in 0..n {
-            agent.tool_calls.push(crate::state::session::ToolCallInfo {
-                id: format!("toolu_{i}"),
-                name: "Bash".into(),
-                summary: None,
-                ts: None,
-                end_ts: None,
-                state: ToolState::Pending,
-            });
+            agent
+                .tool_calls
+                .push_back(crate::state::session::ToolCallInfo {
+                    id: format!("toolu_{i}"),
+                    name: "Bash".into(),
+                    summary: None,
+                    ts: None,
+                    end_ts: None,
+                    state: ToolState::Pending,
+                });
         }
         m
     }
@@ -475,14 +483,16 @@ mod tests {
         m.apply_meta("sub1", None, &meta);
         let agent = m.agents.get_mut("sub1").unwrap();
         for (i, name) in names.iter().enumerate() {
-            agent.tool_calls.push(crate::state::session::ToolCallInfo {
-                id: format!("toolu_{i}"),
-                name: (*name).into(),
-                summary: None,
-                ts: None,
-                end_ts: None,
-                state: ToolState::Pending,
-            });
+            agent
+                .tool_calls
+                .push_back(crate::state::session::ToolCallInfo {
+                    id: format!("toolu_{i}"),
+                    name: (*name).into(),
+                    summary: None,
+                    ts: None,
+                    end_ts: None,
+                    state: ToolState::Pending,
+                });
         }
         m
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,6 +10,7 @@ pub mod chips;
 pub mod edges;
 pub mod nodes;
 pub mod panel;
+pub mod rail;
 
 use rataflow::{Background, MiniMap, MiniMapPosition};
 use ratatui::Frame;
@@ -53,6 +54,29 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     // whole row) so the input handler maps a click to the same width the
     // playhead is drawn over.
     app.scrubber_area = None;
+    // Same contract for the rail: a frame that does not draw it must not leave
+    // a stale rect behind to swallow canvas clicks.
+    app.rail_area = None;
+
+    // The session rail takes a fixed column off the left of the canvas, before
+    // the detail panel splits what remains — the rail is workspace-level
+    // furniture, the panel is about the selected agent inside one session.
+    let now = chrono::Utc::now();
+    // NOT gated on `rail.layout()`: the forest renderer does not exist yet, so
+    // letting the layout choice hide the rail meant three concurrent sessions
+    // silently removed it — and `w` then looked broken, because the auto-switch
+    // was overriding it. The rail hides only when the user says so or the
+    // terminal is too narrow to hold it and a usable canvas.
+    let show_rail = app.rail.should_show() && canvas_area.width > rail::RAIL_WIDTH * 2;
+    let canvas_area = if show_rail {
+        let [rail_area, rest] =
+            Layout::horizontal([Constraint::Length(rail::RAIL_WIDTH), Constraint::Fill(1)])
+                .areas(canvas_area);
+        rail::render(frame, rail_area, app, now);
+        rest
+    } else {
+        canvas_area
+    };
 
     // Copy the selected agent id out *before* borrowing the flow mutably for
     // the canvas render (borrow split: companions take &Flow, Widget is &mut).
@@ -545,7 +569,7 @@ fn render_log_line(frame: &mut Frame, row: Rect, app: &App) {
 /// Centered help overlay: full key reference + status-glyph legend.
 fn render_help(frame: &mut Frame, area: Rect, palette: &rataflow::Palette) {
     let w = area.width.min(60);
-    let h = area.height.min(18);
+    let h = area.height.min(19);
     if w < 24 || h < 9 {
         return;
     }
@@ -570,7 +594,7 @@ fn render_help(frame: &mut Frame, area: Rect, palette: &rataflow::Palette) {
         "q · ctrl-c"
     };
 
-    let lines = vec![
+    let mut lines = vec![
         Line::from(""),
         Line::from(vec![
             Span::styled(" camera    ", key),
@@ -631,6 +655,18 @@ fn render_help(frame: &mut Frame, area: Rect, palette: &rataflow::Palette) {
             Span::styled("green edges = agent running", dim),
         ]),
     ];
+
+    // The rail is native-only: the browser frontend is handed one session's
+    // bytes and has no filesystem to discover others in, so listing its keys
+    // there would advertise something that cannot happen.
+    #[cfg(not(target_arch = "wasm32"))]
+    lines.insert(
+        3,
+        Line::from(vec![
+            Span::styled(" sessions  ", key),
+            Span::styled("canvas shows all live · w rail · n/p focus", txt),
+        ]),
+    );
 
     let block = Block::default()
         .borders(Borders::ALL)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -594,6 +594,8 @@ fn render_help(frame: &mut Frame, area: Rect, palette: &rataflow::Palette) {
         "q · ctrl-c"
     };
 
+    // The `mut` is only used by the native-only sessions row appended below.
+    #[cfg_attr(target_arch = "wasm32", allow(unused_mut))]
     let mut lines = vec![
         Line::from(""),
         Line::from(vec![

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -62,11 +62,10 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     // the detail panel splits what remains — the rail is workspace-level
     // furniture, the panel is about the selected agent inside one session.
     let now = chrono::Utc::now();
-    // NOT gated on `rail.layout()`: the forest renderer does not exist yet, so
-    // letting the layout choice hide the rail meant three concurrent sessions
-    // silently removed it — and `w` then looked broken, because the auto-switch
-    // was overriding it. The rail hides only when the user says so or the
-    // terminal is too narrow to hold it and a usable canvas.
+    // The rail hides only when the user says so, or the terminal is too narrow
+    // to hold it and a usable canvas. Nothing else may take it away: an earlier
+    // version let a layout mode hide it, and `w` then looked broken because
+    // something invisible kept overriding the user's choice.
     let show_rail = app.rail.should_show() && canvas_area.width > rail::RAIL_WIDTH * 2;
     let canvas_area = if show_rail {
         let [rail_area, rest] =

--- a/src/ui/panel.rs
+++ b/src/ui/panel.rs
@@ -565,7 +565,7 @@ mod tests {
         .iter()
         .enumerate()
         {
-            agent.tool_calls.push(ToolCallInfo {
+            agent.tool_calls.push_back(ToolCallInfo {
                 id: format!("t{i}"),
                 name: "Bash".into(),
                 summary: None,

--- a/src/ui/rail.rs
+++ b/src/ui/rail.rs
@@ -170,9 +170,7 @@ mod tests {
             project: project.to_string(),
             main_path: PathBuf::from("/p/s.jsonl"),
             agents: 4,
-            tool_calls: 12,
             failures,
-            prompts: 3,
             last_activity: Some(now - chrono::Duration::seconds(ago)),
             sidecar_active: false,
         }

--- a/src/ui/rail.rs
+++ b/src/ui/rail.rs
@@ -1,0 +1,453 @@
+//! The session rail: one row per live session, down the left edge.
+//!
+//! Reads [`SessionRail`](crate::state::rail::SessionRail) only — rows arrive
+//! pre-summarized from the discovery sweep, so rendering never touches the
+//! filesystem and never folds a model. The row for the watched session is
+//! marked; every other row is a session the app is *not* tailing, which is the
+//! whole point of the rail being cheap.
+//!
+//! Glyphs and colors are the graph's: `●` running, `◌` idle
+//! ([`AgentStatus::glyph`](crate::state::session::AgentStatus::glyph)), and
+//! every color resolved from `flow.theme.palette()` — `success` for alive,
+//! `error` for failures, `accent` for the focus marker, on the `surface`
+//! background the other panels use. A rail row and the agent card for the same
+//! session must never look like they disagree, which they would the moment the
+//! rail hardcoded a color the theme could change.
+
+use chrono::{DateTime, Utc};
+use rataflow::Palette;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Padding, Paragraph};
+
+use crate::state::App;
+use crate::state::rail::{RailRow, RailStatus};
+use crate::state::session::AgentStatus;
+use crate::ui::truncate;
+
+/// Width of the rail pane, in columns.
+///
+/// Wide enough for a project name plus the status/count/age columns, narrow
+/// enough that the canvas keeps the majority of a standard 80-column terminal.
+pub const RAIL_WIDTH: u16 = 30;
+
+/// Columns the fixed right-hand side of a row occupies: status glyph, agent
+/// count, and age. The project name gets whatever is left.
+const FIXED_COLS: u16 = 12;
+
+/// Render the rail into `area`.
+///
+/// Records `area` on the App so a click can be mapped back to a row; a frame
+/// that does not draw the rail leaves it cleared, so a stale rect can never
+/// swallow a canvas click.
+pub fn render(frame: &mut Frame, area: Rect, app: &mut App, now: DateTime<Utc>) {
+    let palette = app.flow.theme.palette();
+    let bg = Style::default().bg(palette.surface);
+    // No view-mode label: until the forest renderer lands there is only one
+    // layout, and printing "auto:forest" over a rail would be a caption that
+    // disagrees with the screen.
+    let title = format!(
+        " sessions {}/{} ",
+        app.rail.running(now),
+        app.rail.rows.len()
+    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(bg.fg(palette.subtle))
+        .style(bg)
+        .padding(Padding::horizontal(1))
+        .title(Span::styled(
+            title,
+            bg.fg(palette.subtle).add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    app.rail_area = Some(inner);
+
+    if app.rail.rows.is_empty() {
+        let msg = if app.rail.swept {
+            "no recent sessions"
+        } else {
+            "scanning…"
+        };
+        frame.render_widget(
+            Paragraph::new(Span::styled(
+                msg,
+                bg.fg(palette.subtle).add_modifier(Modifier::ITALIC),
+            ))
+            .style(bg),
+            inner,
+        );
+        return;
+    }
+
+    let focused = app.rail.focused_index(&app.current_session_id);
+    let lines: Vec<Line> = app
+        .rail
+        .rows
+        .iter()
+        .take(inner.height as usize)
+        .enumerate()
+        .map(|(i, row)| row_line(row, Some(i) == focused, inner.width, now, &palette))
+        .collect();
+
+    frame.render_widget(Paragraph::new(lines).style(bg), inner);
+}
+
+/// One rail row: `▸ project  ● 4 12m`.
+fn row_line<'a>(
+    row: &'a RailRow,
+    focused: bool,
+    width: u16,
+    now: DateTime<Utc>,
+    palette: &Palette,
+) -> Line<'a> {
+    let bg = Style::default().bg(palette.surface);
+    let alive = row.status(now) == RailStatus::Running;
+    // The graph's own status vocabulary: `success` is reserved for "alive"
+    // there, so reusing it here is what keeps the two readings identical.
+    let (glyph, status_color) = if alive {
+        (AgentStatus::Running.glyph(), palette.success)
+    } else {
+        (AgentStatus::Idle.glyph(), palette.subtle)
+    };
+
+    // The focused row is the one the canvas is showing, and `accent` is the
+    // app's selection color everywhere else — so it means the same thing here.
+    let marker = if focused { "▸" } else { " " };
+    let name_width = width.saturating_sub(FIXED_COLS).max(4) as usize;
+    let name = truncate(&row.project, name_width);
+
+    let name_style = match (focused, alive) {
+        (true, _) => bg.fg(palette.accent).add_modifier(Modifier::BOLD),
+        (false, true) => bg.fg(palette.text),
+        (false, false) => bg.fg(palette.subtle),
+    };
+
+    let mut spans = vec![
+        Span::styled(marker, bg.fg(palette.accent)),
+        Span::styled(" ", bg),
+        Span::styled(format!("{name:<name_width$}"), name_style),
+        Span::styled(" ", bg),
+        Span::styled(glyph.to_string(), bg.fg(status_color)),
+        // Agent count includes the main agent, so it is never zero.
+        Span::styled(format!("{:>3}", row.agents), bg.fg(palette.subtle)),
+        Span::styled(format!("{:>4}", row.age(now)), bg.fg(palette.subtle)),
+    ];
+
+    // Failures and subagent-only activity are the two things worth interrupting
+    // a scan of the rail for, so they get their own marks rather than a number
+    // column nobody reads.
+    if row.failures > 0 {
+        spans.push(Span::styled(" ✗", bg.fg(palette.error)));
+    } else if row.sidecar_active {
+        spans.push(Span::styled(" ·", bg.fg(palette.success)));
+    }
+
+    Line::from(spans)
+}
+
+/// Which rail row a click at `y` lands on, if any.
+///
+/// `area` is the rail's INNER rect (what [`render`] recorded), so row 0 is the
+/// first session rather than the border.
+pub fn row_at(area: Rect, y: u16, rows: usize) -> Option<usize> {
+    let index = y.checked_sub(area.y)? as usize;
+    (index < rows && index < area.height as usize).then_some(index)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn row(project: &str, ago: i64, failures: usize, now: DateTime<Utc>) -> RailRow {
+        RailRow {
+            session_id: "s".to_string(),
+            project: project.to_string(),
+            main_path: PathBuf::from("/p/s.jsonl"),
+            agents: 4,
+            tool_calls: 12,
+            failures,
+            prompts: 3,
+            last_activity: Some(now - chrono::Duration::seconds(ago)),
+            sidecar_active: false,
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        "2026-08-26T12:00:00Z".parse().unwrap()
+    }
+
+    /// The palette the app actually renders with — `graph::new_flow`'s, so a
+    /// theme change reaches these tests rather than being asserted around.
+    fn palette() -> Palette {
+        crate::state::graph::new_flow().theme.palette()
+    }
+
+    /// The rendered row must fit the pane exactly — an over-long project name
+    /// that pushed the age column off the edge would silently hide the one
+    /// number the rail exists to show.
+    #[test]
+    fn a_row_never_outgrows_the_pane() {
+        let n = now();
+        let long = row("a-very-long-project-name-indeed", 5, 0, n);
+        for width in [16u16, RAIL_WIDTH, 60] {
+            let line = row_line(&long, true, width, n, &palette());
+            let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+            assert!(
+                rendered.chars().count() <= width as usize,
+                "width {width}: {rendered:?} is {} chars",
+                rendered.chars().count()
+            );
+        }
+    }
+
+    #[test]
+    fn a_failure_mark_wins_over_the_subagent_mark() {
+        let n = now();
+        let mut r = row("proj", 5, 2, n);
+        r.sidecar_active = true;
+        let line = row_line(&r, false, RAIL_WIDTH, n, &palette());
+        let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(rendered.contains('✗'));
+        assert!(
+            !rendered.contains('·'),
+            "one mark per row — a failure is the more urgent of the two"
+        );
+    }
+
+    #[test]
+    fn running_and_idle_use_the_graphs_glyphs() {
+        let n = now();
+        let live: String = row_line(&row("p", 5, 0, n), false, RAIL_WIDTH, n, &palette())
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        let idle: String = row_line(&row("p", 9999, 0, n), false, RAIL_WIDTH, n, &palette())
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(live.contains(AgentStatus::Running.glyph()));
+        assert!(idle.contains(AgentStatus::Idle.glyph()));
+    }
+
+    /// Draw the whole UI with a populated rail and return the flattened buffer.
+    ///
+    /// The unit tests above check one row in isolation; this proves the rail
+    /// survives `draw`'s layout — that it is actually reached, gets a pane, and
+    /// does not get clipped away by the canvas/panel split.
+    fn rendered_ui(app: &mut App, width: u16, height: u16) -> String {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|frame| crate::ui::draw(frame, app)).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect()
+    }
+
+    fn app_with_two_sessions() -> App {
+        let mut app = App::new("sess-a".to_string(), crate::state::Mode::Live);
+        let n = Utc::now();
+        let mut a = row("alpha", 5, 0, n);
+        a.session_id = "sess-a".to_string();
+        a.main_path = PathBuf::from("/p/sess-a.jsonl");
+        let mut b = row("bravo", 5, 0, n);
+        b.session_id = "sess-b".to_string();
+        b.main_path = PathBuf::from("/p/sess-b.jsonl");
+        app.rail.adopt(vec![a, b]);
+        app
+    }
+
+    #[test]
+    fn the_rail_reaches_the_screen_and_marks_the_watched_session() {
+        let mut app = app_with_two_sessions();
+        let out = rendered_ui(&mut app, 100, 24);
+        assert!(out.contains("alpha"), "rail row missing: {out:?}");
+        assert!(out.contains("bravo"));
+        assert!(out.contains("sessions 2/2"), "rail header missing");
+        assert!(app.rail_area.is_some(), "click target recorded");
+
+        // One session: the rail costs 30 columns to say nothing, so it stays
+        // away and the canvas keeps the full width.
+        let mut solo = App::new("sess-a".to_string(), crate::state::Mode::Live);
+        let n = Utc::now();
+        let mut a = row("alpha", 5, 0, n);
+        a.session_id = "sess-a".to_string();
+        solo.rail.adopt(vec![a]);
+        let out = rendered_ui(&mut solo, 100, 24);
+        assert!(!out.contains("sessions 1/1"));
+        assert!(solo.rail_area.is_none(), "no stale click target");
+    }
+
+    /// A terminal too narrow to hold both the rail and a usable canvas keeps
+    /// the canvas — the rail is the thing you can live without.
+    #[test]
+    fn a_narrow_terminal_drops_the_rail() {
+        let mut app = app_with_two_sessions();
+        let out = rendered_ui(&mut app, 50, 20);
+        assert!(!out.contains("alpha"));
+        assert!(app.rail_area.is_none());
+    }
+
+    #[test]
+    fn keys_and_clicks_queue_a_session_switch() {
+        use crossterm::event::{
+            Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
+            MouseEventKind,
+        };
+
+        let mut app = app_with_two_sessions();
+        rendered_ui(&mut app, 100, 24);
+
+        // `n` steps to the next session and queues it for the tailer; the
+        // marker does NOT move yet, because the app is still watching sess-a
+        // until the tailer confirms the switch.
+        crate::handler::handle_event(
+            &Event::Key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)),
+            &mut app,
+        );
+        assert_eq!(app.pending_watch, Some(PathBuf::from("/p/sess-b.jsonl")));
+        assert_eq!(app.rail.focused_index(&app.current_session_id), Some(0));
+
+        // With two rows, `p` wraps to the same other session as `n` does.
+        app.pending_watch = None;
+        crate::handler::handle_event(
+            &Event::Key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE)),
+            &mut app,
+        );
+        assert_eq!(app.pending_watch, Some(PathBuf::from("/p/sess-b.jsonl")));
+
+        let area = app.rail_area.expect("rail drawn");
+        let click = |app: &mut App, row: u16| {
+            crate::handler::handle_event(
+                &Event::Mouse(MouseEvent {
+                    kind: MouseEventKind::Down(MouseButton::Left),
+                    column: area.x + 2,
+                    row: area.y + row,
+                    modifiers: KeyModifiers::NONE,
+                }),
+                app,
+            );
+        };
+
+        // Clicking the row already being watched must not queue anything — a
+        // switch tears down and rebuilds the whole model.
+        app.pending_watch = None;
+        click(&mut app, 0);
+        assert_eq!(app.pending_watch, None, "no redundant model rebuild");
+
+        // Clicking the other row queues the switch.
+        click(&mut app, 1);
+        assert_eq!(app.pending_watch, Some(PathBuf::from("/p/sess-b.jsonl")));
+
+        // `w` hides the rail even with two sessions; `v` cycles the layout.
+        let press = |app: &mut App, c: char| {
+            crate::handler::handle_event(
+                &Event::Key(KeyEvent {
+                    code: KeyCode::Char(c),
+                    modifiers: KeyModifiers::NONE,
+                    kind: KeyEventKind::Press,
+                    state: crossterm::event::KeyEventState::NONE,
+                }),
+                app,
+            );
+        };
+        press(&mut app, 'w');
+        assert!(!app.rail.should_show());
+        press(&mut app, 'w');
+        assert!(app.rail.should_show());
+    }
+
+    /// Regression: a concurrent-session count used to select a layout that had
+    /// no renderer, which silently removed the rail and made `w` look broken.
+    /// Nothing but the user and the terminal width may hide it.
+    #[test]
+    fn concurrent_sessions_never_hide_the_rail() {
+        let n = Utc::now();
+        let mut app = App::new("sess-0".to_string(), crate::state::Mode::Live);
+        let rows: Vec<_> = (0..5)
+            .map(|i| {
+                let mut r = row(&format!("proj{i}"), 1, 0, n);
+                r.session_id = format!("sess-{i}");
+                r
+            })
+            .collect();
+        app.rail.adopt(rows);
+        assert_eq!(app.rail.running(n), 5);
+
+        let out = rendered_ui(&mut app, 100, 24);
+        assert!(out.contains("proj0"), "rail vanished: {out:?}");
+        assert!(app.rail_area.is_some());
+
+        // ...and `w` still governs it in both directions.
+        app.rail.toggle_visible();
+        let out = rendered_ui(&mut app, 100, 24);
+        assert!(!out.contains("proj0"));
+        app.rail.toggle_visible();
+        let out = rendered_ui(&mut app, 100, 24);
+        assert!(out.contains("proj0"));
+    }
+
+    /// Every color in a row must come from the palette, and every span must
+    /// carry the panel background. A hardcoded color would look right in the
+    /// stock dark theme and wrong the moment the theme changed — the same
+    /// class of bug as the rail and the agent card disagreeing about liveness.
+    #[test]
+    fn row_colors_come_from_the_palette() {
+        let n = now();
+        let p = palette();
+
+        let live_row = row("proj", 5, 2, n);
+        let live = row_line(&live_row, true, RAIL_WIDTH, n, &p);
+        for span in &live.spans {
+            assert_eq!(
+                span.style.bg,
+                Some(p.surface),
+                "span {:?} is missing the panel background",
+                span.content
+            );
+            if let Some(fg) = span.style.fg {
+                assert!(
+                    [p.accent, p.success, p.error, p.subtle, p.text].contains(&fg),
+                    "span {:?} uses {fg:?}, which is not in the palette",
+                    span.content
+                );
+            }
+        }
+
+        // The specific assignments the graph shares.
+        let fg_of = |line: &Line, needle: &str| {
+            line.spans
+                .iter()
+                .find(|s| s.content.contains(needle))
+                .and_then(|s| s.style.fg)
+        };
+        assert_eq!(fg_of(&live, "▸"), Some(p.accent), "focus marker");
+        assert_eq!(fg_of(&live, "●"), Some(p.success), "running");
+        assert_eq!(fg_of(&live, "✗"), Some(p.error), "failures");
+
+        let idle_row = row("proj", 9999, 0, n);
+        let idle = row_line(&idle_row, false, RAIL_WIDTH, n, &p);
+        assert_eq!(fg_of(&idle, "◌"), Some(p.subtle), "idle");
+    }
+
+    #[test]
+    fn clicks_map_to_rows_inside_the_pane_only() {
+        let area = Rect::new(0, 5, RAIL_WIDTH, 4);
+        assert_eq!(row_at(area, 5, 3), Some(0));
+        assert_eq!(row_at(area, 7, 3), Some(2));
+        assert_eq!(row_at(area, 8, 3), None, "past the last row");
+        assert_eq!(row_at(area, 4, 3), None, "above the pane");
+        assert_eq!(row_at(area, 9, 9), None, "past the pane height");
+    }
+}

--- a/src/ui/rail.rs
+++ b/src/ui/rail.rs
@@ -297,6 +297,8 @@ mod tests {
         assert!(app.rail_area.is_none());
     }
 
+    // Drives the key/mouse handler, which is native-only.
+    #[cfg(feature = "native")]
     #[test]
     fn keys_and_clicks_queue_a_session_switch() {
         use crossterm::event::{

--- a/src/ui/rail.rs
+++ b/src/ui/rail.rs
@@ -355,7 +355,7 @@ mod tests {
         click(&mut app, 1);
         assert_eq!(app.pending_watch, Some(PathBuf::from("/p/sess-b.jsonl")));
 
-        // `w` hides the rail even with two sessions; `v` cycles the layout.
+        // `w` hides the rail even with two sessions.
         let press = |app: &mut App, c: char| {
             crate::handler::handle_event(
                 &Event::Key(KeyEvent {

--- a/src/ui/rail.rs
+++ b/src/ui/rail.rs
@@ -307,24 +307,29 @@ mod tests {
         let mut app = app_with_two_sessions();
         rendered_ui(&mut app, 100, 24);
 
-        // `n` steps to the next session and queues it for the tailer; the
-        // marker does NOT move yet, because the app is still watching sess-a
-        // until the tailer confirms the switch.
+        // `n` switches focus and queues the new transcript for the tailer. The
+        // switch is the App's own decision now, so the marker moves at once
+        // rather than waiting for a tailer to confirm it.
         crate::handler::handle_event(
             &Event::Key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)),
             &mut app,
         );
         assert_eq!(app.pending_watch, Some(PathBuf::from("/p/sess-b.jsonl")));
-        assert_eq!(app.rail.focused_index(&app.current_session_id), Some(0));
+        assert_eq!(app.current_session_id, "sess-b");
+        assert_eq!(app.rail.focused_index(&app.current_session_id), Some(1));
 
-        // With two rows, `p` wraps to the same other session as `n` does.
+        // `p` steps back to the session we came from.
         app.pending_watch = None;
         crate::handler::handle_event(
             &Event::Key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE)),
             &mut app,
         );
-        assert_eq!(app.pending_watch, Some(PathBuf::from("/p/sess-b.jsonl")));
+        assert_eq!(app.pending_watch, Some(PathBuf::from("/p/sess-a.jsonl")));
+        assert_eq!(app.current_session_id, "sess-a");
 
+        // The rail must still be drawn to map clicks; the switch cleared the
+        // recorded rect along with everything else about the old session.
+        rendered_ui(&mut app, 100, 24);
         let area = app.rail_area.expect("rail drawn");
         let click = |app: &mut App, row: u16| {
             crate::handler::handle_event(

--- a/web/wasm/Cargo.lock
+++ b/web/wasm/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca55ee147b1926dbea904f50fe4902494e97bc742205abbbf10c709e43815f"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +99,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
+
+[[package]]
 name = "bitvec"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +121,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "castaway"
@@ -371,6 +389,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "imbl"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ea8d4c37ee560727e824d62804183624d371e632019b0e9e3532bce64a33e5"
+dependencies = [
+ "archery",
+ "bitmaps",
+ "equivalent",
+ "imbl-sized-chunks",
+ "rand_core",
+ "rand_xoshiro",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +605,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rataflow"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +730,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "serde"
@@ -950,6 +1017,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1105,7 @@ name = "zoetrope"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "imbl",
  "rataflow",
  "ratatui",
  "serde",


### PR DESCRIPTION
Hi, I have had some code for a while that deals with multi session support (did it as an exercise to learn rust, while taking some optimization opportunities). The unit tests and benchmarks are coded with AI agents.

Generalizes zoetrope from "the newest session in this project" to "every session running right now", and does the performance work that makes that affordable/possible.

> Even if you're not interested in multi-session support, i still think the performance improvements arel a big enough of win

The canvas shows every live session as a root card with its agents beneath it.
A session rail (`w`) lists everything touched in the last 24h; one session is
*focused* and owns the timeline, scrubber and detail panel. Selecting any card focuses its session.

Clippy clean at `--all-targets`; the portable core (`--no-default-features`) and the wasm frontend both build. Let me know if anything else is required to pass.

## Performance

- Benchmark baseline in  first commit (so everything else is mesurable) over synthetic sessions (200 / 2400 / 31k line variants).
- A skeleton index 32 bytes per session line, built by scanning top-level JSON fields only (memchr over an mmap), append-incremental, disk cached -> discover how many agents, last activity, failures without parsing a single message body.
- `imbl` persistent collections: model clone is O(1) helping to manage liveness state efficiently
- Snapshot ladder:  a rung every 1024 folded items, so a backward seek folds ≤1 stride instead of from item zero.
- Precise ladder invalidation
- Backward seek patches the canvas: seeking back can only *remove* agents, so `OrdMap::diff` names them and only those nodes come off.
- Discovery caching. Previously every 2s tick re-walked every session's tree and re-decoded every index (the one index for a single session). if sessions were not touched for hours, this is wastefull.
- per-row and per-batch whole-canvas resyncs (now one per sweep); root cards rebuilt every frame once labelled (`content_matches` compared against the literal `"claude"`).