### PR TITLE
Feat/snapshot ladder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +34,18 @@ checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -57,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +132,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +213,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +299,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
@@ -358,6 +512,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +619,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -557,6 +731,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +780,22 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "palette"
@@ -673,6 +872,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,7 +962,7 @@ dependencies = [
  "bitflags",
  "compact_str",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
@@ -769,7 +996,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -780,6 +1007,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +1034,35 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rust-sugiyama"
@@ -831,6 +1107,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1033,6 +1318,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,7 +1366,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1081,6 +1376,16 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1134,6 +1439,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1473,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1234,6 +1558,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,8 +1589,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "criterion",
  "crossterm",
  "futures",
+ "memchr",
+ "memmap2",
  "rataflow",
  "ratatui",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca55ee147b1926dbea904f50fe4902494e97bc742205abbbf10c709e43815f"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +81,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +97,12 @@ name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "cast"
@@ -590,6 +608,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "imbl"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ea8d4c37ee560727e824d62804183624d371e632019b0e9e3532bce64a33e5"
+dependencies = [
+ "archery",
+ "bitmaps",
+ "equivalent",
+ "imbl-sized-chunks",
+ "rand_core",
+ "rand_xoshiro",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,15 +772,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memmap2"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "mio"
@@ -930,6 +964,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rataflow"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +1156,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -1378,6 +1436,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1520,16 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -1592,8 +1666,7 @@ dependencies = [
  "criterion",
  "crossterm",
  "futures",
- "memchr",
- "memmap2",
+ "imbl",
  "rataflow",
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,16 @@ name = "zoe"
 path = "src/main.rs"
 # Native terminal binary — skipped by a `--no-default-features` build.
 required-features = ["native"]
+
+[dev-dependencies]
+criterion = { version = "0.8.2", features = ["html_reports"] }
+
+# Baselines for the parse -> timeline -> fold -> seek pipeline, over synthetic
+# sessions (benches/common).
+[[bench]]
+name = "timeline"
+harness = false
+
+[[bench]]
+name = "memory"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,9 @@ tokio = { version = "1", features = [
 ], optional = true }
 futures = { version = "0.3", optional = true }
 anyhow = { version = "1", optional = true }
+# Persistent collections: cloning a `SessionModel` shares structure instead of
+# copying it, which is what makes a snapshot ladder rung O(1).
+imbl = "7.0.1"
 
 # The library's own wasm requirement, independent of any frontend: chrono needs
 # its wasm time binding for `Utc::now()` to work in-browser. A browser backend

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -1,0 +1,501 @@
+//! Deterministic synthetic session generator for the benchmarks.
+//!
+//! Produces transcripts in the on-disk shape (`<uuid>.jsonl` + `subagents/`
+//! sidecars) without touching `~/.claude/projects`: benches must be
+//! reproducible on any machine and must never read a real session. Every line
+//! is built with `serde_json::json!`, so the output parses by construction.
+//!
+//! Shape and volume are calibrated against the aggregate statistics of real
+//! transcripts: a line is a couple of kilobytes, spawns land every few prompt
+//! eras, and the subagent sidecars outweigh the main transcript. The scales are
+//! deliberately spread so a result can be read as a trend rather than a point —
+//! see `Spec::SMALL/MEDIUM/LARGE`.
+
+#![allow(dead_code)]
+
+use serde_json::json;
+
+/// Filler text of exactly `n` bytes — JSON-safe ASCII, no escapes, so a line's
+/// serialized size is predictable.
+fn filler(n: usize) -> String {
+    const WORDS: [&str; 8] = [
+        "resolve ",
+        "the ",
+        "handler ",
+        "before ",
+        "folding ",
+        "into ",
+        "the model ",
+        "again ",
+    ];
+    let mut s = String::with_capacity(n + 16);
+    let mut i = 0;
+    while s.len() < n {
+        s.push_str(WORDS[i % WORDS.len()]);
+        i += 1;
+    }
+    s.truncate(n);
+    s
+}
+
+/// ISO-8601 stamp `t` seconds after a fixed epoch. Monotone across a session.
+fn ts(t: u64) -> String {
+    let base = chrono::DateTime::parse_from_rfc3339("2026-06-01T09:00:00.000Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    (base + chrono::Duration::seconds(t as i64))
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string()
+}
+
+/// The volume knobs of a generated session.
+#[derive(Debug, Clone, Copy)]
+pub struct Spec {
+    /// Human prompts — the era spine.
+    pub eras: usize,
+    /// Assistant turns per era.
+    pub turns_per_era: usize,
+    /// `tool_use` blocks per assistant turn (each gets a `tool_result`).
+    pub tools_per_turn: usize,
+    /// Direct `Agent` spawns (one subagent sidecar each).
+    pub subagents: usize,
+    /// Assistant turns inside each subagent transcript.
+    pub sub_turns: usize,
+    /// `Workflow` launches (one group + `wf_agents` sidecars + a journal each).
+    pub workflows: usize,
+    /// Subagents per workflow.
+    pub wf_agents: usize,
+    /// Filler bytes per text/thinking/result payload — the line-size dial.
+    pub payload: usize,
+}
+
+impl Spec {
+    /// A short session: 222 lines / ~0.3 MB. Generation is deterministic, so
+    /// these figures describe the generator, not a measurement.
+    pub const SMALL: Spec = Spec {
+        eras: 12,
+        turns_per_era: 3,
+        tools_per_turn: 3,
+        subagents: 4,
+        sub_turns: 8,
+        workflows: 1,
+        wf_agents: 3,
+        payload: 900,
+    };
+    /// A long working session: 2,391 lines / ~4.6 MB.
+    pub const MEDIUM: Spec = Spec {
+        eras: 60,
+        turns_per_era: 5,
+        tools_per_turn: 4,
+        subagents: 20,
+        sub_turns: 20,
+        workflows: 4,
+        wf_agents: 5,
+        payload: 1100,
+    };
+    /// A pathologically large session: 31,371 lines / ~67 MB, the order of the
+    /// largest single transcripts that occur in practice.
+    pub const LARGE: Spec = Spec {
+        eras: 450,
+        turns_per_era: 6,
+        tools_per_turn: 5,
+        subagents: 130,
+        sub_turns: 45,
+        workflows: 18,
+        wf_agents: 8,
+        payload: 1300,
+    };
+}
+
+/// One generated subagent sidecar: transcript text + `meta.json` text.
+pub struct Sidecar {
+    pub agent_id: String,
+    pub meta: String,
+    pub transcript: String,
+    pub workflow: Option<String>,
+    pub journal: bool,
+}
+
+/// A generated session: the main transcript plus every sidecar.
+pub struct Session {
+    pub main: String,
+    pub sidecars: Vec<Sidecar>,
+}
+
+impl Session {
+    /// Total bytes across every file — what a cold parse actually reads.
+    pub fn bytes(&self) -> usize {
+        self.main.len()
+            + self
+                .sidecars
+                .iter()
+                .map(|s| s.transcript.len() + s.meta.len())
+                .sum::<usize>()
+    }
+
+    /// Total lines across every file.
+    pub fn lines(&self) -> usize {
+        self.main.lines().count()
+            + self
+                .sidecars
+                .iter()
+                .map(|s| s.transcript.lines().count())
+                .sum::<usize>()
+    }
+
+    /// Borrowed view in the shape `tailer::replay_from_session` expects.
+    pub fn demo_subagents(&self) -> Vec<zoetrope::tailer::DemoSubagent<'_>> {
+        self.sidecars
+            .iter()
+            .map(|s| zoetrope::tailer::DemoSubagent {
+                agent_id: &s.agent_id,
+                meta: &s.meta,
+                transcript: &s.transcript,
+                workflow: s.workflow.as_deref(),
+                journal: s.journal,
+            })
+            .collect()
+    }
+}
+
+/// 17-hex agent id, the width real `agent-<id>.jsonl` filenames use.
+fn agent_id(n: usize) -> String {
+    format!("{n:017x}")
+}
+
+/// Build a full synthetic session from `spec`.
+///
+/// The main transcript interleaves prompt eras with spawns so the model
+/// exercises every join it has: era attribution, `Agent`/`Workflow` spawn
+/// context, `tool_result` completion, and the workflow journal's `result`
+/// ledger.
+pub fn session(spec: Spec) -> Session {
+    let mut main = String::new();
+    let mut sidecars = Vec::new();
+    let mut t = 0u64;
+    let mut uuid = 0usize;
+    let mut tool_seq = 0usize;
+    let next_uuid = |uuid: &mut usize| {
+        *uuid += 1;
+        format!("u{uuid:07}")
+    };
+
+    // Flat session metadata (untimed — routed to SessionInfo, off the timeline).
+    for line in [
+        json!({"type":"ai-title","aiTitle":"Synthetic benchmark session","sessionId":"bench"}),
+        json!({"type":"mode","mode":"normal","sessionId":"bench"}),
+        json!({"type":"permission-mode","permissionMode":"acceptEdits","sessionId":"bench"}),
+    ] {
+        main.push_str(&line.to_string());
+        main.push('\n');
+    }
+
+    // Spawns are spread evenly across the eras rather than clustered at the
+    // front, so a mid-timeline seek always lands inside live subagent work.
+    let total_spawns = spec.subagents + spec.workflows;
+    let spawn_every = spec
+        .eras
+        .checked_div(total_spawns)
+        .map_or(usize::MAX, |n| n.max(1));
+    let mut spawned_subs = 0usize;
+    let mut spawned_wfs = 0usize;
+
+    let mut prev = String::new();
+    for era in 0..spec.eras {
+        // --- the human prompt: an era boundary ---
+        let id = next_uuid(&mut uuid);
+        t += 30;
+        main.push_str(
+            &json!({
+                "type":"user","uuid":id,
+                "parentUuid": if prev.is_empty() { serde_json::Value::Null } else { json!(prev) },
+                "timestamp": ts(t),
+                "sessionId":"bench","cwd":"/home/dev/project",
+                "origin":{"kind":"human"},
+                "message":{"role":"user","content":format!("era {era}: {}", filler(spec.payload / 4))}
+            })
+            .to_string(),
+        );
+        main.push('\n');
+        prev = id;
+
+        // --- assistant turns, each answered by a tool_result user turn ---
+        for _ in 0..spec.turns_per_era {
+            let a_id = next_uuid(&mut uuid);
+            t += 7;
+            let tools: Vec<_> = (0..spec.tools_per_turn)
+                .map(|_| {
+                    tool_seq += 1;
+                    let tid = format!("toolu_{tool_seq:08}");
+                    (
+                        tid.clone(),
+                        json!({"type":"tool_use","id":tid,"name":"Read",
+                               "input":{"file_path":"/home/dev/project/src/state/mod.rs","offset":1,"limit":200}}),
+                    )
+                })
+                .collect();
+            let mut content = vec![
+                json!({"type":"thinking","thinking":filler(spec.payload),"signature":"sig"}),
+                json!({"type":"text","text":filler(spec.payload / 2)}),
+            ];
+            content.extend(tools.iter().map(|(_, b)| b.clone()));
+            main.push_str(
+                &json!({
+                    "type":"assistant","uuid":a_id,"parentUuid":prev,"timestamp":ts(t),
+                    "sessionId":"bench","requestId":"req_bench",
+                    "message":{"role":"assistant","model":"claude-opus-5","stop_reason":"tool_use",
+                               "content":content,
+                               "usage":{"input_tokens":12000,"output_tokens":800,
+                                        "cache_read_input_tokens":9000}}
+                })
+                .to_string(),
+            );
+            main.push('\n');
+            prev = a_id;
+
+            let r_id = next_uuid(&mut uuid);
+            t += 4;
+            // One result per call; every 9th fails, so failure markers land on
+            // the scrubber the way a real session's do.
+            let blocks: Vec<_> = tools
+                .iter()
+                .enumerate()
+                .map(|(i, (tid, _))| {
+                    json!({"type":"tool_result","tool_use_id":tid,
+                           "is_error": i % 9 == 8,
+                           "content": filler(spec.payload)})
+                })
+                .collect();
+            main.push_str(
+                &json!({
+                    "type":"user","uuid":r_id,"parentUuid":prev,"timestamp":ts(t),
+                    "sessionId":"bench","message":{"role":"user","content":blocks}
+                })
+                .to_string(),
+            );
+            main.push('\n');
+            prev = r_id;
+        }
+
+        // --- periodic spawn: a direct subagent, then a workflow ---
+        if era % spawn_every == 0 {
+            if spawned_subs < spec.subagents {
+                let n = spawned_subs;
+                spawned_subs += 1;
+                tool_seq += 1;
+                let tid = format!("toolu_{tool_seq:08}");
+                let aid = agent_id(0x1000 + n);
+                let a_id = next_uuid(&mut uuid);
+                t += 6;
+                main.push_str(
+                    &json!({
+                        "type":"assistant","uuid":a_id,"parentUuid":prev,"timestamp":ts(t),
+                        "sessionId":"bench",
+                        "message":{"role":"assistant","model":"claude-opus-5","stop_reason":"tool_use",
+                            "content":[
+                                {"type":"text","text":filler(spec.payload / 2)},
+                                {"type":"tool_use","id":tid,"name":"Agent",
+                                 "input":{"description":format!("probe subsystem {n}"),
+                                          "subagent_type":"Explore",
+                                          "prompt":filler(spec.payload / 2)}}]}
+                    })
+                    .to_string(),
+                );
+                main.push('\n');
+                prev = a_id;
+
+                // The spawn ack (a tool_result), then the subagent's own file.
+                let r_id = next_uuid(&mut uuid);
+                t += 2;
+                main.push_str(
+                    &json!({
+                        "type":"user","uuid":r_id,"parentUuid":prev,"timestamp":ts(t),
+                        "sessionId":"bench",
+                        "message":{"role":"user","content":[
+                            {"type":"tool_result","tool_use_id":tid,"content":filler(spec.payload / 2)}]}
+                    })
+                    .to_string(),
+                );
+                main.push('\n');
+                prev = r_id;
+
+                sidecars.push(Sidecar {
+                    meta: json!({"agentType":"Explore",
+                                 "description":format!("probe subsystem {n}"),
+                                 "toolUseId":tid})
+                    .to_string(),
+                    transcript: subagent_transcript(&aid, t, spec),
+                    agent_id: aid,
+                    workflow: None,
+                    journal: false,
+                });
+            } else if spawned_wfs < spec.workflows {
+                let n = spawned_wfs;
+                spawned_wfs += 1;
+                tool_seq += 1;
+                let tid = format!("toolu_{tool_seq:08}");
+                let run_id = format!("wf_bench{n:04}");
+                let a_id = next_uuid(&mut uuid);
+                t += 6;
+                main.push_str(
+                    &json!({
+                        "type":"assistant","uuid":a_id,"parentUuid":prev,"timestamp":ts(t),
+                        "sessionId":"bench",
+                        "message":{"role":"assistant","model":"claude-opus-5","stop_reason":"tool_use",
+                            "content":[{"type":"tool_use","id":tid,"name":"Workflow",
+                                        "input":{"description":"review the change across dimensions",
+                                                 "name":"review-changes"}}]}
+                    })
+                    .to_string(),
+                );
+                main.push('\n');
+                prev = a_id;
+
+                // The launch ack carries the runId — ground truth for the group id.
+                let r_id = next_uuid(&mut uuid);
+                t += 3;
+                main.push_str(
+                    &json!({
+                        "type":"user","uuid":r_id,"parentUuid":prev,"timestamp":ts(t),
+                        "sessionId":"bench",
+                        "toolUseResult":{"taskType":"local_workflow","runId":run_id,
+                                         "workflowName":"review-changes",
+                                         "summary":"Review changed files across dimensions"},
+                        "message":{"role":"user","content":[
+                            {"type":"tool_result","tool_use_id":tid,"content":"started"}]}
+                    })
+                    .to_string(),
+                );
+                main.push('\n');
+                prev = r_id;
+
+                let mut journal = String::new();
+                for k in 0..spec.wf_agents {
+                    let aid = agent_id(0x2000 + n * 100 + k);
+                    journal.push_str(
+                        &json!({"type":"started","key":format!("agent-{k}"),"agentId":aid})
+                            .to_string(),
+                    );
+                    journal.push('\n');
+                    journal.push_str(
+                        &json!({"type":"result","key":format!("agent-{k}"),"agentId":aid,
+                                "result":{"ok":true,"text":filler(spec.payload / 4)}})
+                        .to_string(),
+                    );
+                    journal.push('\n');
+                    sidecars.push(Sidecar {
+                        meta: json!({"agentType":"workflow-subagent"}).to_string(),
+                        transcript: subagent_transcript(&aid, t, spec),
+                        agent_id: aid,
+                        workflow: Some(run_id.clone()),
+                        journal: false,
+                    });
+                }
+                sidecars.push(Sidecar {
+                    agent_id: String::new(),
+                    meta: String::new(),
+                    transcript: journal,
+                    workflow: Some(run_id),
+                    journal: true,
+                });
+            }
+        }
+    }
+
+    Session { main, sidecars }
+}
+
+/// A subagent's own transcript: a sidechain prompt then `sub_turns` tool turns,
+/// every line stamped with `agentId` (the join key the model folds on).
+fn subagent_transcript(aid: &str, start: u64, spec: Spec) -> String {
+    let mut s = String::new();
+    let mut t = start;
+    let mut seq = 0usize;
+
+    let id = format!("{aid}-u0");
+    t += 1;
+    s.push_str(
+        &json!({
+            "type":"user","uuid":id,"parentUuid":serde_json::Value::Null,"timestamp":ts(t),
+            "agentId":aid,"isSidechain":true,
+            "message":{"role":"user","content":filler(spec.payload)}
+        })
+        .to_string(),
+    );
+    s.push('\n');
+    let mut prev = id;
+
+    for turn in 0..spec.sub_turns {
+        seq += 1;
+        let tid = format!("toolu_{aid}_{seq:05}");
+        let a_id = format!("{aid}-a{turn}");
+        t += 5;
+        s.push_str(
+            &json!({
+                "type":"assistant","uuid":a_id,"parentUuid":prev,"timestamp":ts(t),
+                "agentId":aid,"attributionAgent":aid,
+                "message":{"role":"assistant","model":"claude-sonnet-5","stop_reason":"tool_use",
+                    "content":[
+                        {"type":"thinking","thinking":filler(spec.payload),"signature":"sig"},
+                        {"type":"tool_use","id":tid,"name":"Grep",
+                         "input":{"pattern":"fn apply_update","path":"src"}}],
+                    "usage":{"input_tokens":8000,"output_tokens":400}}
+            })
+            .to_string(),
+        );
+        s.push('\n');
+        prev = a_id;
+
+        let r_id = format!("{aid}-r{turn}");
+        t += 3;
+        s.push_str(
+            &json!({
+                "type":"user","uuid":r_id,"parentUuid":prev,"timestamp":ts(t),
+                "agentId":aid,"isSidechain":true,
+                "message":{"role":"user","content":[
+                    {"type":"tool_result","tool_use_id":tid,"content":filler(spec.payload)}]}
+            })
+            .to_string(),
+        );
+        s.push('\n');
+        prev = r_id;
+    }
+    s
+}
+
+/// Write a generated session to disk in the real on-disk layout, under
+/// `project_dir`: `<uuid>.jsonl` plus `<uuid>/subagents/agent-<id>.jsonl` and
+/// `<uuid>/subagents/workflows/<wf>/…`. Returns the main transcript's path.
+///
+/// The index and discovery benches measure the filesystem path (mmap, cache
+/// sidecars, directory sweeps), so they need real files rather than strings.
+pub fn write_to_disk(s: &Session, project_dir: &std::path::Path, uuid: &str) -> std::path::PathBuf {
+    std::fs::create_dir_all(project_dir).unwrap();
+    let main = project_dir.join(format!("{uuid}.jsonl"));
+    std::fs::write(&main, &s.main).unwrap();
+
+    let subs = project_dir.join(uuid).join("subagents");
+    std::fs::create_dir_all(&subs).unwrap();
+    for sc in &s.sidecars {
+        let dir = match &sc.workflow {
+            Some(wf) => subs.join("workflows").join(wf),
+            None => subs.clone(),
+        };
+        std::fs::create_dir_all(&dir).unwrap();
+        if sc.journal {
+            std::fs::write(dir.join("journal.jsonl"), &sc.transcript).unwrap();
+            continue;
+        }
+        std::fs::write(
+            dir.join(format!("agent-{}.jsonl", sc.agent_id)),
+            &sc.transcript,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join(format!("agent-{}.meta.json", sc.agent_id)),
+            &sc.meta,
+        )
+        .unwrap();
+    }
+    main
+}

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -11,8 +11,6 @@
 //! deliberately spread so a result can be read as a trend rather than a point —
 //! see `Spec::SMALL/MEDIUM/LARGE`.
 
-#![allow(dead_code)]
-
 use serde_json::json;
 
 /// Filler text of exactly `n` bytes — JSON-safe ASCII, no escapes, so a line's
@@ -134,6 +132,9 @@ impl Session {
     }
 
     /// Total lines across every file.
+    // Each bench is its own crate and uses a different part of this module;
+    // only `memory.rs` reports line counts.
+    #[allow(dead_code)]
     pub fn lines(&self) -> usize {
         self.main.lines().count()
             + self
@@ -461,41 +462,4 @@ fn subagent_transcript(aid: &str, start: u64, spec: Spec) -> String {
         prev = r_id;
     }
     s
-}
-
-/// Write a generated session to disk in the real on-disk layout, under
-/// `project_dir`: `<uuid>.jsonl` plus `<uuid>/subagents/agent-<id>.jsonl` and
-/// `<uuid>/subagents/workflows/<wf>/…`. Returns the main transcript's path.
-///
-/// The index and discovery benches measure the filesystem path (mmap, cache
-/// sidecars, directory sweeps), so they need real files rather than strings.
-pub fn write_to_disk(s: &Session, project_dir: &std::path::Path, uuid: &str) -> std::path::PathBuf {
-    std::fs::create_dir_all(project_dir).unwrap();
-    let main = project_dir.join(format!("{uuid}.jsonl"));
-    std::fs::write(&main, &s.main).unwrap();
-
-    let subs = project_dir.join(uuid).join("subagents");
-    std::fs::create_dir_all(&subs).unwrap();
-    for sc in &s.sidecars {
-        let dir = match &sc.workflow {
-            Some(wf) => subs.join("workflows").join(wf),
-            None => subs.clone(),
-        };
-        std::fs::create_dir_all(&dir).unwrap();
-        if sc.journal {
-            std::fs::write(dir.join("journal.jsonl"), &sc.transcript).unwrap();
-            continue;
-        }
-        std::fs::write(
-            dir.join(format!("agent-{}.jsonl", sc.agent_id)),
-            &sc.transcript,
-        )
-        .unwrap();
-        std::fs::write(
-            dir.join(format!("agent-{}.meta.json", sc.agent_id)),
-            &sc.meta,
-        )
-        .unwrap();
-    }
-    main
 }

--- a/benches/memory.rs
+++ b/benches/memory.rs
@@ -1,0 +1,91 @@
+//! Memory baseline: how much resident memory one loaded session costs.
+//!
+//! Not a criterion bench — it prints a table. Timing lives in `timeline.rs`;
+//! this answers the other half of the multi-session question, since the whole
+//! point of tracking N sessions is that N × this has to fit.
+//!
+//! RSS is sampled from `/proc/self/statm`, so the deltas are approximate: the
+//! allocator does not return freed pages to the OS, which makes each stage's
+//! delta an upper bound on what that stage retains and the total a fair figure
+//! for "what one open session costs". Non-Linux prints the shape only.
+
+mod common;
+
+use common::{Session, Spec};
+use zoetrope::state::{App, Mode};
+use zoetrope::tailer::{UiEvent, replay_from_session};
+
+/// Resident set size in bytes, or `None` where `/proc` is not available.
+fn rss() -> Option<usize> {
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let pages: usize = statm.split_whitespace().nth(1)?.parse().ok()?;
+    Some(pages * page_size())
+}
+
+fn page_size() -> usize {
+    // 4 KiB everywhere this runs; reading it out of `getconf` is not worth a dep.
+    4096
+}
+
+fn mb(bytes: usize) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+/// Load one scale end to end, sampling RSS at each stage.
+fn measure(name: &str, spec: Spec) {
+    let base = rss();
+
+    let s: Session = common::session(spec);
+    let after_gen = rss();
+
+    let (items, info) = replay_from_session(&s.main, &s.demo_subagents());
+    let item_count = items.len();
+    let after_items = rss();
+
+    let mut app = App::new("bench".to_string(), Mode::Live);
+    app.handle_ui_event(UiEvent::ReplayLoaded {
+        session_id: "bench".to_string(),
+        items,
+        speed: 8.0,
+        info,
+    });
+    app.go_live();
+    let after_app = rss();
+
+    let delta = |a: Option<usize>, b: Option<usize>| match (a, b) {
+        (Some(a), Some(b)) => format!("{:>8.1}", mb(b.saturating_sub(a))),
+        _ => "     n/a".to_string(),
+    };
+
+    println!(
+        "{name:<7} {:>7} {:>9.1} {:>9} {:>8} {:>8} {:>8} {:>8} {:>7} {:>7}",
+        s.lines(),
+        mb(s.bytes()),
+        item_count,
+        delta(base, after_gen),
+        delta(after_gen, after_items),
+        delta(after_items, after_app),
+        delta(base, after_app),
+        app.session.agents.len(),
+        app.flow.nodes().count(),
+    );
+
+    // Keep everything alive to the end of the measurement.
+    std::hint::black_box(&s);
+    std::hint::black_box(&app);
+}
+
+fn main() {
+    println!("synthetic session memory baseline (RSS deltas, MB)\n");
+    println!(
+        "{:<7} {:>7} {:>9} {:>9} {:>8} {:>8} {:>8} {:>8} {:>7} {:>7}",
+        "scale", "lines", "text MB", "items", "gen", "items", "app", "total", "agents", "nodes"
+    );
+    println!("{}", "-".repeat(88));
+    // Each scale runs in its own process-lifetime segment; the allocator's
+    // retained pages make later rows read high, so run them smallest-first and
+    // read each row's `total` as the headline.
+    measure("small", Spec::SMALL);
+    measure("medium", Spec::MEDIUM);
+    measure("large", Spec::LARGE);
+}

--- a/benches/memory.rs
+++ b/benches/memory.rs
@@ -66,7 +66,7 @@ fn measure(name: &str, spec: Spec) {
         delta(after_gen, after_items),
         delta(after_items, after_app),
         delta(base, after_app),
-        app.session.agents.len(),
+        app.session.agent_count(),
         app.flow.nodes().count(),
     );
 

--- a/benches/memory.rs
+++ b/benches/memory.rs
@@ -1,46 +1,77 @@
-//! Memory baseline: how much resident memory one loaded session costs.
+//! Memory baseline: how much heap one loaded session costs.
 //!
 //! Not a criterion bench — it prints a table. Timing lives in `timeline.rs`;
-//! this answers the other half of the multi-session question, since the whole
-//! point of tracking N sessions is that N × this has to fit.
+//! this answers the other half: a snapshot ladder trades memory for seek time,
+//! so the rungs have to be worth what they retain.
 //!
-//! RSS is sampled from `/proc/self/statm`, so the deltas are approximate: the
-//! allocator does not return freed pages to the OS, which makes each stage's
-//! delta an upper bound on what that stage retains and the total a fair figure
-//! for "what one open session costs". Non-Linux prints the shape only.
+//! Measured with a counting global allocator rather than RSS, which reports
+//! LIVE heap: exact, allocator-independent, and identical on every platform.
+//! RSS could only ever be an upper bound, since the allocator does not return
+//! freed pages to the OS, and it read as zero wherever `/proc` is absent.
 
 mod common;
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use common::{Session, Spec};
 use zoetrope::state::{App, Mode};
 use zoetrope::tailer::{UiEvent, replay_from_session};
 
-/// Resident set size in bytes, or `None` where `/proc` is not available.
-fn rss() -> Option<usize> {
-    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
-    let pages: usize = statm.split_whitespace().nth(1)?.parse().ok()?;
-    Some(pages * page_size())
+/// Bytes currently allocated and not yet freed.
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+
+/// `System`, plus a running total of live bytes.
+///
+/// Relaxed ordering throughout: the counter is a statistic, and no other memory
+/// is published through it.
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc(layout) };
+        if !p.is_null() {
+            LIVE.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        p
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let p = unsafe { System.realloc(ptr, layout, new_size) };
+        if !p.is_null() {
+            LIVE.fetch_add(new_size, Ordering::Relaxed);
+            LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+        }
+        p
+    }
 }
 
-fn page_size() -> usize {
-    // 4 KiB everywhere this runs; reading it out of `getconf` is not worth a dep.
-    4096
+#[global_allocator]
+static ALLOC: Counting = Counting;
+
+fn live() -> usize {
+    LIVE.load(Ordering::Relaxed)
 }
 
 fn mb(bytes: usize) -> f64 {
     bytes as f64 / (1024.0 * 1024.0)
 }
 
-/// Load one scale end to end, sampling RSS at each stage.
+/// Load one scale end to end, sampling live heap at each stage.
 fn measure(name: &str, spec: Spec) {
-    let base = rss();
+    let base = live();
 
     let s: Session = common::session(spec);
-    let after_gen = rss();
+    let after_gen = live();
 
     let (items, info) = replay_from_session(&s.main, &s.demo_subagents());
     let item_count = items.len();
-    let after_items = rss();
+    let after_items = live();
 
     let mut app = App::new("bench".to_string(), Mode::Live);
     app.handle_ui_event(UiEvent::ReplayLoaded {
@@ -50,22 +81,27 @@ fn measure(name: &str, spec: Spec) {
         info,
     });
     app.go_live();
-    let after_app = rss();
+    let after_app = live();
 
-    let delta = |a: Option<usize>, b: Option<usize>| match (a, b) {
-        (Some(a), Some(b)) => format!("{:>8.1}", mb(b.saturating_sub(a))),
-        _ => "     n/a".to_string(),
-    };
+    // The ladder is the part that trades memory for seek time, so price it on
+    // its own: fold to the edge, then read what the rungs added.
+    let before_seek = live();
+    app.seek_to_fraction(0.0);
+    app.seek_to_fraction(1.0);
+    let ladder = live().saturating_sub(before_seek);
+
+    let d = |a: usize, b: usize| mb(b.saturating_sub(a));
 
     println!(
-        "{name:<7} {:>7} {:>9.1} {:>9} {:>8} {:>8} {:>8} {:>8} {:>7} {:>7}",
+        "{name:<7} {:>7} {:>9.1} {:>9} {:>8.1} {:>8.1} {:>8.1} {:>8.1} {:>8.1} {:>7} {:>7}",
         s.lines(),
         mb(s.bytes()),
         item_count,
-        delta(base, after_gen),
-        delta(after_gen, after_items),
-        delta(after_items, after_app),
-        delta(base, after_app),
+        d(base, after_gen),
+        d(after_gen, after_items),
+        d(after_items, after_app),
+        d(base, after_app),
+        mb(ladder),
         app.session.agent_count(),
         app.flow.nodes().count(),
     );
@@ -76,15 +112,22 @@ fn measure(name: &str, spec: Spec) {
 }
 
 fn main() {
-    println!("synthetic session memory baseline (RSS deltas, MB)\n");
+    println!("synthetic session memory baseline (live heap, MB)\n");
     println!(
-        "{:<7} {:>7} {:>9} {:>9} {:>8} {:>8} {:>8} {:>8} {:>7} {:>7}",
-        "scale", "lines", "text MB", "items", "gen", "items", "app", "total", "agents", "nodes"
+        "{:<7} {:>7} {:>9} {:>9} {:>8} {:>8} {:>8} {:>8} {:>8} {:>7} {:>7}",
+        "scale",
+        "lines",
+        "text MB",
+        "items",
+        "gen",
+        "items",
+        "app",
+        "total",
+        "ladder",
+        "agents",
+        "nodes"
     );
-    println!("{}", "-".repeat(88));
-    // Each scale runs in its own process-lifetime segment; the allocator's
-    // retained pages make later rows read high, so run them smallest-first and
-    // read each row's `total` as the headline.
+    println!("{}", "-".repeat(97));
     measure("small", Spec::SMALL);
     measure("medium", Spec::MEDIUM);
     measure("large", Spec::LARGE);

--- a/benches/timeline.rs
+++ b/benches/timeline.rs
@@ -1,0 +1,183 @@
+//! Baseline benchmarks for the parse → timeline → fold → seek pipeline.
+//!
+//! Every input is synthesized (`common::session`) — the benches never read a
+//! real transcript, so a run is reproducible on any machine. Three scales
+//! bracket what the format produces in practice: a short session, a long
+//! working session, and a pathologically large one.
+//!
+//! What each group answers:
+//! - `parse`   — raw `parse_line` throughput, the floor on any cold open.
+//! - `load`    — assembling the ts-ordered timeline, and folding it into a model.
+//! - `seek`    — the playhead moves. `seek_back_*` is the O(k) rebuild path
+//!   (`App::rebuild_to`), the number that decides whether scrubbing is usable.
+
+mod common;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+use std::time::Duration;
+
+use common::{Session, Spec};
+use zoetrope::state::session::SessionModel;
+use zoetrope::state::{App, Mode};
+use zoetrope::tailer::{ReplayItem, UiEvent, replay_from_session};
+use zoetrope::transcript;
+
+/// The scales every group runs over.
+fn scales() -> Vec<(&'static str, Session)> {
+    vec![
+        ("small", common::session(Spec::SMALL)),
+        ("medium", common::session(Spec::MEDIUM)),
+        ("large", common::session(Spec::LARGE)),
+    ]
+}
+
+/// Assemble the ts-ordered timeline for a session (the untimed setup step
+/// shared by the fold and seek benches).
+fn items_of(s: &Session) -> Vec<ReplayItem> {
+    replay_from_session(&s.main, &s.demo_subagents()).0
+}
+
+/// An App with the whole session loaded and the playhead at the live edge —
+/// the state a user is in when they grab the scrubber.
+fn app_at_edge(s: &Session) -> App {
+    let (items, info) = replay_from_session(&s.main, &s.demo_subagents());
+    let mut app = App::new("bench".to_string(), Mode::Live);
+    app.handle_ui_event(UiEvent::ReplayLoaded {
+        session_id: "bench".to_string(),
+        items,
+        speed: 8.0,
+        info,
+    });
+    app.go_live();
+    app
+}
+
+fn bench_parse(c: &mut Criterion) {
+    let mut g = c.benchmark_group("parse");
+    for (name, s) in scales() {
+        // Every line of every file — what a cold open of one session reads.
+        let lines: Vec<&str> = s
+            .main
+            .lines()
+            .chain(s.sidecars.iter().flat_map(|sc| sc.transcript.lines()))
+            .collect();
+        let bytes: usize = lines.iter().map(|l| l.len() + 1).sum();
+        g.throughput(Throughput::Bytes(bytes as u64));
+        g.bench_with_input(BenchmarkId::new("parse_line", name), &lines, |b, lines| {
+            b.iter(|| {
+                let mut n = 0usize;
+                for l in lines {
+                    if transcript::parse_line(black_box(l)).is_some() {
+                        n += 1;
+                    }
+                }
+                n
+            })
+        });
+    }
+    g.finish();
+}
+
+fn bench_load(c: &mut Criterion) {
+    let mut g = c.benchmark_group("load");
+    // A cold open at the large scale is on the order of a second, so the
+    // criterion defaults (100 samples, 3 s warm-up) would run for many minutes
+    // to sharpen a number whose interesting digit is the first one.
+    g.sample_size(10);
+    g.warm_up_time(Duration::from_millis(500));
+    g.measurement_time(Duration::from_secs(10));
+    for (name, s) in scales() {
+        g.throughput(Throughput::Bytes(s.bytes() as u64));
+
+        // Text → dated, sorted timeline items.
+        g.bench_with_input(BenchmarkId::new("replay_assemble", name), &s, |b, s| {
+            b.iter(|| black_box(items_of(s).len()))
+        });
+
+        // Items → model. The pure fold, no graph projection.
+        g.bench_with_input(BenchmarkId::new("fold_cold", name), &s, |b, s| {
+            b.iter_batched(
+                || items_of(s),
+                |items| {
+                    let mut m = SessionModel::new("bench".to_string());
+                    for it in &items {
+                        m.apply_update(&it.update);
+                    }
+                    black_box(m.agents.len())
+                },
+                BatchSize::LargeInput,
+            )
+        });
+
+        // The real cold open: assemble + fold + project onto the flow graph.
+        g.bench_with_input(BenchmarkId::new("app_cold_open", name), &s, |b, s| {
+            b.iter(|| black_box(app_at_edge(s).flow.nodes().count()))
+        });
+    }
+    g.finish();
+}
+
+fn bench_seek(c: &mut Criterion) {
+    let mut g = c.benchmark_group("seek");
+    // Each sample re-loads the session in untimed setup (a seek mutates the
+    // App, so it cannot be reused) — same reasoning as `load` above.
+    g.sample_size(10);
+    g.warm_up_time(Duration::from_millis(500));
+    g.measurement_time(Duration::from_secs(10));
+    for (name, s) in scales() {
+        let n = items_of(&s).len();
+        g.throughput(Throughput::Elements(n as u64));
+
+        // Backward seek to the middle — rebuilds the model from items[0..n/2].
+        g.bench_with_input(BenchmarkId::new("back_to_50pct", name), &s, |b, s| {
+            b.iter_batched_ref(
+                || app_at_edge(s),
+                |app| app.seek_to_fraction(black_box(0.5)),
+                BatchSize::PerIteration,
+            )
+        });
+
+        // Backward seek to the start — the cheapest rebuild (folds nothing) but
+        // still pays the full model + flow teardown.
+        g.bench_with_input(BenchmarkId::new("back_to_start", name), &s, |b, s| {
+            b.iter_batched_ref(
+                || app_at_edge(s),
+                |app| app.seek_to_fraction(black_box(0.0)),
+                BatchSize::PerIteration,
+            )
+        });
+
+        // Forward seek across the whole timeline — the in-place fold path, for
+        // contrast with the rebuild above.
+        g.bench_with_input(BenchmarkId::new("fwd_start_to_edge", name), &s, |b, s| {
+            b.iter_batched_ref(
+                || {
+                    let mut app = app_at_edge(s);
+                    app.seek_to_fraction(0.0);
+                    app
+                },
+                |app| app.seek_to_fraction(black_box(1.0)),
+                BatchSize::PerIteration,
+            )
+        });
+
+        // A scrub drag: ten backward hops. This is what holding the mouse down
+        // on the scrubber actually costs.
+        g.bench_with_input(BenchmarkId::new("drag_10_back", name), &s, |b, s| {
+            b.iter_batched_ref(
+                || app_at_edge(s),
+                |app| {
+                    for i in (0..10).rev() {
+                        app.seek_to_fraction(black_box(i as f64 / 10.0));
+                    }
+                },
+                BatchSize::PerIteration,
+            )
+        });
+    }
+    g.finish();
+}
+
+criterion_group!(benches, bench_parse, bench_load, bench_seek);
+criterion_main!(benches);

--- a/benches/timeline.rs
+++ b/benches/timeline.rs
@@ -162,6 +162,18 @@ fn bench_seek(c: &mut Criterion) {
             )
         });
 
+        // One SMALL backward hop — what a scrubber drag actually delivers once
+        // `pending_seek` coalesces a burst to one seek per frame. The big jumps
+        // above are the worst case for patching the canvas; this is the case
+        // it exists for.
+        g.bench_with_input(BenchmarkId::new("back_one_hop", name), &s, |b, s| {
+            b.iter_batched_ref(
+                || app_at_edge(s),
+                |app| app.seek_to_fraction(black_box(0.95)),
+                BatchSize::PerIteration,
+            )
+        });
+
         // A scrub drag: ten backward hops. This is what holding the mouse down
         // on the scrubber actually costs.
         g.bench_with_input(BenchmarkId::new("drag_10_back", name), &s, |b, s| {

--- a/benches/timeline.rs
+++ b/benches/timeline.rs
@@ -104,7 +104,7 @@ fn bench_load(c: &mut Criterion) {
                     for it in &items {
                         m.apply_update(&it.update);
                     }
-                    black_box(m.agents.len())
+                    black_box(m.agent_count())
                 },
                 BatchSize::LargeInput,
             )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,14 +33,39 @@ Why this is non-negotiable — three independent consumers demand it:
 - **Multi-file merge.** Main transcript, `subagents/*.jsonl`, and workflow
   `journal.jsonl` are tailed separately and interleave by timestamp; a subagent's
   result can be read before its spawn.
-- **Backward seek.** Folding is forward-only, so seeking into the past *rebuilds*
-  the model from `items[0..target]` from scratch. That rebuild must land on
-  exactly the state that playing there would have.
+- **Backward seek.** Folding is forward-only, so seeking into the past re-folds
+  the model from `items[0..target]` from a **snapshot ladder** rung when one is
+  available, from item zero when it is not. Either way it must land on exactly
+  the state that playing there would have.
 - **Live vs replay.** The same items arrive as a bulk sorted `Vec` (replay) or as
   arrival-order appends (live). Both must converge.
 
 Guarded by a **shuffle-invariance property test**: fold a real stream in bulk
 order and in many shuffled orders; the final model must be identical.
+
+### The snapshot ladder
+
+A rung every `SNAPSHOT_STRIDE` folded items, so a backward seek re-folds at most
+a stride instead of the whole prefix. Cloning a rung is O(1): `SessionModel` is
+built from persistent (`imbl`) collections, so a rung shares structure with its
+neighbours rather than copying the model. Invariants:
+
+- **A rung holds fold state only.** Liveness and workflow rollups are
+  projections *of the playhead*, not facts about the prefix, and are meaningless
+  at a different one. Every restore re-derives them through `resync`. This is
+  the fold/projection split above, applied to snapshots.
+- **Every fold path goes through `drop_stale_rungs`.** Item indices are not
+  stable: a late batch that dates a previously-`Pending` item re-sorts the list
+  and shifts every index around it, which would silently repoint a rung at a
+  different prefix. `Timeline::generation` marks that a re-sort happened and
+  `take_disturbance` reports how much of the prefix it provably left alone, so
+  rungs below that line are re-stamped and the rest discarded.
+- **A backward seek patches the canvas, it does not rebuild it.** Seeking back
+  can only *remove* agents: a fold never un-spawns one the earlier prefix
+  already had, and `sync` adds and updates but never removes. So `OrdMap::diff`
+  names the departed agents and only those nodes come off. Node positions, the
+  viewport and the selection are never disturbed, which is why nothing has to be
+  captured and restored around the seek.
 
 **Corollary — derived state is never monotonic.** A rollup that concluded "done"
 must *revert* when a contradicting fact (a late child, resumed activity) arrives.

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,7 +270,7 @@ fn read_session_info(main_path: &Path) -> zoetrope::state::SessionInfo {
 
 /// Recursively print agents whose `parent` equals `parent`, in spawn order.
 fn print_agent_tree(model: &SessionModel, parent: Option<&str>, depth: usize) {
-    for id in &model.spawn_order {
+    for id in model.spawn_order() {
         let Some(agent) = model.agent(id) else {
             continue;
         };
@@ -298,7 +298,7 @@ fn print_agent_tree(model: &SessionModel, parent: Option<&str>, depth: usize) {
         let mut ok = 0u32;
         let mut err = 0u32;
         let mut pending = 0u32;
-        for t in &agent.tool_calls {
+        for t in agent.tool_calls() {
             match t.state {
                 ToolState::Ok => ok += 1,
                 ToolState::Err => err += 1,
@@ -317,7 +317,7 @@ fn print_agent_tree(model: &SessionModel, parent: Option<&str>, depth: usize) {
         }
         println!(
             "{indent}    tools: {} ({ok}✓ {err}✗ {pending}⏳)   tokens: {}",
-            agent.tool_calls.len(),
+            agent.tool_calls().len(),
             agent.output_tokens
         );
 

--- a/src/state/graph.rs
+++ b/src/state/graph.rs
@@ -230,23 +230,26 @@ fn edge_id(child: &str) -> String {
     format!("e-{child}")
 }
 
+/// Remove several agents from the canvas in ONE pass.
+///
+/// Bulk, not a loop of single removals: `Flow::remove_node` costs O(nodes plus
+/// edges) every time — it shifts every lookup index and rebuilds the edge
+/// lookup per call — so removing k of them is quadratic. `retain_nodes` makes a
+/// single pass over each vec and drops the connected edges itself.
+pub fn remove_agents(flow: &mut AgentFlow, agents: &[String]) {
+    if agents.is_empty() {
+        return;
+    }
+    let doomed: std::collections::HashSet<&str> = agents.iter().map(String::as_str).collect();
+    flow.retain_nodes(|n| !doomed.contains(n.id.as_str()));
+}
+
 /// Apply the Sugiyama vertical layout to `flow`.
 ///
 /// Split out so it can be called explicitly and unit-tested independently of
 /// the per-agent diffing in [`sync`].
 pub fn relayout(flow: &mut AgentFlow) {
     flow.apply_layout(Sugiyama::vertical());
-}
-
-/// Restore saved positions onto whichever nodes still exist (used after a
-/// backward-seek rebuild to carry the user's manual arrangement across — and to
-/// avoid a layout jump, since a rebuilt subset would otherwise re-place from
-/// scratch). Nodes absent from `positions` keep their fresh local placement.
-pub fn restore_positions(
-    flow: &mut AgentFlow,
-    positions: &std::collections::HashMap<String, (f64, f64)>,
-) {
-    flow.set_node_positions(positions.iter().map(|(id, &pos)| (id, pos)));
 }
 
 #[cfg(test)]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -374,16 +374,36 @@ impl App {
                 // moves the cursor.
                 let following = self.timeline.following();
                 if following {
-                    // The model is order-independent, so apply the new updates
-                    // DIRECTLY (their position in the now-ts-sorted `items` is
-                    // irrelevant) — out-of-order live arrivals never force a
-                    // rebuild. Then mark the whole stream folded.
-                    let mut structural = false;
-                    for update in &activity {
-                        structural |= self.session.apply_update(update);
-                    }
-                    self.timeline.append_live(activity);
-                    self.timeline.folded = self.timeline.items.len();
+                    // Attach: nothing is folded yet, so the whole backfill
+                    // arrives as one batch. Fold it BY INDEX, which walks the
+                    // sorted prefix and leaves a rung every stride — the direct
+                    // apply below jumps `folded` straight to the edge, so the
+                    // only rung it can ever take sits at the edge, and the very
+                    // first backward seek would fold from item zero.
+                    //
+                    // Safe only here: an incremental batch can re-sort an item
+                    // in BELOW `folded`, which an index fold from `folded` would
+                    // skip. At zero there is no prefix to skip.
+                    let structural = if self.timeline.folded == 0 {
+                        self.timeline.append_live(activity);
+                        let to = self.timeline.items.len();
+                        let structural = self.fold_range(0, to);
+                        self.timeline.folded = to;
+                        structural
+                    } else {
+                        // The model is order-independent, so apply the new
+                        // updates DIRECTLY (their position in the now-ts-sorted
+                        // `items` is irrelevant) — out-of-order live arrivals
+                        // never force a rebuild. Then mark the whole stream
+                        // folded.
+                        let mut structural = false;
+                        for update in &activity {
+                            structural |= self.session.apply_update(update);
+                        }
+                        self.timeline.append_live(activity);
+                        self.timeline.folded = self.timeline.items.len();
+                        structural
+                    };
                     self.note_fold();
                     self.commit_fold(structural);
                 } else {
@@ -499,17 +519,27 @@ impl App {
         self.maybe_snapshot(self.timeline.folded, generation);
     }
 
-    /// Push a rung if `folded` is a full stride past the last one.
+    /// Push a rung if `folded` is a full stride past the nearest rung below it.
     ///
     /// Shared by both fold paths so the cadence cannot drift between them.
+    ///
+    /// Measured against the nearest rung at or below `folded`, not the last one
+    /// in the vec: with a rung already at the live edge, comparing against the
+    /// last would refuse every rung beneath it, so a fold that walks the early
+    /// timeline could never leave a ladder behind and each backward seek would
+    /// re-fold from zero.
     fn maybe_snapshot(&mut self, folded: usize, generation: u64) {
-        let last = self.snapshots.last().map_or(0, |s| s.folded);
-        if folded >= last + SNAPSHOT_STRIDE {
-            self.snapshots.push(Snapshot {
-                folded,
-                generation,
-                model: self.session.clone(),
-            });
+        let at = self.snapshots.partition_point(|s| s.folded <= folded);
+        let below = at.checked_sub(1).map_or(0, |i| self.snapshots[i].folded);
+        if folded >= below + SNAPSHOT_STRIDE {
+            self.snapshots.insert(
+                at,
+                Snapshot {
+                    folded,
+                    generation,
+                    model: self.session.clone(),
+                },
+            );
             // This rung folds the prefix as it stands NOW, so every re-sort
             // recorded so far is already baked into it — including the ones
             // that predate the whole ladder (a replay load moves every index).
@@ -1174,6 +1204,40 @@ mod tests {
         );
         assert_eq!(app.camera, Camera::Manual);
         assert!(app.camera_glide.is_none(), "user pan must cancel the glide");
+    }
+
+    /// A live attach ships the whole backfill as ONE batch, which is the case
+    /// the ladder is least able to help with and most needs to: the live path
+    /// applies updates directly and jumps `folded` to the edge, so the only
+    /// rung ever taken sits AT the edge — and a backward seek finds nothing at
+    /// or before its target and folds from item zero, exactly as if there were
+    /// no ladder at all.
+    #[test]
+    fn a_live_attach_leaves_a_usable_ladder() {
+        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+        let n = SNAPSHOT_STRIDE * 3;
+        let mut app = App::new("s".to_string(), Mode::Live);
+        app.handle_ui_event(UiEvent::Batch {
+            session_id: "s".into(),
+            updates: (0..n)
+                .map(|i| {
+                    crate::tailer::Update::Entry {
+                        source: crate::tailer::Source::Main,
+                        entry: crate::transcript::parse_line(&format!(
+                            r#"{{"type":"user","uuid":"u{i}","parentUuid":null,"timestamp":"{}","message":{{"role":"user","content":"hi"}}}}"#,
+                            (t0 + chrono::Duration::seconds(i as i64)).to_rfc3339()
+                        ))
+                        .unwrap(),
+                    }
+                })
+                .collect(),
+        });
+        assert_eq!(app.timeline.folded, n, "the backfill folded to the edge");
+        assert!(
+            app.snapshots.iter().any(|s| s.folded <= n / 2),
+            "no rung at or before mid-timeline: {:?}",
+            app.snapshots.iter().map(|s| s.folded).collect::<Vec<_>>()
+        );
     }
 
     /// The ladder is only allowed to be FASTER. Restoring a rung and folding

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -110,12 +110,15 @@ impl CameraGlide {
 /// cheap because [`SessionModel`] is built from persistent collections — a rung
 /// shares structure with its neighbours instead of copying the model.
 ///
-/// Measured on the pathological bench scale (~31k items, 293 agents), halving
-/// this to 512 bought no measurable seek time but cost ~9 MB of retained
-/// rungs. That is because the fold is no longer what a backward seek spends
-/// its time on: `rebuild_to` still discards the whole `Flow` and re-projects
-/// every node, which dominates whatever the fold costs. Shrink this only once
-/// that is fixed — until then it would buy memory for nothing.
+/// Read the stride off `drag_10_back`, not off a single seek: it keeps improving
+/// as the stride shrinks, while `back_to_50pct` and `back_one_hop` appear to
+/// plateau only because one fixed target sits an arbitrary distance from its
+/// rung. The drag averages over positions.
+///
+/// 1024 keeps a hop under a millisecond even on the pathological bench scale
+/// (~31k items, 293 agents), where what is left is `resync` rather than the
+/// fold, so shrinking further spends memory against a cost the fold no longer
+/// dominates.
 const SNAPSHOT_STRIDE: usize = 1024;
 
 /// A folded model captured at a known point on the timeline.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -103,6 +103,37 @@ impl CameraGlide {
     }
 }
 
+/// Items folded between two rungs of the snapshot ladder.
+///
+/// The trade is latency against memory: a backward seek re-folds at most this
+/// many items, and the ladder holds `folded / STRIDE` rungs. Snapshots are
+/// cheap because [`SessionModel`] is built from persistent collections — a rung
+/// shares structure with its neighbours instead of copying the model.
+///
+/// Measured on the pathological bench scale (~31k items, 293 agents), halving
+/// this to 512 bought no measurable seek time but cost ~9 MB of retained
+/// rungs. That is because the fold is no longer what a backward seek spends
+/// its time on: `rebuild_to` still discards the whole `Flow` and re-projects
+/// every node, which dominates whatever the fold costs. Shrink this only once
+/// that is fixed — until then it would buy memory for nothing.
+const SNAPSHOT_STRIDE: usize = 1024;
+
+/// A folded model captured at a known point on the timeline.
+struct Snapshot {
+    /// How many items were folded into `model`.
+    folded: usize,
+    /// The [`Timeline::generation`] this was taken under. A rung from an older
+    /// generation describes a prefix that no longer exists — see the field's
+    /// docs — and must be discarded rather than restored.
+    generation: u64,
+    /// The model as of `folded` items. Restoring it is a clone, which is O(1).
+    ///
+    /// This includes derived projections (liveness, workflow rollups) as they
+    /// stood when the rung was taken, which are meaningless at a different
+    /// playhead — every restore re-runs them via `resync`.
+    model: SessionModel,
+}
+
 /// The central application state, owned by the single UI task.
 pub struct App {
     /// The rendered flow graph (agent cards + step edges).
@@ -179,6 +210,9 @@ pub struct App {
     /// costs ONE seek (a backward seek rebuilds the whole model), not one per
     /// mouse event.
     pub pending_seek: Option<f64>,
+    /// Ladder of folded-model snapshots, ascending by `folded`, used to start a
+    /// backward seek near its target instead of re-folding from item zero.
+    snapshots: Vec<Snapshot>,
 }
 
 impl App {
@@ -209,6 +243,7 @@ impl App {
             show_info: false,
             pending_center: None,
             pending_seek: None,
+            snapshots: Vec::new(),
         }
     }
 
@@ -349,6 +384,7 @@ impl App {
                     }
                     self.timeline.append_live(activity);
                     self.timeline.folded = self.timeline.items.len();
+                    self.note_fold();
                     self.commit_fold(structural);
                 } else {
                     // Scrubbed back: new live data extends the (sorted) timeline
@@ -395,6 +431,10 @@ impl App {
                 self.current_session_id = session_id.clone();
                 self.session = SessionModel::new(session_id);
                 self.flow = graph::new_flow();
+                // A different session (or a truncated one) shares nothing with
+                // the rungs we hold, and a fresh `Timeline` restarts the
+                // generation counter — so they cannot be told apart by it.
+                self.snapshots.clear();
                 // A reset is a fresh live timeline (only live emits resets — the
                 // initial announce, truncation, or auto-switch). Replay arrives
                 // via ReplayLoaded, never a reset.
@@ -425,12 +465,65 @@ impl App {
         if target <= self.timeline.folded {
             return;
         }
-        let mut structural = false;
-        for i in self.timeline.folded..target {
-            structural |= self.session.apply_update(&self.timeline.items[i].update);
-        }
+        let structural = self.fold_range(self.timeline.folded, target);
         self.timeline.folded = target;
         self.commit_fold(structural);
+    }
+
+    /// Fold `items[from..to]` into the model, taking a ladder rung every
+    /// [`SNAPSHOT_STRIDE`] items. Returns whether anything structural changed.
+    ///
+    /// Rungs are taken INSIDE the loop, not after it: a jump straight to the
+    /// live edge folds the whole timeline in one call, and a ladder that only
+    /// recorded where each fold *ended* would hold a single rung at the edge —
+    /// useless for seeking backward, which needs a rung at or before its target.
+    fn fold_range(&mut self, from: usize, to: usize) -> bool {
+        let generation = self.timeline.generation;
+        self.drop_stale_rungs(generation);
+        let mut structural = false;
+        for i in from..to {
+            structural |= self.session.apply_update(&self.timeline.items[i].update);
+            self.maybe_snapshot(i + 1, generation);
+        }
+        structural
+    }
+
+    /// Record a ladder rung for a fold that did not go through
+    /// [`fold_range`](Self::fold_range) — the live `Batch` path, which applies
+    /// updates directly (the model is order-independent) and jumps `folded` to
+    /// the edge. Successive batches leave rungs roughly a stride apart, which
+    /// is what a later backward seek restores from.
+    fn note_fold(&mut self) {
+        let generation = self.timeline.generation;
+        self.drop_stale_rungs(generation);
+        self.maybe_snapshot(self.timeline.folded, generation);
+    }
+
+    /// Push a rung if `folded` is a full stride past the last one.
+    ///
+    /// Shared by both fold paths so the cadence cannot drift between them.
+    fn maybe_snapshot(&mut self, folded: usize, generation: u64) {
+        let last = self.snapshots.last().map_or(0, |s| s.folded);
+        if folded >= last + SNAPSHOT_STRIDE {
+            self.snapshots.push(Snapshot {
+                folded,
+                generation,
+                model: self.session.clone(),
+            });
+        }
+    }
+
+    /// Discard every rung if the item list has been re-sorted or replaced since
+    /// they were taken. Generation is monotonic, so one stale rung means all of
+    /// them are stale.
+    fn drop_stale_rungs(&mut self, generation: u64) {
+        if self
+            .snapshots
+            .last()
+            .is_some_and(|s| s.generation != generation)
+        {
+            self.snapshots.clear();
+        }
     }
 
     /// Post-apply step shared by `fold_to` (forward, index-based — replay pacing
@@ -530,9 +623,7 @@ impl App {
         if target < self.timeline.folded {
             self.rebuild_to(target);
         } else {
-            for i in self.timeline.folded..target {
-                self.session.apply_update(&self.timeline.items[i].update);
-            }
+            self.fold_range(self.timeline.folded, target);
             self.timeline.folded = target;
             self.resync();
         }
@@ -570,12 +661,39 @@ impl App {
             .map(|n| (n.id.clone(), (n.position.x, n.position.y)))
             .collect();
 
-        // Fresh model + flow, re-fold the prefix.
-        self.session = SessionModel::new(self.current_session_id.clone());
-        self.flow = graph::new_flow();
-        for i in 0..target {
-            self.session.apply_update(&self.timeline.items[i].update);
+        // Start from the newest ladder rung at or before the target instead of
+        // from item zero. Restoring a rung is a clone of a persistent model —
+        // O(1) — so the fold that follows is bounded by SNAPSHOT_STRIDE rather
+        // than by how far back the user seeked.
+        let generation = self.timeline.generation;
+        if self
+            .snapshots
+            .last()
+            .is_some_and(|s| s.generation != generation)
+        {
+            self.snapshots.clear();
         }
+        let resume = self
+            .snapshots
+            .iter()
+            .rev()
+            .find(|s| s.folded <= target)
+            .map(|s| (s.model.clone(), s.folded));
+
+        let start = match resume {
+            Some((model, folded)) => {
+                self.session = model;
+                folded
+            }
+            None => {
+                self.session = SessionModel::new(self.current_session_id.clone());
+                0
+            }
+        };
+        self.flow = graph::new_flow();
+        // Re-folding also rebuilds the ladder above `start`, so a scrub that
+        // walks backward repeatedly keeps finding rungs near where it lands.
+        self.fold_range(start, target);
         self.timeline.folded = target;
         self.resync();
 
@@ -1047,6 +1165,102 @@ mod tests {
         );
         assert_eq!(app.camera, Camera::Manual);
         assert!(app.camera_glide.is_none(), "user pan must cancel the glide");
+    }
+
+    /// The ladder is only allowed to be FASTER. Restoring a rung and folding
+    /// forward from it must land on exactly the model a from-scratch rebuild
+    /// would produce — otherwise a backward seek silently shows a different
+    /// session than the same seek did yesterday.
+    #[test]
+    fn a_ladder_restore_matches_a_full_rebuild() {
+        // Enough items that several rungs are taken.
+        let count = SNAPSHOT_STRIDE * 3 + 17;
+        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+        let items = |n: usize| -> Vec<crate::tailer::ReplayItem> {
+            (0..n)
+                .map(|i| {
+                    crate::tailer::ReplayItem::at(
+                        Some(t0 + chrono::Duration::seconds(i as i64)),
+                        // Re-touch earlier agents as well as adding new ones, so
+                        // the fold is not purely insert-only.
+                        meta_update(&format!("sub{}", i % (n / 4).max(1))),
+                    )
+                })
+                .collect()
+        };
+
+        let load = |app: &mut App| {
+            app.handle_ui_event(UiEvent::ReplayLoaded {
+                session_id: "s".into(),
+                items: items(count),
+                speed: 8.0,
+                info: Default::default(),
+            });
+            app.go_live();
+        };
+
+        let target = SNAPSHOT_STRIDE * 2 + 5;
+
+        // With the ladder: fold to the edge (taking rungs), then seek back.
+        let mut laddered = App::new("s".to_string(), Mode::Replay);
+        load(&mut laddered);
+        assert!(
+            laddered.snapshots.len() >= 3,
+            "expected several rungs, got {}",
+            laddered.snapshots.len()
+        );
+        laddered.seek_to_fraction(target as f64 / count as f64);
+        let restored_from = laddered.timeline.folded;
+
+        // Without: same App, same seek, but the ladder emptied first so
+        // `rebuild_to` has to fold from item zero.
+        let mut plain = App::new("s".to_string(), Mode::Replay);
+        load(&mut plain);
+        plain.snapshots.clear();
+        plain.seek_to_fraction(target as f64 / count as f64);
+
+        assert_eq!(
+            restored_from, plain.timeline.folded,
+            "both paths must land on the same item"
+        );
+        assert!(
+            laddered.session == plain.session,
+            "ladder restore diverged from a full rebuild"
+        );
+    }
+
+    /// A re-sort moves existing items, so every rung taken before it describes
+    /// a prefix that no longer exists. They must be discarded, not restored.
+    #[test]
+    fn a_generation_bump_voids_the_ladder() {
+        let mut app = App::new("s".to_string(), Mode::Live);
+        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+        app.handle_ui_event(UiEvent::ReplayLoaded {
+            session_id: "s".into(),
+            items: (0..SNAPSHOT_STRIDE * 2)
+                .map(|i| {
+                    crate::tailer::ReplayItem::at(
+                        Some(t0 + chrono::Duration::seconds(i as i64)),
+                        meta_update(&format!("sub{i}")),
+                    )
+                })
+                .collect(),
+            speed: 8.0,
+            info: Default::default(),
+        });
+        app.go_live();
+        assert!(!app.snapshots.is_empty(), "rungs were taken");
+
+        // Simulate the re-sort that `append_live` performs when a late batch
+        // dates a previously-pending item.
+        app.timeline.generation = app.timeline.generation.wrapping_add(1);
+        app.seek_to_fraction(0.25);
+        assert!(
+            app.snapshots
+                .iter()
+                .all(|s| s.generation == app.timeline.generation),
+            "a stale-generation rung survived the seek"
+        );
     }
 
     #[test]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -645,65 +645,56 @@ impl App {
 
     /// Rebuild the model and graph from scratch by re-folding `items[0..target]`
     /// into a fresh [`SessionModel`] — the only way to move the playhead
-    /// *backward* (folding is forward-only). Preserves view state across the
-    /// rebuild: node positions (the user's arrangement / a stable layout) and
-    /// the selected node are carried over by id.
+    /// *backward* (folding is forward-only). The `Flow` is patched rather than
+    /// rebuilt, so node positions (the user's arrangement / a stable layout),
+    /// the viewport and the selection are never disturbed in the first place.
     fn rebuild_to(&mut self, target: usize) {
-        // Snapshot view state to carry across the wipe.
-        let selected = self.selected_agent_id();
-        // The camera/viewport (pan + zoom) is the user's — a fresh `Flow` would
-        // reset it to the origin, snapping the graph on every backward seek even
-        // in Manual/Overview. Carry it across.
-        let viewport = self.flow.viewport;
-        let positions: std::collections::HashMap<String, (f64, f64)> = self
-            .flow
-            .nodes()
-            .map(|n| (n.id.clone(), (n.position.x, n.position.y)))
-            .collect();
-
         // Start from the newest ladder rung at or before the target instead of
         // from item zero. Restoring a rung is a clone of a persistent model —
         // O(1) — so the fold that follows is bounded by SNAPSHOT_STRIDE rather
         // than by how far back the user seeked.
         let generation = self.timeline.generation;
-        if self
-            .snapshots
-            .last()
-            .is_some_and(|s| s.generation != generation)
-        {
-            self.snapshots.clear();
-        }
+        self.drop_stale_rungs(generation);
         let resume = self
             .snapshots
             .iter()
             .rev()
             .find(|s| s.folded <= target)
             .map(|s| (s.model.clone(), s.folded));
-
-        let start = match resume {
-            Some((model, folded)) => {
-                self.session = model;
-                folded
-            }
-            None => {
-                self.session = SessionModel::new(self.current_session_id.clone());
-                0
-            }
+        let (model, start) = match resume {
+            Some((model, folded)) => (model, folded),
+            None => (SessionModel::new(self.current_session_id.clone()), 0),
         };
-        self.flow = graph::new_flow();
+
+        // Keep the model we are replacing, to work out what left the canvas.
+        let previous = std::mem::replace(&mut self.session, model);
         // Re-folding also rebuilds the ladder above `start`, so a scrub that
         // walks backward repeatedly keeps finding rungs near where it lands.
         self.fold_range(start, target);
         self.timeline.folded = target;
-        self.resync();
 
-        // Carry the arrangement + selection + viewport across so a seek doesn't
-        // jump the layout or the camera.
-        graph::restore_positions(&mut self.flow, &positions);
-        self.flow.viewport = viewport;
-        if let Some(id) = selected {
-            self.flow.select_node(&id);
-        }
+        // Seeking back can only REMOVE agents (a fold never un-spawns one that
+        // the earlier prefix already had), and `sync` adds and updates but never
+        // removes — so taking those few nodes off the canvas is the whole
+        // difference between here and a full rebuild.
+        //
+        // `OrdMap::diff` skips subtrees the two models share, and they share
+        // almost everything: the new model is a rung cloned from this very
+        // lineage. So this costs what actually changed, not what exists.
+        let departed: Vec<String> = previous
+            .agents
+            .diff(&self.session.agents)
+            .filter_map(|change| match change {
+                imbl::ordmap::DiffItem::Remove(id, _) => Some(id.clone()),
+                _ => None,
+            })
+            .collect();
+        graph::remove_agents(&mut self.flow, &departed);
+
+        // No flow wipe, so node positions, the viewport and the selection all
+        // survive on their own — none of it has to be captured and restored
+        // around a teardown any more.
+        self.resync();
     }
 
     /// Roll workflow-group status up from children, then project the model onto
@@ -1171,6 +1162,61 @@ mod tests {
     /// forward from it must land on exactly the model a from-scratch rebuild
     /// would produce — otherwise a backward seek silently shows a different
     /// session than the same seek did yesterday.
+    /// Seeking back patches the canvas instead of rebuilding it: agents that do
+    /// not exist yet at the target leave, and everything the old teardown had to
+    /// capture and restore by hand — node positions, the viewport, the
+    /// selection — survives because nothing is thrown away.
+    #[test]
+    fn seeking_back_patches_the_canvas_instead_of_rebuilding_it() {
+        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+        let mut app = App::new("focused".to_string(), Mode::Replay);
+        app.handle_ui_event(UiEvent::ReplayLoaded {
+            session_id: "focused".into(),
+            items: (0..6)
+                .map(|i| {
+                    crate::tailer::ReplayItem::at(
+                        Some(t0 + chrono::Duration::seconds(i as i64)),
+                        meta_update(&format!("sub{i}")),
+                    )
+                })
+                .collect(),
+            speed: 8.0,
+            info: Default::default(),
+        });
+        app.go_live();
+
+        let early = "sub1";
+        let late = "sub5";
+        assert!(app.flow.node(late).is_some(), "precondition: sub5 exists");
+
+        // Arrange the canvas the way a user would: drag a node, pan, select.
+        app.flow
+            .set_node_positions(std::iter::once((early, (123.0, 456.0))));
+        app.flow.zoom_to(2.5);
+        let viewport = app.flow.viewport;
+        app.flow.select_node(early);
+
+        // Seek back to before sub5 (and sub4, sub3…) were ever spawned.
+        app.seek_to_fraction(2.0 / 6.0);
+
+        assert!(
+            app.flow.node(late).is_none(),
+            "an agent that does not exist at this playhead must leave the canvas"
+        );
+        assert!(app.session.agent("sub5").is_none(), "and leave the model");
+        assert!(app.flow.node(early).is_some(), "sub1 predates the target");
+
+        // The three things the old rebuild had to save and restore explicitly.
+        let node = app.flow.node(early).unwrap();
+        assert_eq!(
+            (node.position.x, node.position.y),
+            (123.0, 456.0),
+            "a dragged position survived the seek"
+        );
+        assert_eq!(app.flow.viewport.zoom, viewport.zoom, "viewport survived");
+        assert_eq!(app.selected_agent_id().as_deref(), Some("sub1"));
+    }
+
     #[test]
     fn a_ladder_restore_matches_a_full_rebuild() {
         // Enough items that several rungs are taken.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -510,19 +510,37 @@ impl App {
                 generation,
                 model: self.session.clone(),
             });
+            // This rung folds the prefix as it stands NOW, so every re-sort
+            // recorded so far is already baked into it — including the ones
+            // that predate the whole ladder (a replay load moves every index).
+            // Leaving them pending would make the next prune apply them to
+            // rungs they cannot possibly invalidate, and the ladder would
+            // collapse to a single rung on the first out-of-order batch.
+            self.timeline.take_disturbance();
         }
     }
 
-    /// Discard every rung if the item list has been re-sorted or replaced since
-    /// they were taken. Generation is monotonic, so one stale rung means all of
-    /// them are stale.
+    /// Reconcile the ladder with a re-sorted or replaced item list.
+    ///
+    /// A rung describes `items[0..folded]`, so it survives exactly as long as
+    /// that prefix does. The timeline reports how much of it the re-sorts left
+    /// alone ([`Timeline::take_disturbance`]); rungs below that line are still
+    /// accurate and are re-stamped to the new generation instead of thrown
+    /// away. That distinction is what keeps the ladder alive on a live session:
+    /// a subagent's entries arriving a moment out of order re-sort the tail on
+    /// most batches, and voiding the whole ladder there left every backward
+    /// seek folding from item zero, which is the case it exists for.
     fn drop_stale_rungs(&mut self, generation: u64) {
         if self
             .snapshots
             .last()
             .is_some_and(|s| s.generation != generation)
         {
-            self.snapshots.clear();
+            let stable = self.timeline.take_disturbance();
+            self.snapshots.retain(|s| s.folded <= stable);
+            for rung in &mut self.snapshots {
+                rung.generation = generation;
+            }
         }
     }
 
@@ -1275,15 +1293,13 @@ mod tests {
         );
     }
 
-    /// A re-sort moves existing items, so every rung taken before it describes
-    /// a prefix that no longer exists. They must be discarded, not restored.
-    #[test]
-    fn a_generation_bump_voids_the_ladder() {
+    /// Seed a live App with `n` dated items one second apart, folded to the
+    /// edge so the ladder has rungs.
+    fn app_with_rungs(n: usize, t0: chrono::DateTime<chrono::Utc>) -> App {
         let mut app = App::new("s".to_string(), Mode::Live);
-        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
         app.handle_ui_event(UiEvent::ReplayLoaded {
             session_id: "s".into(),
-            items: (0..SNAPSHOT_STRIDE * 2)
+            items: (0..n)
                 .map(|i| {
                     crate::tailer::ReplayItem::at(
                         Some(t0 + chrono::Duration::seconds(i as i64)),
@@ -1296,16 +1312,86 @@ mod tests {
         });
         app.go_live();
         assert!(!app.snapshots.is_empty(), "rungs were taken");
+        app
+    }
 
-        // Simulate the re-sort that `append_live` performs when a late batch
-        // dates a previously-pending item.
-        app.timeline.generation = app.timeline.generation.wrapping_add(1);
-        app.seek_to_fraction(0.25);
+    /// An undated item sorts to the HEAD, so one arriving shifts every index
+    /// after it: no rung describes its prefix any more, and all must go.
+    #[test]
+    fn an_undated_arrival_voids_the_whole_ladder() {
+        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+        let mut app = app_with_rungs(SNAPSHOT_STRIDE * 2, t0);
+
+        // A meta with no timestamp of its own — the `needs_dating` path.
+        app.handle_ui_event(UiEvent::Batch {
+            session_id: "s".into(),
+            updates: vec![meta_update("late")],
+        });
+        // Only a rung taken at the new edge remains; every rung describing the
+        // old prefix is gone.
+        assert!(
+            app.snapshots
+                .iter()
+                .all(|s| s.folded == app.timeline.folded),
+            "a rung describing the pre-sort prefix survived: {:?}",
+            app.snapshots.iter().map(|s| s.folded).collect::<Vec<_>>()
+        );
+    }
+
+    /// The case the ladder exists for: a live session whose sidecars land a
+    /// moment out of order. The re-sort touches only the tail, so the rungs
+    /// below it still describe their prefix exactly — voiding them wholesale
+    /// sent every backward seek back to folding from item zero.
+    #[test]
+    fn an_out_of_order_batch_keeps_the_rungs_below_it() {
+        let count = SNAPSHOT_STRIDE * 3;
+        let t0: chrono::DateTime<chrono::Utc> = "2026-06-05T10:00:00.000Z".parse().unwrap();
+        let mut app = app_with_rungs(count, t0);
+        let before = app.snapshots.len();
+        assert!(before >= 2, "expected several rungs, got {before}");
+
+        // A sidecar entry timestamped just before the edge: out of order, but
+        // it cannot disturb anything earlier than itself.
+        app.handle_ui_event(UiEvent::Batch {
+            session_id: "s".into(),
+            updates: vec![crate::tailer::Update::Entry {
+                source: crate::tailer::Source::Sub("late".into()),
+                entry: crate::transcript::parse_line(&format!(
+                    r#"{{"type":"assistant","uuid":"u","parentUuid":null,"timestamp":"{}","message":{{"role":"assistant","content":[{{"type":"tool_use","id":"b1","name":"Bash","input":{{}}}}]}}}}"#,
+                    (t0 + chrono::Duration::seconds(count as i64 - 2)).to_rfc3339()
+                ))
+                .unwrap(),
+            }],
+        });
+
+        assert!(
+            app.snapshots.len() >= before - 1,
+            "the untouched prefix lost its rungs: {} -> {}",
+            before,
+            app.snapshots.len()
+        );
         assert!(
             app.snapshots
                 .iter()
                 .all(|s| s.generation == app.timeline.generation),
-            "a stale-generation rung survived the seek"
+            "a surviving rung kept a stale generation stamp"
+        );
+
+        // And a rung is only worth keeping if restoring it is still correct.
+        let target = SNAPSHOT_STRIDE + 5;
+        let total = app.timeline.items.len();
+        app.seek_to_fraction(target as f64 / total as f64);
+        let laddered = app.session.clone();
+        let landed = app.timeline.folded;
+
+        app.snapshots.clear();
+        app.seek_to_fraction(1.0);
+        app.snapshots.clear();
+        app.seek_to_fraction(target as f64 / total as f64);
+        assert_eq!(landed, app.timeline.folded, "both paths land on one item");
+        assert!(
+            laddered == app.session,
+            "a surviving rung diverged from a full rebuild"
         );
     }
 

--- a/src/state/session.rs
+++ b/src/state/session.rs
@@ -875,41 +875,57 @@ impl SessionModel {
         let Some(reference) = now.or(self.last_activity) else {
             return false;
         };
-        let mut changed = false;
-        for agent in self.agents.values_mut() {
-            let Some(ts) = agent.last_ts else {
-                continue;
-            };
-            // An unresolved tool_call is direct evidence the agent is still
-            // working — stronger than "no transcript line for 120s". Without it,
-            // an agent blocked on a long tool (a 2-minute Bash) looks quiet and
-            // settles to Done/Idle mid-tool, then snaps back when the result
-            // lands. A reliably-terminal agent short-circuits below, so this
-            // can't revive a genuinely finished one.
-            let active = (reference - ts).num_seconds() <= INTERACTIVE_IDLE_SECS
-                || agent
-                    .tool_calls
-                    .iter()
-                    .any(|c| c.state == ToolState::Pending);
-            let next = if agent.is_interactive() {
-                if active {
+        // Two passes: decide in a read-only walk, then write ONLY the agents
+        // whose status actually moved.
+        //
+        // The obvious single `values_mut()` loop takes a mutable borrow of
+        // every agent on every call — and this runs once a second from
+        // `status_tick`, plus on every resync, overwhelmingly finding nothing
+        // to change. That is wasted work with plain maps and actively harmful
+        // with persistent ones, where touching an entry copies it.
+        let pending: Vec<(String, AgentStatus)> = self
+            .agents
+            .iter()
+            .filter_map(|(id, agent)| {
+                let ts = agent.last_ts?;
+                // An unresolved tool_call is direct evidence the agent is still
+                // working — stronger than "no transcript line for 120s". Without
+                // it, an agent blocked on a long tool (a 2-minute Bash) looks
+                // quiet and settles to Done/Idle mid-tool, then snaps back when
+                // the result lands. A reliably-terminal agent short-circuits
+                // below, so this can't revive a genuinely finished one.
+                let active = (reference - ts).num_seconds() <= INTERACTIVE_IDLE_SECS
+                    || agent
+                        .tool_calls
+                        .iter()
+                        .any(|c| c.state == ToolState::Pending);
+                let next = if agent.is_interactive() {
+                    if active {
+                        AgentStatus::Running
+                    } else {
+                        AgentStatus::Idle
+                    }
+                } else if agent.terminal {
+                    // A reliably-completed subagent (sync ack / journal) is terminal.
+                    agent.status
+                } else if active {
+                    // Async agent still producing activity — and REVERSIBLE: a
+                    // long gap (e.g. a subagent running `cargo test`) that
+                    // settled it to Done flips straight back to Running when it
+                    // resumes.
                     AgentStatus::Running
                 } else {
-                    AgentStatus::Idle
-                }
-            } else if agent.terminal {
-                // A reliably-completed subagent (sync ack / journal) is terminal.
-                agent.status
-            } else if active {
-                // Async agent still producing activity — and REVERSIBLE: a long
-                // gap (e.g. a subagent running `cargo test`) that settled it to
-                // Done flips straight back to Running when it resumes.
-                AgentStatus::Running
-            } else {
-                AgentStatus::Done
-            };
-            changed |= agent.status != next;
-            agent.status = next;
+                    AgentStatus::Done
+                };
+                (next != agent.status).then(|| (id.clone(), next))
+            })
+            .collect();
+
+        let changed = !pending.is_empty();
+        for (id, next) in pending {
+            if let Some(agent) = self.agents.get_mut(&id) {
+                agent.status = next;
+            }
         }
         changed
     }
@@ -918,16 +934,31 @@ impl SessionModel {
     /// agent goes `Idle` — the recording is over, nothing is active, and
     /// completion remains unclaimable.
     pub fn end_of_stream(&mut self) {
-        for agent in self.agents.values_mut() {
-            if agent.is_interactive() {
-                // Interactive agents (main/forks) never "complete" — the stream
-                // ending just means they went quiet.
-                agent.status = AgentStatus::Idle;
-            } else if agent.status == AgentStatus::Running {
-                // A subagent still Running at the recording's end has finished
-                // (its async spawn-ack Done was superseded by its own later
-                // activity via `resolve_spawn_status`; now there's no more).
-                agent.status = AgentStatus::Done;
+        // Same two-pass shape as `recompute_liveness`, for the same reason.
+        let pending: Vec<(String, AgentStatus)> = self
+            .agents
+            .iter()
+            .filter_map(|(id, agent)| {
+                let next = if agent.is_interactive() {
+                    // Interactive agents (main/forks) never "complete" — the
+                    // stream ending just means they went quiet.
+                    AgentStatus::Idle
+                } else if agent.status == AgentStatus::Running {
+                    // A subagent still Running at the recording's end has
+                    // finished (its async spawn-ack Done was superseded by its
+                    // own later activity via `resolve_spawn_status`; now there's
+                    // no more).
+                    AgentStatus::Done
+                } else {
+                    return None;
+                };
+                (next != agent.status).then(|| (id.clone(), next))
+            })
+            .collect();
+
+        for (id, next) in pending {
+            if let Some(agent) = self.agents.get_mut(&id) {
+                agent.status = next;
             }
         }
     }

--- a/src/state/session.rs
+++ b/src/state/session.rs
@@ -7,7 +7,7 @@
 //! group node. Spawn order is tracked explicitly so layout and navigation are
 //! deterministic.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use imbl::{HashMap, HashSet, OrdMap, Vector};
 
 use chrono::{DateTime, Utc};
 
@@ -25,18 +25,23 @@ pub const MAIN_ID: &str = "main";
 const INTERACTIVE_IDLE_SECS: i64 = 120;
 
 /// The full derived view of a session.
+///
+/// `Clone` is O(1): every growing collection here is persistent
+/// ([`imbl`]), so cloning shares structure rather than copying it. That is what
+/// makes a snapshot cheap enough to keep several of.
+#[derive(Clone, PartialEq)]
 pub struct SessionModel {
     pub session_id: String,
     /// Agents keyed by stable node id (`"main"`, `agentId`, or `wf-id`).
-    pub agents: BTreeMap<String, AgentInfo>,
+    pub agents: OrdMap<String, AgentInfo>,
     /// Stable spawn order of node ids (insertion order). Drives layout/nav.
-    pub spawn_order: Vec<String>,
+    pub spawn_order: Vector<String>,
     /// Most recent activity timestamp seen across all files.
     pub last_activity: Option<DateTime<Utc>>,
     /// `runId → (workflowName, summary)` from main-transcript workflow launches,
     /// kept as a FACT rather than applied on arrival: the launch and the group's
     /// first subagent meta can fold in either order, so both sides consult this.
-    workflow_labels: BTreeMap<String, (Option<String>, Option<String>)>,
+    workflow_labels: OrdMap<String, (Option<String>, Option<String>)>,
     /// Completion facts, kept so model state is a function of the fact SET,
     /// not of arrival order — a completion can arrive before its target
     /// exists (live attach applies the main transcript before directory scans
@@ -64,7 +69,7 @@ pub struct SessionModel {
     /// Every plain user prompt in the main transcript, in order — the
     /// session's spine. Tool calls and spawns attribute to a prompt era via
     /// [`Self::prompt_for_ts`] (timestamp-derived, order-independent).
-    pub prompts: Vec<PromptInfo>,
+    pub prompts: Vector<PromptInfo>,
     /// Excerpt of the most recent assistant text in the main transcript.
     /// One logical turn spans several JSONL lines, so the reasoning for a
     /// spawn usually lives on an EARLIER line than the tool_use — this is the
@@ -93,7 +98,7 @@ pub enum LogKind {
 
 /// One user prompt in the main transcript — an era boundary on the session's
 /// timeline.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PromptInfo {
     /// One-line excerpt of the prompt text.
     pub excerpt: String,
@@ -105,7 +110,7 @@ pub struct PromptInfo {
 /// DERIVED from it via [`SessionModel::prompt_for_ts`] — order-independent,
 /// like all era attribution) and the assistant text immediately preceding the
 /// spawning tool call (stored: reasoning is not timestamp-derivable).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct SpawnContext {
     /// Timestamp of the spawning `tool_use` entry.
     pub ts: Option<DateTime<Utc>>,
@@ -188,7 +193,7 @@ pub enum ToolState {
 }
 
 /// One tool invocation within an agent.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ToolCallInfo {
     /// `tool_use.id` — join key for the result.
     pub id: String,
@@ -215,6 +220,11 @@ impl ToolCallInfo {
 }
 
 /// Everything known about one agent node.
+///
+/// Cloned whenever the containing map copy-on-writes the node holding it, so
+/// its own growing collections are persistent too — a plain `Vec` of tool calls
+/// here would make every tool-call append copy the agent's whole history.
+#[derive(Clone, PartialEq)]
 pub struct AgentInfo {
     pub kind: AgentKind,
     /// Interactive category (main-session semantics: no completion evidence
@@ -240,7 +250,7 @@ pub struct AgentInfo {
     pub(crate) terminal: bool,
     pub model: Option<String>,
     /// Tool calls in observed order.
-    pub tool_calls: Vec<ToolCallInfo>,
+    pub tool_calls: Vector<ToolCallInfo>,
     /// tool_use id → index into `tool_calls`, so the per-entry dedup check and
     /// per-result completion are O(1) instead of scanning every prior call
     /// (which made folding a tool-heavy agent quadratic).
@@ -272,7 +282,7 @@ impl AgentInfo {
             status: AgentStatus::Running,
             terminal: false,
             model: None,
-            tool_calls: Vec::new(),
+            tool_calls: Vector::new(),
             tool_index: HashMap::new(),
             output_tokens: 0,
             first_ts: None,
@@ -316,19 +326,19 @@ impl SessionModel {
     /// Create an empty model for the given session id, with the `"main"` agent
     /// pre-seeded as [`AgentStatus::Running`].
     pub fn new(session_id: String) -> Self {
-        let mut agents = BTreeMap::new();
+        let mut agents = OrdMap::new();
         agents.insert(MAIN_ID.to_string(), AgentInfo::new(AgentKind::Main));
         SessionModel {
             session_id,
             agents,
-            spawn_order: vec![MAIN_ID.to_string()],
+            spawn_order: Vector::unit(MAIN_ID.to_string()),
             last_activity: None,
-            workflow_labels: BTreeMap::new(),
+            workflow_labels: OrdMap::new(),
             completed_spawns: HashMap::new(),
             task_terminal: HashMap::new(),
             journal_done: HashSet::new(),
             spawn_context: HashMap::new(),
-            prompts: Vec::new(),
+            prompts: Vector::new(),
             last_main_text: None,
         }
     }
@@ -346,7 +356,7 @@ impl SessionModel {
             info.terminal = true;
         }
         self.agents.insert(id.to_string(), info);
-        self.spawn_order.push(id.to_string());
+        self.spawn_order.push_back(id.to_string());
         true
     }
 
@@ -473,7 +483,7 @@ impl SessionModel {
                         // replay). A genuine repeat at a *different* ts is kept.
                         let dup = self.prompts.iter().any(|p| p.excerpt == ex && p.ts == ts);
                         if !dup {
-                            self.prompts.push(PromptInfo { excerpt: ex, ts });
+                            self.prompts.push_back(PromptInfo { excerpt: ex, ts });
                         }
                     }
                 }
@@ -532,7 +542,7 @@ impl SessionModel {
                 // same cumulative usage; count it once per `requestId`. Lines
                 // with no `requestId` can't be deduped, so they sum per line.
                 match &e.envelope.request_id {
-                    Some(req) if !agent.seen_request_ids.insert(req.clone()) => {}
+                    Some(req) if agent.seen_request_ids.insert(req.clone()).is_some() => {}
                     // Saturating: counts come from untrusted transcript
                     // content; overflow must not panic (debug) or wrap.
                     _ => agent.output_tokens = agent.output_tokens.saturating_add(out),
@@ -568,7 +578,7 @@ impl SessionModel {
                     }
                     let summary = summarize_tool(&name, &tu.input, e.envelope.cwd.as_deref());
                     agent.tool_index.insert(id.clone(), agent.tool_calls.len());
-                    agent.tool_calls.push(ToolCallInfo {
+                    agent.tool_calls.push_back(ToolCallInfo {
                         id: id.clone(),
                         name,
                         summary,
@@ -1206,12 +1216,12 @@ mod tests {
                 }
             };
         let mut m = SessionModel::new("s".into());
-        m.prompts.push(PromptInfo {
+        m.prompts.push_back(PromptInfo {
             excerpt: "review the codebase".into(),
             ts: Some(ts("2026-06-05T10:00:00Z")),
         });
         let main = m.agents.get_mut(MAIN_ID).unwrap();
-        main.tool_calls.push(tool(
+        main.tool_calls.push_back(tool(
             "s1",
             "Agent",
             "hunt bugs",
@@ -1220,7 +1230,7 @@ mod tests {
             ToolState::Ok,
         ));
         // A slow Bash: started 10:10, failed (result) at 10:12.
-        main.tool_calls.push(tool(
+        main.tool_calls.push_back(tool(
             "b1",
             "Bash",
             "cargo test",
@@ -1229,7 +1239,7 @@ mod tests {
             ToolState::Err,
         ));
         // A later SUCCESSFUL non-spawn tool is not a log event.
-        main.tool_calls.push(tool(
+        main.tool_calls.push_back(tool(
             "r1",
             "Read",
             "src/lib.rs",
@@ -1277,7 +1287,7 @@ mod tests {
             .get_mut(MAIN_ID)
             .unwrap()
             .tool_calls
-            .push(ToolCallInfo {
+            .push_back(ToolCallInfo {
                 id: "call1".into(),
                 name: "Agent".into(),
                 summary: Some("hunt bugs".into()),

--- a/src/state/session.rs
+++ b/src/state/session.rs
@@ -33,9 +33,9 @@ const INTERACTIVE_IDLE_SECS: i64 = 120;
 pub struct SessionModel {
     pub session_id: String,
     /// Agents keyed by stable node id (`"main"`, `agentId`, or `wf-id`).
-    pub agents: OrdMap<String, AgentInfo>,
+    pub(crate) agents: OrdMap<String, AgentInfo>,
     /// Stable spawn order of node ids (insertion order). Drives layout/nav.
-    pub spawn_order: Vector<String>,
+    pub(crate) spawn_order: Vector<String>,
     /// Most recent activity timestamp seen across all files.
     pub last_activity: Option<DateTime<Utc>>,
     /// `runId → (workflowName, summary)` from main-transcript workflow launches,
@@ -69,7 +69,7 @@ pub struct SessionModel {
     /// Every plain user prompt in the main transcript, in order — the
     /// session's spine. Tool calls and spawns attribute to a prompt era via
     /// [`Self::prompt_for_ts`] (timestamp-derived, order-independent).
-    pub prompts: Vector<PromptInfo>,
+    pub(crate) prompts: Vector<PromptInfo>,
     /// Excerpt of the most recent assistant text in the main transcript.
     /// One logical turn spans several JSONL lines, so the reasoning for a
     /// spawn usually lives on an EARLIER line than the tool_use — this is the
@@ -250,7 +250,7 @@ pub struct AgentInfo {
     pub(crate) terminal: bool,
     pub model: Option<String>,
     /// Tool calls in observed order.
-    pub tool_calls: Vector<ToolCallInfo>,
+    pub(crate) tool_calls: Vector<ToolCallInfo>,
     /// tool_use id → index into `tool_calls`, so the per-entry dedup check and
     /// per-result completion are O(1) instead of scanning every prior call
     /// (which made folding a tool-heavy agent quadratic).
@@ -269,6 +269,12 @@ pub struct AgentInfo {
 }
 
 impl AgentInfo {
+    /// This agent's tool calls, oldest first. See
+    /// [`SessionModel::spawn_order`] for why this is an iterator.
+    pub fn tool_calls(&self) -> impl ExactSizeIterator<Item = &ToolCallInfo> {
+        self.tool_calls.iter()
+    }
+
     /// A fresh agent record of the given kind, defaulting to
     /// [`AgentStatus::Running`] with no activity yet.
     pub(crate) fn new(kind: AgentKind) -> Self {
@@ -981,6 +987,15 @@ impl SessionModel {
     /// Total tool calls across all agents.
     pub fn tool_count(&self) -> usize {
         self.agents.values().map(|a| a.tool_calls.len()).sum()
+    }
+
+    /// Agent ids in spawn order.
+    ///
+    /// An iterator rather than the collection itself: the backing store is an
+    /// `imbl` persistent type, which is an implementation detail of the fold
+    /// rather than something the published API should pin down.
+    pub fn spawn_order(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.spawn_order.iter().map(String::as_str)
     }
 
     /// Borrow an agent by node id.

--- a/src/state/timeline.rs
+++ b/src/state/timeline.rs
@@ -76,6 +76,15 @@ pub struct Timeline {
     /// must re-run dating. Lets `append_live` skip the full date-and-sort for
     /// the common in-order, fully-timed batch.
     undated_agents: HashSet<String>,
+    /// Bumped whenever an item's INDEX may have changed meaning: a bulk
+    /// replay load, or a re-sort that moved already-present items.
+    ///
+    /// Anything that caches a result keyed by item index — the snapshot ladder
+    /// in particular — records the generation it was built under and must
+    /// discard itself when this moves. Without it a snapshot of `items[0..N]`
+    /// silently describes a different prefix after a late batch dates a
+    /// previously-pending item and the whole list re-sorts around it.
+    pub generation: u64,
     /// Skip inactivity: compress dead-air gaps during paced playback (see
     /// `compress_gap`). On by default (review-friendly); toggle off for
     /// faithful real-time pacing. Presentation-only — never affects content.
@@ -137,6 +146,7 @@ impl Timeline {
             gap_progress: 0.0,
             undated_agents: HashSet::new(),
             compress_gaps: true,
+            generation: 0,
         }
     }
 
@@ -155,6 +165,7 @@ impl Timeline {
         self.ended = false;
         self.gap_anchor = start;
         self.gap_progress = 0.0;
+        self.generation = self.generation.wrapping_add(1);
         self.rescan_undated();
     }
 
@@ -211,8 +222,12 @@ impl Timeline {
             self.items.push(item);
         }
         if needs_dating || !in_order {
+            // Existing items can move: an item that was `Pending` sorts ahead
+            // of every dated one and jumps into place once its date resolves,
+            // shifting every index in between. Index-keyed caches are void.
             crate::tailer::date_and_sort_live(&mut self.items);
             self.rescan_undated();
+            self.generation = self.generation.wrapping_add(1);
         }
         if self.items.len() != before {
             self.ended = false;

--- a/src/state/timeline.rs
+++ b/src/state/timeline.rs
@@ -85,6 +85,19 @@ pub struct Timeline {
     /// silently describes a different prefix after a late batch dates a
     /// previously-pending item and the whole list re-sorts around it.
     pub generation: u64,
+    /// How many leading items every generation bump since the last
+    /// [`take_disturbance`](Self::take_disturbance) is known to have left
+    /// alone.
+    ///
+    /// A re-sort is rarely a reshuffle: a late subagent entry inserts among the
+    /// newest items and leaves the long prefix before it exactly where it was.
+    /// `generation` alone cannot say that, so a cache keyed by index would have
+    /// to discard itself wholesale on every out-of-order batch — which, once a
+    /// subagent is writing, is most batches. This is the part that is provably
+    /// still valid; it accumulates as a MINIMUM so a consumer that misses a bump
+    /// (the App only reconciles while following the edge) still sees the worst
+    /// case rather than the last one.
+    stable_prefix: usize,
     /// Skip inactivity: compress dead-air gaps during paced playback (see
     /// `compress_gap`). On by default (review-friendly); toggle off for
     /// faithful real-time pacing. Presentation-only — never affects content.
@@ -147,6 +160,7 @@ impl Timeline {
             undated_agents: HashSet::new(),
             compress_gaps: true,
             generation: 0,
+            stable_prefix: usize::MAX,
         }
     }
 
@@ -166,6 +180,8 @@ impl Timeline {
         self.gap_anchor = start;
         self.gap_progress = 0.0;
         self.generation = self.generation.wrapping_add(1);
+        // Every index means something new — nothing is stable.
+        self.stable_prefix = 0;
         self.rescan_undated();
     }
 
@@ -198,11 +214,15 @@ impl Timeline {
         let mut tail_ts = self.items.last().and_then(|i| i.ts());
         let mut in_order = true;
         let mut needs_dating = false;
+        // Earliest timestamp in this batch: where a re-sort can start moving
+        // things, and so where the untouched prefix ends.
+        let mut earliest_new: Option<DateTime<Utc>> = None;
         for update in updates {
             let item = ReplayItem::live(update);
             match item.ts() {
                 Some(ts) => {
                     self.head = Some(self.head.map_or(ts, |h| h.max(ts)));
+                    earliest_new = Some(earliest_new.map_or(ts, |e: DateTime<Utc>| e.min(ts)));
                     if tail_ts.is_some_and(|t| ts < t) {
                         in_order = false;
                     }
@@ -224,7 +244,21 @@ impl Timeline {
         if needs_dating || !in_order {
             // Existing items can move: an item that was `Pending` sorts ahead
             // of every dated one and jumps into place once its date resolves,
-            // shifting every index in between. Index-keyed caches are void.
+            // shifting every index in between. Index-keyed caches are void
+            // from `stable_prefix` on.
+            let stable = if needs_dating {
+                // Undated items sort to the head, so one arriving (or leaving,
+                // once it dates) shifts every index after it — i.e. all of them.
+                0
+            } else {
+                // Purely an out-of-order batch: the new items are all dated and
+                // land at or after the first item they undercut. Everything
+                // before that is untouched. `<` rather than `<=` keeps this
+                // conservative against the sort's equal-timestamp tie-break.
+                let earliest = earliest_new.expect("an out-of-order batch is dated");
+                self.items[..before].partition_point(|i| i.ts().is_none_or(|t| t < earliest))
+            };
+            self.stable_prefix = self.stable_prefix.min(stable);
             crate::tailer::date_and_sort_live(&mut self.items);
             self.rescan_undated();
             self.generation = self.generation.wrapping_add(1);
@@ -235,6 +269,13 @@ impl Timeline {
         if self.follow_head && was_at_edge {
             self.cursor = self.head;
         }
+    }
+
+    /// How many leading items are still known-good since the last call, then
+    /// reset. Consumers of `generation` pair the two: a bump says *some* index
+    /// changed meaning, this says from where.
+    pub fn take_disturbance(&mut self) -> usize {
+        std::mem::replace(&mut self.stable_prefix, usize::MAX)
     }
 
     /// Recompute which undated items are waiting on future data (the metas /

--- a/src/ui/chips.rs
+++ b/src/ui/chips.rs
@@ -95,16 +95,18 @@ fn group_state(
     start: usize,
     count: usize,
 ) -> Option<ToolState> {
-    let calls = model
-        .agent(agent_id)?
-        .tool_calls
-        .get(start..start + count)?;
-    if calls.is_empty() {
+    let tool_calls = &model.agent(agent_id)?.tool_calls;
+    // `tool_calls` is a persistent `Vector`, which has no slicing by shared
+    // reference (its `slice` splits the vector in place), so walk the window
+    // instead. Out-of-range is still `None`, matching the previous
+    // `get(range)?` — a truncated run means the model was rebuilt underneath us.
+    if count == 0 || start + count > tool_calls.len() {
         return None;
     }
-    if calls.iter().any(|c| c.state == ToolState::Pending) {
+    let calls = || tool_calls.iter().skip(start).take(count);
+    if calls().any(|c| c.state == ToolState::Pending) {
         Some(ToolState::Pending)
-    } else if calls.iter().any(|c| c.state == ToolState::Err) {
+    } else if calls().any(|c| c.state == ToolState::Err) {
         Some(ToolState::Err)
     } else {
         Some(ToolState::Ok)
@@ -228,8 +230,12 @@ impl ChipTray {
                     i += 1;
                 }
                 let count = i - start;
-                let settled = !calls[start..i]
+                // Window-walk rather than slice: `calls` is a persistent
+                // `Vector` and cannot be sliced through a shared reference.
+                let settled = !calls
                     .iter()
+                    .skip(start)
+                    .take(count)
                     .any(|c| c.state == ToolState::Pending);
                 let prev = prior.get(&(id.clone(), start)).copied();
 
@@ -450,14 +456,16 @@ mod tests {
         m.apply_meta("sub1", None, &meta);
         let agent = m.agents.get_mut("sub1").unwrap();
         for i in 0..n {
-            agent.tool_calls.push(crate::state::session::ToolCallInfo {
-                id: format!("toolu_{i}"),
-                name: "Bash".into(),
-                summary: None,
-                ts: None,
-                end_ts: None,
-                state: ToolState::Pending,
-            });
+            agent
+                .tool_calls
+                .push_back(crate::state::session::ToolCallInfo {
+                    id: format!("toolu_{i}"),
+                    name: "Bash".into(),
+                    summary: None,
+                    ts: None,
+                    end_ts: None,
+                    state: ToolState::Pending,
+                });
         }
         m
     }
@@ -475,14 +483,16 @@ mod tests {
         m.apply_meta("sub1", None, &meta);
         let agent = m.agents.get_mut("sub1").unwrap();
         for (i, name) in names.iter().enumerate() {
-            agent.tool_calls.push(crate::state::session::ToolCallInfo {
-                id: format!("toolu_{i}"),
-                name: (*name).into(),
-                summary: None,
-                ts: None,
-                end_ts: None,
-                state: ToolState::Pending,
-            });
+            agent
+                .tool_calls
+                .push_back(crate::state::session::ToolCallInfo {
+                    id: format!("toolu_{i}"),
+                    name: (*name).into(),
+                    summary: None,
+                    ts: None,
+                    end_ts: None,
+                    state: ToolState::Pending,
+                });
         }
         m
     }

--- a/src/ui/chips.rs
+++ b/src/ui/chips.rs
@@ -96,14 +96,16 @@ fn group_state(
     count: usize,
 ) -> Option<ToolState> {
     let tool_calls = &model.agent(agent_id)?.tool_calls;
-    // `tool_calls` is a persistent `Vector`, which has no slicing by shared
-    // reference (its `slice` splits the vector in place), so walk the window
-    // instead. Out-of-range is still `None`, matching the previous
-    // `get(range)?` — a truncated run means the model was rebuilt underneath us.
+    // Out-of-range is `None`, matching the previous `get(range)?` — a truncated
+    // run means the model was rebuilt underneath us.
     if count == 0 || start + count > tool_calls.len() {
         return None;
     }
-    let calls = || tool_calls.iter().skip(start).take(count);
+    // `Vector::slice` splits in place and needs ownership, and `skip(start)` on
+    // the iterator walks every element it discards — O(start) per chip, per
+    // frame. A focus seeks the range in O(log n) instead.
+    let focus = tool_calls.focus();
+    let calls = || focus.clone().narrow(start..start + count).into_iter();
     if calls().any(|c| c.state == ToolState::Pending) {
         Some(ToolState::Pending)
     } else if calls().any(|c| c.state == ToolState::Err) {
@@ -230,12 +232,12 @@ impl ChipTray {
                     i += 1;
                 }
                 let count = i - start;
-                // Window-walk rather than slice: `calls` is a persistent
-                // `Vector` and cannot be sliced through a shared reference.
+                // Ranged, not `skip(start)`: the latter walks every element
+                // it discards, once per run, on every frame.
                 let settled = !calls
-                    .iter()
-                    .skip(start)
-                    .take(count)
+                    .focus()
+                    .narrow(start..start + count)
+                    .into_iter()
                     .any(|c| c.state == ToolState::Pending);
                 let prev = prior.get(&(id.clone(), start)).copied();
 

--- a/src/ui/panel.rs
+++ b/src/ui/panel.rs
@@ -565,7 +565,7 @@ mod tests {
         .iter()
         .enumerate()
         {
-            agent.tool_calls.push(ToolCallInfo {
+            agent.tool_calls.push_back(ToolCallInfo {
                 id: format!("t{i}"),
                 name: "Bash".into(),
                 summary: None,

--- a/web/wasm/Cargo.lock
+++ b/web/wasm/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca55ee147b1926dbea904f50fe4902494e97bc742205abbbf10c709e43815f"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +99,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
+
+[[package]]
 name = "bitvec"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +121,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "castaway"
@@ -371,6 +389,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "imbl"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ea8d4c37ee560727e824d62804183624d371e632019b0e9e3532bce64a33e5"
+dependencies = [
+ "archery",
+ "bitmaps",
+ "equivalent",
+ "imbl-sized-chunks",
+ "rand_core",
+ "rand_xoshiro",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +605,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rataflow"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +730,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "serde"
@@ -950,6 +1017,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1105,7 @@ name = "zoetrope"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "imbl",
  "rataflow",
  "ratatui",
  "serde",


### PR DESCRIPTION
Performance and snapshot ladder work from #13 in accordance with the comments there.

Moved from #13 as-is:
- `perf(state)` commits,  `perf(graph)`, the benches baseline, and the ladder-precision work.

Dropped from #13:
- Any multisession work, session-qualified IDs -> now retain_nodes over plain agent ids
- related tests

New stuff:
- Bug fix for Rungs to work in live mode
- `chips.rs` O(start) skip (the `perf(ui)` commit)
- imbl out of the published API