### PR TITLE
refactor(api): decide what the crate exposes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ cd web/wasm && cargo clippy   # its .cargo/config.toml defaults to wasm32
 
 ## Commits
 
-[Conventional Commits](https://www.conventionalcommits.org/), lowercase imperative subject. Scope is a module, not a file: `fact`, `provider`, `state`, `graph`, `timeline`, `tailer`, `ui`, `panel`, `cli`, `wasm`, `web`, `docs`. A change inside one provider is `provider` (e.g. `fix(provider): inherit the timestamp across progress records`).
+[Conventional Commits](https://www.conventionalcommits.org/), lowercase imperative subject. Scope is a module, not a file: `fact`, `provider`, `state`, `graph`, `timeline`, `tailer`, `ui`, `panel`, `cli`, `wasm`, `web`, `api`, `docs`. `api` is a change to what the crate exposes rather than to one module. A change inside one provider is `provider` (e.g. `fix(provider): inherit the timestamp across progress records`).
 
 ```
 feat(timeline): index the playhead by event instead of wall-clock

--- a/benches/timeline.rs
+++ b/benches/timeline.rs
@@ -18,10 +18,25 @@ use std::hint::black_box;
 use std::time::Duration;
 
 use common::{Session, Spec};
-use zoetrope::provider::claude::wire;
+use zoetrope::provider::{FileRole, Provider, ReadMode, SessionFile};
 use zoetrope::state::session::SessionModel;
 use zoetrope::state::{App, Mode};
 use zoetrope::tailer::{ReplayItem, UiEvent};
+
+/// A parser for a session's root file, the way a feeder gets one: state what
+/// the file is, then ask its provider. Reading through `Stream` rather than the
+/// wire parser is what production does, and keeps the bench on the public API.
+fn root_stream() -> zoetrope::provider::Stream {
+    Provider::Claude.stream_for(&SessionFile {
+        provider: Provider::Claude,
+        path: std::path::PathBuf::from("bench.jsonl"),
+        session: "bench".to_string(),
+        role: FileRole::Root,
+        read: ReadMode::Tail,
+        project_key: "bench".to_string(),
+        modified: std::time::SystemTime::UNIX_EPOCH,
+    })
+}
 
 /// The scales every group runs over.
 fn scales() -> Vec<(&'static str, Session)> {
@@ -64,16 +79,20 @@ fn bench_parse(c: &mut Criterion) {
             .collect();
         let bytes: usize = lines.iter().map(|l| l.len() + 1).sum();
         g.throughput(Throughput::Bytes(bytes as u64));
-        g.bench_with_input(BenchmarkId::new("parse_line", name), &lines, |b, lines| {
-            b.iter(|| {
-                let mut n = 0usize;
-                for l in lines {
-                    if wire::parse_line(black_box(l)).is_some() {
-                        n += 1;
+        g.bench_with_input(BenchmarkId::new("stream_push", name), &lines, |b, lines| {
+            b.iter_batched(
+                root_stream,
+                |mut stream| {
+                    let mut n = 0usize;
+                    for l in lines {
+                        if stream.push(black_box(l)).is_some() {
+                            n += 1;
+                        }
                     }
-                }
-                n
-            })
+                    n
+                },
+                BatchSize::SmallInput,
+            )
         });
     }
     g.finish();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! features off).
 //!
 //! Portable everywhere: the domain [`state`] (model + unified replay/live
-//! [`timeline`](state::timeline) + flow-graph projection), the [`ui`] rendering,
+//! [`timeline`](state::Timeline) + flow-graph projection), the [`ui`] rendering,
 //! the [`fact`] vocabulary every transcript format is reduced to, and the
 //! [`provider`] providers that do the reducing. The wire types and pure replay
 //! assembly live in [`tailer`]; its live file-tailing + the terminal loop ([`tui`]) and input
@@ -34,6 +34,11 @@ pub mod tailer;
 pub mod ui;
 
 // The native frontend: terminal loop + crossterm input.
+//
+// Frontend plumbing, with no stability promise. These are public because the
+// `zoe` binary is a separate crate that links this one, not because they are an
+// interface to build on: they may change shape in any release. The parts meant
+// to be depended on are the domain and the vocabulary above.
 #[cfg(feature = "native")]
 pub mod autopilot;
 #[cfg(feature = "native")]

--- a/src/provider/claude/discovery.rs
+++ b/src/provider/claude/discovery.rs
@@ -65,35 +65,6 @@ pub fn is_session_file(path: &std::path::Path) -> bool {
         .is_some_and(is_uuid)
 }
 
-/// Find the newest `<uuid>.jsonl` transcript directly inside `project_dir`
-/// (ignoring non-transcript files like `skill-injections.jsonl`,
-/// `sessions-index.json`, and subdirectories).
-pub fn latest_session_file(project_dir: &std::path::Path) -> Option<std::path::PathBuf> {
-    let mut best: Option<(std::time::SystemTime, std::path::PathBuf)> = None;
-    for entry in std::fs::read_dir(project_dir).ok()? {
-        let Ok(entry) = entry else { continue };
-        let path = entry.path();
-        if !is_session_file(&path) {
-            continue;
-        }
-        let Ok(meta) = entry.metadata() else { continue };
-        if !meta.is_file() {
-            continue;
-        }
-        let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
-        // Newest wins; equal mtimes break ties on the (lexicographically greater)
-        // path so the choice is deterministic, not `read_dir` order.
-        let better = match &best {
-            None => true,
-            Some((bt, bp)) => mtime > *bt || (mtime == *bt && path > *bp),
-        };
-        if better {
-            best = Some((mtime, path));
-        }
-    }
-    best.map(|(_, p)| p)
-}
-
 // ---------------------------------------------------------------------------
 // Subagent directory scanning
 // ---------------------------------------------------------------------------
@@ -559,34 +530,6 @@ mod tests {
         assert_eq!(found[1].agent_id, "a9dd56e1137830d9d");
         assert_eq!(found[0].workflow.as_deref(), Some("wf_x"));
         assert_eq!(found[0].meta, tmp.join("agent-a5301c73ab04591b2.meta.json"));
-
-        let _ = std::fs::remove_dir_all(&tmp);
-    }
-
-    #[test]
-    fn latest_session_file_picks_newest_uuid_jsonl() {
-        let tmp = std::env::temp_dir().join(format!(
-            "zoetrope-latest-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        ));
-        std::fs::create_dir_all(&tmp).expect("mkdir");
-        let older = tmp.join("11111111-1111-1111-1111-111111111111.jsonl");
-        let newer = tmp.join("22222222-2222-2222-2222-222222222222.jsonl");
-        // Non-transcript files must be ignored even if they are the newest.
-        std::fs::write(tmp.join("skill-injections.jsonl"), b"{}\n").unwrap();
-        std::fs::write(tmp.join("sessions-index.json"), b"{}\n").unwrap();
-        std::fs::write(&older, b"{}\n").unwrap();
-        // Ensure a real mtime gap across coarse-granularity filesystems, then
-        // write `newer` strictly after `older`.
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        std::fs::write(&newer, b"{}\n").unwrap();
-
-        let latest = latest_session_file(&tmp).expect("finds one");
-        assert_eq!(latest, newer, "newest uuid .jsonl wins; sidecars ignored");
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/provider/claude/mod.rs
+++ b/src/provider/claude/mod.rs
@@ -43,6 +43,11 @@ pub enum Source {
 
 /// One unit of Claude input: a parsed transcript line from a known file, or a
 /// discovered `meta.json` sidecar.
+///
+/// Test-only. Production reads a file through a [`Stream`], which is what the
+/// feeders do; this is the shape the tests find convenient for stating one
+/// record at a time.
+#[cfg(test)]
 #[derive(Debug)]
 pub enum Record {
     Entry {
@@ -56,6 +61,7 @@ pub enum Record {
     },
 }
 
+#[cfg(test)]
 impl Record {
     /// The facts this record states.
     pub fn facts(&self) -> Vec<Fact> {

--- a/src/provider/claude/wire.rs
+++ b/src/provider/claude/wire.rs
@@ -215,8 +215,6 @@ pub struct AgentToolInput {
     #[serde(default)]
     pub description: Option<String>,
     #[serde(default)]
-    pub prompt: Option<String>,
-    #[serde(default)]
     pub subagent_type: Option<String>,
 }
 

--- a/src/provider/codex/discovery.rs
+++ b/src/provider/codex/discovery.rs
@@ -124,6 +124,10 @@ pub fn rollouts_from(root: &Path) -> Vec<PathBuf> {
 
 /// The rollouts that belong to the session whose root is `root`: the root
 /// itself, then every file whose own meta names that root as its session.
+///
+/// Test-only: the conformance harness reads a fixture session this way.
+/// Feeders go through [`related_paths`] and let the core assemble.
+#[cfg(test)]
 pub fn session_rollouts(root: &Path) -> Vec<(PathBuf, SessionMeta)> {
     let Some(root_meta) = read_meta(root) else {
         return Vec::new();

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -67,8 +67,12 @@ use std::time::SystemTime;
 
 use crate::fact::Statement;
 
-pub mod claude;
-pub mod codex;
+// One module per transcript format. Crate-private: what a provider states is
+// the vocabulary in `fact`, and how it finds its files is the primitives on
+// `Provider` below. Nothing outside needs the parsers themselves, and the
+// browser frontend goes through `tailer::Bundle`.
+pub(crate) mod claude;
+pub(crate) mod codex;
 pub(crate) mod summary;
 
 #[cfg(test)]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -6,18 +6,23 @@
 //! [`App::handle_ui_event`] folds tailer events into the model and re-syncs the
 //! graph; events for stale sessions are dropped via [`App::is_current`].
 
-pub mod graph;
+// Two projections of the model. Crate-private: what the frontends need from
+// them is re-exported below, as the types of `App`'s fields.
+pub(crate) mod graph;
 pub mod info;
 pub mod render;
 pub mod session;
-pub mod timeline;
+pub(crate) mod timeline;
 
-use self::graph::AgentFlow;
+// `App`'s public fields, nameable from outside without exposing the module
+// layout they live in.
+pub use self::graph::AgentFlow;
 pub use self::info::SessionInfo;
+pub use self::timeline::Timeline;
+pub use crate::ui::chips::ChipTray;
+
 use self::session::SessionModel;
-use self::timeline::Timeline;
 use crate::tailer::UiEvent;
-use crate::ui::chips::ChipTray;
 
 /// Whether the app is watching a live session or replaying a finished one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -139,6 +144,10 @@ struct Snapshot {
 }
 
 /// The central application state, owned by the single UI task.
+///
+/// Its fields are public for the two frontends that drive it, this crate's own
+/// [`tui`](crate::tui) loop and the browser crate. They are frontend plumbing
+/// rather than an interface to build on, and carry no stability promise.
 pub struct App {
     /// The rendered flow graph (agent cards + step edges).
     pub flow: AgentFlow,
@@ -278,7 +287,7 @@ impl App {
     }
 
     /// Seek to a fraction (`0.0..=1.0`) along the timeline — a scrubber
-    /// click/drag. Index-based (see [`Timeline::progress`]), so the playhead
+    /// click/drag. Index-based (see `Timeline::progress`), so the playhead
     /// lands under the cursor and activity is evenly reachable. No-op when empty.
     pub fn seek_to_fraction(&mut self, f: f64) {
         let len = self.timeline.items.len();

--- a/src/state/session.rs
+++ b/src/state/session.rs
@@ -1,6 +1,6 @@
 //! `SessionModel`: the pure domain model — agents, their statuses, and tool
 //! calls, folded solely from `Fact`s. No provider records and no rataflow types
-//! here; the graph layer ([`crate::state::graph`]) projects this onto a `Flow`.
+//! here; the graph layer ([`AgentFlow`](crate::state::AgentFlow)) projects this onto a `Flow`.
 //!
 //! Node ids are stable strings: `"main"` for the root agent, and otherwise
 //! whatever id the provider stated the agent under (Claude's 17-hex agent id,
@@ -344,6 +344,7 @@ impl SessionModel {
 
     /// Fold one Claude record through the provider. Test convenience: the
     /// production paths hand facts in directly.
+    #[cfg(test)]
     #[cfg(test)]
     pub(crate) fn apply_update(&mut self, record: &crate::provider::claude::Record) -> bool {
         record

--- a/src/ui/chips.rs
+++ b/src/ui/chips.rs
@@ -141,7 +141,7 @@ fn within_gap(prev: Option<DateTime<Utc>>, next: Option<DateTime<Utc>>) -> bool 
 /// mark that separates new activity from already-seen history. Owned by `App`;
 /// driven every frame by the single `reconcile`(Self::reconcile) pass and
 /// re-baselined on attach/seek by [`adopt_baseline`](Self::adopt_baseline);
-/// drawn by [`render`].
+/// drawn by this module's `render`.
 #[derive(Default)]
 pub struct ChipTray {
     chips: Vec<Chip>,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,10 +6,13 @@
 //! `&Flow`, so they are separate `render_widget` calls), and finally the status
 //! bar.
 
-pub mod chips;
-pub mod edges;
-pub mod nodes;
-pub mod panel;
+// Crate-private: the frontends call `ui::draw` and nothing else here. The
+// types these hold reach the outside through `state`'s re-exports, where they
+// are fields of `App`.
+pub(crate) mod chips;
+pub(crate) mod edges;
+pub(crate) mod nodes;
+pub(crate) mod panel;
 
 use crate::fact::{FactKind, Outcome};
 use rataflow::{Background, MiniMap, MiniMapPosition};

--- a/src/ui/panel.rs
+++ b/src/ui/panel.rs
@@ -443,12 +443,6 @@ fn era_header_flags(
     (flags, agent.tool_calls.len() + headers)
 }
 
-/// Total rendered lines of an agent's tool list (rows + era headers) — the
-/// scroll ceiling the handler clamps against.
-pub fn tool_list_lines(agent: &AgentInfo, model: &crate::state::session::SessionModel) -> usize {
-    era_header_flags(agent, model).1
-}
-
 /// One row of the tool-call list: state glyph, name, summary, local time.
 fn tool_line(
     tc: &crate::state::session::ToolCallInfo,
@@ -580,7 +574,7 @@ mod tests {
         let agent = m.agent(crate::state::session::MAIN_ID).unwrap();
         // 3 tool rows + 2 era headers (eras 0 and 1) = 5 rendered lines —
         // the scroll ceiling the handler clamps against.
-        assert_eq!(tool_list_lines(agent, &m), 5);
+        assert_eq!(era_header_flags(agent, &m).1, 5);
     }
 
     use chrono::{TimeZone, Utc};


### PR DESCRIPTION
**Why**

zoetrope ships a library as well as the `zoe` binary, and right now every module in it is public. That was never a decision, it is just what you get from writing `pub mod`. Once 0.2.0 is on crates.io, all of it is what people can depend on, and renaming anything inside becomes a breaking change.

Only two things actually use the library: the `zoe` binary, which is a separate crate that links it, and the browser frontend. This keeps public what those need, plus what anyone building on zoetrope would need, and makes the rest private.

**What the library still gives you**

| Module | For |
| --- | --- |
| `fact` | the vocabulary: `Fact`, `Statement`, `Outcome`, `AgentKind`, `AgentStatus` |
| `provider` | finding and reading sessions: `open`, `sweep`, `Target`, `Scope`, `Session`, `SessionFile`, `Stream`, `provider_of` |
| `state` | the model: `App`, `SessionModel`, `SessionInfo`, `AgentFlow`, `Timeline`, `Mode`, the camera types |
| `tailer` | feeding files in: `Bundle`, `ReplayItem`, `TailRequest`, `UiEvent` |
| `ui` | `draw`, which is the whole renderer |
| `autopilot`, `handler`, `tui` | the native terminal loop |

You can still find sessions on disk, parse one into facts, fold it into a model, and draw it. What you can no longer reach is how a transcript format is decoded, or how the graph and the chip rows are laid out.

**What went private**

The two parser modules, `provider::claude` and `provider::codex`. Hiding the format is the whole point of the boundary, and the browser reads files through `tailer::Bundle` rather than through either of them.

`state::graph`, `state::timeline` and the `ui` submodules, for the same reason. Three of their types are still fields on `App`, so `AgentFlow`, `Timeline` and `ChipTray` are re-exported from `state`. You can name them without the module layout being public.

`App`'s fields and the native modules stay public, because the binary is a separate crate and cannot work without them. Their docs now say what that means: they are there to drive a frontend, not to build on, and they can change in any release.

**What it turned up**

While everything was public, nothing looked unused, because the compiler assumed someone outside might call it. Once the parsers were private it could tell the truth:

- Deleted: `ui::panel::tool_list_lines`, since the renderer clamps the scroll itself; `claude::discovery::latest_session_file`, replaced by the discovery primitives; and a wire field nothing reads.
- Marked `cfg(test)`: `claude::Record` with `SessionModel::apply_update`, and codex's `session_rollouts`. All three are conveniences the tests use to state one record at a time, and they now say so.
- The parse benchmark was reaching through the private wire parser. It measures the same lines through `Stream::push`, which is the path a feeder takes.
