### PR TITLE
feat(herdr): open the focused agent pane's session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ cd web/wasm && cargo clippy   # its .cargo/config.toml defaults to wasm32
 
 ## Commits
 
-[Conventional Commits](https://www.conventionalcommits.org/), lowercase imperative subject. Scope is a module, not a file: `fact`, `provider`, `state`, `graph`, `timeline`, `tailer`, `ui`, `panel`, `cli`, `wasm`, `web`, `api`, `docs`. `api` is a change to what the crate exposes rather than to one module. A change inside one provider is `provider` (e.g. `fix(provider): inherit the timestamp across progress records`).
+[Conventional Commits](https://www.conventionalcommits.org/), lowercase imperative subject. Scope is a module, not a file: `fact`, `provider`, `state`, `graph`, `timeline`, `tailer`, `ui`, `panel`, `cli`, `wasm`, `web`, `herdr`, `api`, `docs`. `herdr` is the Herdr plugin in `herdr-plugin/`, a bridge of shell scripts that opens the focused agent pane's session in `zoe`; it ships by git clone rather than with the crate. `api` is a change to what the crate exposes rather than to one module. A change inside one provider is `provider` (e.g. `fix(provider): inherit the timestamp across progress records`).
 
 ```
 feat(timeline): index the playhead by event instead of wall-clock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Terminal UI that visualizes Claude Code and Codex agent sessions as a live flow 
 
 Transcript formats enter through one boundary: `src/provider/` turns records into the facts in `src/fact.rs`, and nothing past it knows the format. See `docs/ARCHITECTURE.md` §0 before adding to either side.
 
-See `docs/ARCHITECTURE.md` for the invariants and principles, `docs/DESIGN.md` for the module map and transcript format, `TODO.md` for the roadmap, and `README.md` for usage.
+See `docs/ARCHITECTURE.md` for the invariants and principles, `docs/DESIGN.md` for the module map and transcript format, `docs/HERDR-PLUGIN.md` for the Herdr bridge in `herdr-plugin/`, `TODO.md` for the roadmap, and `README.md` for usage.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@
   <img src="https://raw.githubusercontent.com/furkankly/zoetrope/main/assets/zoetrope.svg" alt="A session drawn as a flow graph: a main agent above the subagents it spawned, over a timeline of tool activity" width="620">
 </p>
 
-Claude Code and Codex, the CLI and the desktop app, each write a transcript for every
-session. zoetrope reads it and draws the session as a graph in your terminal: the main
-agent, the agents it spawns, and the tools each one runs, updating live as it goes.
-Point it at a finished run and it replays, paced by the session's own timestamps. Point
-it at a running one and it follows along. It's read-only, and nothing leaves your machine.
+Claude Code and Codex write a transcript for every session. zoetrope reads it and draws
+the session as a graph in your terminal: the main agent, the agents it spawns, and the
+tools each one runs, updating live as it goes. Point it at a finished run and it replays,
+paced by the session's own timestamps. Point it at a running one and it follows along.
+It's read-only, and nothing leaves your machine.
 
 Built on [ratatui](https://ratatui.rs) and [rataflow](https://github.com/furkankly/rataflow).
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ cargo build --release
 No install at all: **[try it in your browser](https://zoetrope.furkankly.dev/app)**.
 Drop a transcript on the page and get the same graph.
 
+## In Herdr
+
+[Herdr](https://herdr.dev) is a terminal multiplexer built for running coding
+agents side by side. It knows which agent occupies a pane and the id of the
+session running there, so the plugin in
+[`herdr-plugin/`](https://github.com/furkankly/zoetrope/tree/main/herdr-plugin)
+opens that exact session in `zoe`, without you naming a file or an id.
+
+```bash
+herdr integration install claude          # and/or codex, so Herdr learns session ids
+herdr plugin install furkankly/zoetrope/herdr-plugin
+herdr plugin action invoke setup-keys --plugin furkankly.zoetrope
+```
+
+Focus an agent pane and press `prefix+shift+z`. The graph opens over the pane,
+follows the session live, and the same key closes it. There are placements for
+a split and a tab as well, and the plugin's
+[README](https://github.com/furkankly/zoetrope/blob/main/herdr-plugin/README.md)
+covers both.
+
 ## Usage
 
 ```bash
@@ -99,26 +119,6 @@ scrub, follow, pause, jump back to live.
 The same engine also runs [in the browser](https://zoetrope.furkankly.dev/app),
 compiled to WebAssembly via [ratzilla](https://github.com/ratatui/ratzilla). Open a
 session from disk, or drop a transcript on the page. It stays local there too.
-
-## In Herdr
-
-[Herdr](https://herdr.dev) is a terminal multiplexer built for running coding
-agents side by side. It knows which agent occupies a pane and the id of the
-session running there, so the plugin in
-[`herdr-plugin/`](https://github.com/furkankly/zoetrope/tree/main/herdr-plugin)
-opens that exact session in `zoe`, without you naming a file or an id.
-
-```bash
-herdr integration install claude          # and/or codex, so Herdr learns session ids
-herdr plugin install furkankly/zoetrope/herdr-plugin
-herdr plugin action invoke setup-keys --plugin furkankly.zoetrope
-```
-
-Focus an agent pane and press `prefix+shift+z`. The graph opens over the pane,
-follows the session live, and the same key closes it. There are placements for
-a split and a tab as well, and the plugin's
-[README](https://github.com/furkankly/zoetrope/blob/main/herdr-plugin/README.md)
-covers both.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,26 @@ The same engine also runs [in the browser](https://zoetrope.furkankly.dev/app),
 compiled to WebAssembly via [ratzilla](https://github.com/ratatui/ratzilla). Open a
 session from disk, or drop a transcript on the page. It stays local there too.
 
+## In Herdr
+
+[Herdr](https://herdr.dev) is a terminal multiplexer built for running coding
+agents side by side. It knows which agent occupies a pane and the id of the
+session running there, so the plugin in
+[`herdr-plugin/`](https://github.com/furkankly/zoetrope/tree/main/herdr-plugin)
+opens that exact session in `zoe`, without you naming a file or an id.
+
+```bash
+herdr integration install claude          # and/or codex, so Herdr learns session ids
+herdr plugin install furkankly/zoetrope/herdr-plugin
+herdr plugin action invoke setup-keys --plugin furkankly.zoetrope
+```
+
+Focus an agent pane and press `prefix+shift+z`. The graph opens over the pane,
+follows the session live, and the same key closes it. There are placements for
+a split and a tab as well, and the plugin's
+[README](https://github.com/furkankly/zoetrope/blob/main/herdr-plugin/README.md)
+covers both.
+
 ## Features
 
 **The graph**

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -42,6 +42,7 @@ Two lockfiles means the two frontends can drift apart. Most of that drift is har
 Cargo.toml          # [workspace] exclude = ["web/wasm"]  — its own workspace, own lockfile
 src/                # the zoetrope library + the `zoe` bin (src/main.rs)
 web/wasm/           # the zoetrope-web crate: Cargo.toml, index.html (trunk entry), src/main.rs
+herdr-plugin/       # the Herdr plugin: a manifest and shell scripts that launch `zoe`; ships by git clone, not with the crate
 ```
 
 ## Dependencies (Cargo.toml)

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -145,7 +145,8 @@ What used to be five feeder sites naming `claude::` are these calls. The live ta
 - **The browser** (`web/wasm`): no filesystem. The page reads files (a drop, an upload, or a directory it may keep re-reading) and passes `[{path, text}]` to `zoetrope_load`; `tailer::Bundle` does the rest through `session_file_from`, `stream_for` and `sidecar`, and `zoetrope_append` continues the same streams. The page's own job is finding files: Claude by the `<uuid>.jsonl` and `<uuid>/subagents/` layout, Codex by reading each rollout's first line, which is `session_file`'s logic written a second time in JavaScript because the page cannot call it before the files are read.
 - **The herdr plugin** (`herdr-plugin/`): asks Herdr which session the focused
   pane is running, hands `zoe` that id, and `open` does the rest. It is the
-  case `Target::Id` was written for: the id is known, the file is not.
+  case `Target::Id` was written for: the id is known, the file is not. See
+  [HERDR-PLUGIN.md](HERDR-PLUGIN.md).
 
 ---
 

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -143,7 +143,9 @@ What used to be five feeder sites naming `claude::` are these calls. The live ta
 - **Replay and follow** (`tailer/replay.rs`, `tailer/live.rs`): `open`, then one `Stream` per tailed file and one `sidecar` statement per whole-read file. Every tick: read appended bytes through each stream, `rescan` for files that appeared, state sidecars that now parse. `Flow::Switch { target, follow }` carries the working directory being followed, so a re-attach after truncation keeps following and a named file or id stays pinned.
 - **`inspect`** (`main.rs`): `open`, read every file, fold. Session-level facts go to the info header whichever record carried them (a Codex root names itself and its app on one line; `Statement::take_session_meta` splits it).
 - **The browser** (`web/wasm`): no filesystem. The page reads files (a drop, an upload, or a directory it may keep re-reading) and passes `[{path, text}]` to `zoetrope_load`; `tailer::Bundle` does the rest through `session_file_from`, `stream_for` and `sidecar`, and `zoetrope_append` continues the same streams. The page's own job is finding files: Claude by the `<uuid>.jsonl` and `<uuid>/subagents/` layout, Codex by reading each rollout's first line, which is `session_file`'s logic written a second time in JavaScript because the page cannot call it before the files are read.
-- **herdr**: hands a path or an id, gets `open`.
+- **The herdr plugin** (`herdr-plugin/`): asks Herdr which session the focused
+  pane is running, hands `zoe` that id, and `open` does the rest. It is the
+  case `Target::Id` was written for: the id is known, the file is not.
 
 ---
 

--- a/docs/HERDR-PLUGIN.md
+++ b/docs/HERDR-PLUGIN.md
@@ -1,0 +1,162 @@
+# The Herdr plugin
+
+A bridge, not a second frontend. [Herdr](https://herdr.dev) already knows which
+agent occupies a pane and the native id of the session running there, which is
+the pair `zoe` would otherwise have to infer. The plugin asks for it and hands
+it over. The user-facing half is [`herdr-plugin/README.md`](../herdr-plugin/README.md);
+this is the rest.
+
+It lives in `herdr-plugin/`, ships by git clone rather than with the crate, and
+is a manifest plus three shell scripts. Herdr plugin panes run an ordinary argv
+command in a real TTY, so `zoe` itself is the plugin UI. Nothing is embedded in
+Herdr's render loop, and nothing about the graph is written twice.
+
+---
+
+## 1. Where it sits on the boundary
+
+[DISCOVERY.md](DISCOVERY.md) fixed the input side: a provider states what a file
+is, the core decides what a session is, and a feeder reaches it through `open`.
+The plugin is the case `Target::Id` was written for. The id is known, the file
+is not, and finding the file is the core's job across every provider's roots.
+
+That is the whole reason the bridge stays small. It never reads a transcript,
+never learns a layout, and never guesses a project from a working directory. It
+resolves one pair, `(agent, session id)`, and spends it on one command:
+
+```
+zoe --provider <agent> --follow <id>
+```
+
+`--provider` narrows the lookup to the agent Herdr named. `--follow` is right
+by definition here, since the pane's agent is running.
+
+## 2. The three scripts
+
+| Script | Role |
+|---|---|
+| `herdr/pane.sh` | all three actions (`open`, `open-split`, `open-tab`), differing only in the placement they pass. Opens the graph pane, or closes it when the graph is the focused pane, which is what makes the key a toggle |
+| `herdr/open.sh` | the pane command. Resolves the session and execs `zoe` |
+| `herdr/resolve.sh` | asks `pane.get` about the focused pane, prints `<agent> <session-id>`, or exits with the reason |
+| `herdr/keys.sh` | the `setup-keys` / `remove-keys` actions |
+| `herdr/ensure-zoe.sh` | the `[[build]]` step: is a usable `zoe` on `PATH` |
+
+Two decisions in there are worth keeping.
+
+**Resolution reads `focused_pane_id`, never `HERDR_PANE_ID`.** In a pane
+command, `HERDR_PANE_ID` is the plugin's own newly created pane, so asking Herdr
+about it returns a pane with no agent. `focused_pane_id` in
+`HERDR_PLUGIN_CONTEXT_JSON` is the pane the plugin was invoked from, and it is
+the same field for an action and for a pane command.
+
+**Every message is printed in the pane, and held until the user presses enter.**
+An action runs headless with its output going to `herdr plugin log`, and Herdr
+notifications can be switched off, in which case a notification is silently
+dropped. The pane's own terminal is the only surface that cannot be turned off.
+Resolution therefore happens in the pane, where its failures are visible, and
+not in the action, where they would not be.
+
+**Closing recognises the plugin's own pane by label.** Herdr labels a plugin
+pane with its manifest title, so a focused pane labelled `zoetrope` that holds
+no agent is ours, and the key closes it instead of trying to graph it. A pane a
+user renamed `zoetrope` still holds an agent, so it is not mistaken for ours.
+
+## 3. Keys
+
+Plugin v1 declares actions, event hooks, panes and link handlers, and nothing
+else. Keybindings live in the user's own config, and Herdr 0.8.2 has no command
+palette, so an action with no key is reachable only from the command line. Of
+the plugins surveyed, most document a snippet to paste and three ship an action
+that writes it; `setup-keys` is the latter.
+
+It resolves the config path the way Herdr does (`HERDR_CONFIG_PATH`, then
+`$XDG_CONFIG_HOME/herdr/config.toml`, then `~/.config/herdr/config.toml`),
+refuses to touch a file that does not already pass `herdr config check`, backs
+it up, writes one marker-fenced block, validates the result and restores the
+backup if it does not parse, then reloads the running Herdr.
+
+It binds one key. Where the graph opens is a standing preference rather than a
+per-press decision, so claiming three chords of a shared keyspace to express it
+would be a poor trade. The other two placements are written into the same block
+as commented bindings, which documents them where the user will look.
+
+## 4. Versions
+
+Three numbers, three reasons to change, and none of them follows a zoetrope
+release:
+
+| Number | Where | Bumped when |
+|---|---|---|
+| `version` | `herdr-plugin.toml` | the files in `herdr-plugin/` change. Displayed by Herdr, resolved by nothing |
+| `min_herdr_version` | `herdr-plugin.toml` | a script starts using a newer Herdr API. The only one that can block an install |
+| `ZOE_SINCE` | `herdr/ensure-zoe.sh` | the `zoe` command line the scripts call changes. A label for the error message, not a check |
+
+`herdr plugin install` clones the repo at its default branch (or at `--ref`), so
+what people get is main, and reinstalling is how it updates. There is no
+registry, no tag resolution and no `plugin update`.
+
+**Why the manifest version does not mirror the crate.** Plugins that keep the
+two in step have a reason to: their installer builds a release download URL out
+of the version, because the plugin is how their binary is distributed. Nothing
+here downloads anything. `zoe` reaches people through Homebrew and crates.io,
+and the bridge drives whatever is on `PATH`, so a mirrored number would be a
+hand-edited label with no reader, touched on every release including the ones
+that never came near this directory.
+
+**Why the binary is gated on capability, not version.** The build step asks
+`zoe --help` whether it takes `--provider`. A version string is a label: a
+binary built from a checkout carries the crate version of its base release, so
+a floor would refuse a `zoe` that has the flag, while a future release that
+renamed the flag would pass a floor and then fail at the first key press.
+
+**The one rule tying the two release channels together.** A script here may only
+call a `zoe` command line that is already published, because installs take the
+branch while the binary comes from a release. Calling something unreleased would
+break every fresh install until the crate ships.
+
+## 5. Notes on Herdr's API
+
+Read from `herdr api schema --json` on Herdr 0.8.2 (protocol 20), the plugin and
+socket docs at v0.9.0, and live responses.
+
+- `PaneInfo` is `pane_id` (not `id`), `agent`, `agent_session`, `agent_status`,
+  `cwd`, `foreground_cwd`, `display_agent`, `focused`, `tokens`, `workspace_id`.
+- `pane.get` nests that record one level down, as
+  `{"result": {"pane": {...}, "type": "pane_info"}}`; `pane.list` answers
+  `.result.panes`. Every CLI response is `{id, result}` or `{id, error}`.
+- `AgentSessionInfo` is `{source, agent, kind, value}`, all required, and the
+  whole object is absent until an integration reports a session.
+- `AgentSessionRefKind` is `"id"` or `"path"`. Herdr maps `herdr:claude` and
+  `herdr:codex` to an id, reported by each agent's `SessionStart` hook; `pi` and
+  `omp` store a path, and zoetrope does not read those agents.
+- `PluginInvocationContext` is flat: `focused_pane_id`, `focused_pane_agent`,
+  `focused_pane_cwd`, `focused_pane_status`, `workspace_cwd`, and so on.
+- Action `contexts` are `global`, `workspace`, `tab`, `pane`, `selection`,
+  stored but not rendered in 0.8.2. Pane `placement` is `overlay`, `popup`,
+  `split`, `tab` or `zoomed`; `overlay` is a temporary zoom that restores the
+  previous focus and zoom on close, `popup` is session-modal, has no pane id and
+  sits outside the pane APIs.
+- Runtime environment: `HERDR_SOCKET_PATH`, `HERDR_BIN_PATH`, `HERDR_PLUGIN_ID`,
+  `HERDR_PLUGIN_ROOT`, `HERDR_PLUGIN_CONFIG_DIR`, `HERDR_PLUGIN_STATE_DIR`,
+  `HERDR_PLUGIN_CONTEXT_JSON`, plus `HERDR_WORKSPACE_ID`, `HERDR_TAB_ID`,
+  `HERDR_PANE_ID` where they apply. Actions also get `HERDR_PLUGIN_ACTION_ID`,
+  pane commands `HERDR_PLUGIN_ENTRYPOINT_ID`.
+
+## 6. Working on it
+
+```bash
+herdr plugin link "$(pwd)/herdr-plugin"        # link runs no build step: have zoe on PATH
+herdr plugin action list --plugin furkankly.zoetrope
+herdr plugin log list --plugin furkankly.zoetrope   # where an action's output goes
+herdr pane list | jq '.result.panes[] | {pane_id, agent, agent_session}'
+```
+
+`herdr plugin link` re-reads the manifest, so run it after editing
+`herdr-plugin.toml`. The scripts read Herdr only through `$HERDR_BIN_PATH` and
+`jq`, so they can be exercised without Herdr by putting a stub `herdr` on
+`PATH` that prints a canned `pane.get` response and setting
+`HERDR_PLUGIN_CONTEXT_JSON` to `{"focused_pane_id":"w1:p1"}`.
+
+Anything asserted here about Herdr's shapes came from the schema or a live
+response, never from memory. Keep it that way: the field names are close enough
+to plausible-but-wrong that guessing has cost a debugging session already.

--- a/herdr-plugin/README.md
+++ b/herdr-plugin/README.md
@@ -1,26 +1,50 @@
-# herdr-plugin-zoetrope
+# zoetrope in Herdr
 
-Open the focused agent's session as a live flow graph, without leaving Herdr.
-Works for Claude Code and Codex panes.
+[Herdr](https://herdr.dev) runs coding agents in panes and knows which session
+each pane is running. This plugin asks it, then opens that session in `zoe` as
+a live flow graph, without you naming a file or an id. Claude Code and Codex
+panes both work.
 
-## First run
+## Installation
 
 ```bash
-herdr integration install claude            # and/or: herdr integration install codex
+herdr integration install claude          # and/or: herdr integration install codex
 herdr plugin install furkankly/zoetrope/herdr-plugin
 herdr plugin action invoke setup-keys --plugin furkankly.zoetrope
 ```
 
-Then start the agent in a pane, and press `prefix+shift+z` (`prefix` is
-`ctrl+b` unless you changed it). The graph opens as an overlay, following the
-session live.
+**The integration** is what makes the rest possible. It adds a `SessionStart`
+hook to the agent, so Herdr learns the native session id of whatever runs in a
+pane. Without it Herdr knows a pane holds Claude Code but not which session,
+and the plugin has nothing to open. An agent already running when you install
+it never reports one, so start it again. `herdr integration status` lists what
+is installed.
 
-To get back to the agent, press `q` in the graph, or `prefix+shift+z` again:
-with the graph in front the key closes it. `?` in the graph lists zoetrope's
-own keys.
+**The plugin install** checks that a `zoe` new enough to open a session by id
+is on `PATH`, and installs one with Homebrew or cargo when it is missing. An
+older `zoe` is reported with the upgrade commands, never replaced. Nothing is
+vendored: `zoe` is a standalone tool with its own releases, and the plugin
+drives the one you have. `jq` is needed as well.
 
-Pressing the key with the graph in front closes it, so one key opens and puts
-away.
+**The key step** writes one marked block into the Herdr config, since plugins
+cannot ship keys in their manifest. It finds the file the way Herdr does
+(`HERDR_CONFIG_PATH`, then `$XDG_CONFIG_HOME/herdr`, then
+`~/.config/herdr/config.toml`), backs it up, leaves a key that is already bound
+alone and names it, validates the result and rolls back if it does not parse,
+then reloads the running Herdr. `remove-keys` deletes the block again.
+
+From a checkout instead:
+
+```bash
+herdr plugin link "$(pwd)"    # link runs no build step, so have zoe on PATH
+```
+
+## Usage
+
+Focus an agent pane and press `prefix+shift+z`, where `prefix` is `ctrl+b`
+unless you changed it. The graph opens over the pane and follows the session
+live. Press `q` in the graph to close it, or the same key again, so one key
+both opens and puts away.
 
 Where it opens is a preference you make once, so `setup-keys` binds one key and
 writes the other two placements into the same block as comments:
@@ -32,56 +56,18 @@ writes the other two placements into the same block as comments:
 | tab | commented | keeping it open. Full area, one tab switch from the agent |
 
 To switch, uncomment one in your Herdr config, or point the live binding at
-`open-split` or `open-tab`, then `herdr server reload-config`.
-
-The **integration** is what makes any of this work: it adds a `SessionStart`
-hook to the agent so Herdr learns the native session id of whatever runs in a
-pane. Without it Herdr knows a pane holds Claude Code but not which session,
-and the plugin has nothing to open. Agents already running when you install it
-keep reporting nothing, so start them again. `herdr integration status` lists
-what is installed.
-
-The **plugin install** checks that a `zoe` new enough to open a session by id
-is on `PATH`, and installs one with Homebrew, or cargo, when it is missing.
-Nothing is vendored: `zoe` is a standalone tool with its own releases, and the
-plugin drives the one you have rather than keeping a private copy on a separate
-update schedule. An older `zoe` is reported with the upgrade commands, never
-replaced. `jq` is needed as well.
-
-The **key step** binds `prefix+shift+z`, next to Herdr's own `prefix+z` for
-zoom, and offers `prefix+shift+v` and `prefix+shift+c` as comments beside
-`prefix+v` for split and `prefix+c` for tab. It writes one marked block into the Herdr config it finds (the
-same lookup Herdr uses: `HERDR_CONFIG_PATH`, then `$XDG_CONFIG_HOME/herdr`,
-then `~/.config/herdr/config.toml`), backs the file up first, refuses if
-`prefix+shift+z` is already bound, and reloads the running Herdr. The outcome
-shows as a Herdr notification and in `herdr plugin log list`. `remove-keys`
-deletes the block again. To use another key, skip `setup-keys` and bind the
-action yourself:
+`open-split` or `open-tab`, then run `herdr server reload-config`. To bind your
+own keys instead, skip `setup-keys` and write them yourself:
 
 ```toml
 [[keys.command]]
 key = "prefix+shift+z"
 type = "plugin_action"
 command = "furkankly.zoetrope.open"
-description = "zoetrope: session graph"
-
-[[keys.command]]
-key = "prefix+shift+v"
-type = "plugin_action"
-command = "furkankly.zoetrope.open-split"
-description = "zoetrope: session graph (split)"
-
-[[keys.command]]
-key = "prefix+shift+c"
-type = "plugin_action"
-command = "furkankly.zoetrope.open-tab"
-description = "zoetrope: session graph (tab)"
+description = "zoetrope: session graph (overlay)"
 ```
 
-A key already bound to something else is left alone and named in the result,
-so `setup-keys` never takes a key you are using.
-
-Without a key, the actions are still there from the command line:
+The actions also run from the command line, with or without a key:
 
 ```bash
 herdr plugin action invoke open --plugin furkankly.zoetrope
@@ -89,35 +75,36 @@ herdr plugin action invoke open-split --plugin furkankly.zoetrope
 herdr plugin action invoke open-tab --plugin furkankly.zoetrope
 ```
 
-From a checkout:
+## Keys inside the graph
 
-```bash
-herdr plugin link "$(pwd)"    # link runs no build step, so have zoe on PATH
-```
+Herdr sees the prefix chord first and everything else reaches the pane, in
+every placement. So zoetrope keeps its own keys (`q`, `?`, `space`, arrows,
+`hjkl`, `+` and `-`, `[` and `]`, `g` and `G`) and Herdr keeps `prefix+...`.
+Herdr's own `hjkl` pane moves live inside navigate mode, which the prefix
+opens, so they never shadow the graph's. The one way to collide is a custom
+`[[keys.command]]` bound to a bare chord rather than a prefix chord, since
+Herdr grabs those before any pane sees them.
 
 ## How it works
 
 Herdr plugin panes run an ordinary argv command in a real TTY, so a ratatui
 program is a first-class plugin UI. Nothing is embedded into Herdr's render
-loop: zoetrope's own TUI is the plugin UI, and the plugin is three shell
-scripts.
-
-Three scripts:
+loop: zoetrope's own TUI is the plugin UI, and the plugin is three scripts.
 
 1. `herdr/pane.sh` is all three actions, which differ only in the placement
-   they pass. It opens the `graph` pane, or closes it when
-   the graph is the focused pane, which makes the key a toggle. Herdr labels a
-   plugin pane with its manifest title, so a focused pane labelled `zoetrope`
-   holding no agent is the plugin's own.
+   they pass. It opens the graph pane, or closes it when the graph is the
+   focused pane, which is what makes the key a toggle. Herdr labels a plugin
+   pane with its manifest title, so a focused pane labelled `zoetrope` holding
+   no agent is the plugin's own.
 2. `herdr/open.sh` is the pane. It resolves the session and runs
    `zoe --provider <agent> --follow <id>`.
-3. `herdr/resolve.sh` asks `pane.get` about the **focused** pane and prints
+3. `herdr/resolve.sh` asks `pane.get` about the focused pane and prints
    `<agent> <session-id>`.
 
 Every failure is printed in the pane and held until you press enter. An action
-runs headless, its output goes to `herdr plugin log`, and Herdr notifications
-can be turned off, so the pane's own terminal is the only place a message is
-certain to be seen.
+runs headless with its output going to `herdr plugin log`, and Herdr
+notifications can be switched off, so the pane's own terminal is the only place
+a message is certain to be seen.
 
 `pane.get` carries a stored session reference for the agent in the pane:
 
@@ -127,39 +114,26 @@ certain to be seen.
                      "kind": "id", "value": "..." } }
 ```
 
-Herdr's Claude Code and Codex integrations report the native session id from a
-`SessionStart` hook, so `kind` is `"id"` for both, and `zoe <id>` is exactly
-what that is for. The plugin passes `--provider` with the agent Herdr named, so
-the lookup stays inside that agent's files, and `--follow`, since the pane's
-agent is running.
+Herdr's Claude Code and Codex integrations both report the native session id,
+so `kind` is `"id"` for either, and `zoe <id>` is exactly what that is for. The
+plugin passes `--provider` with the agent Herdr named, so the lookup stays
+inside that agent's files, and `--follow`, since the pane's agent is running.
 
 | Herdr reports | What happens |
 | --- | --- |
 | an id for a `claude` or `codex` pane | `zoe --provider <agent> --follow <id>` |
-| an agent but no session id | how to install the integration and why the agent has to be restarted |
+| an agent but no session id | how to install the integration, and why the agent has to be restarted |
 | no agent in the pane | a line saying to focus an agent pane |
 | an agent zoetrope does not read | the same, naming the agent |
 
-There is no fallback through the working directory. Herdr knows the session,
-so the plugin uses it or says what it got instead.
-
-## Keys, once the graph is up
-
-Herdr sees the prefix chord first and everything else goes to the pane, in
-every placement. So zoetrope keeps its own keys (`q`, `?`, `space`, arrows,
-`hjkl`, `+`/`-`, `[`/`]`, `g`/`G`) and Herdr keeps `prefix+...`. Herdr's
-`hjkl` pane moves live inside navigate mode, which the prefix opens, so they
-never shadow the graph's own. The one way to collide is a custom
-`[[keys.command]]` bound to a bare chord rather than a prefix chord: Herdr
-grabs those globally, before any pane.
+There is no fallback through the working directory. Herdr knows the session, so
+the plugin uses it or says what it got instead.
 
 ## Versions
 
 The plugin has no release of its own. `herdr plugin install` clones the repo at
-its default branch, so what people get is what is on main, and `herdr plugin
-uninstall` then `install` is how it updates.
-
-Three numbers, three reasons to change:
+its default branch, so what people get is what is on main, and reinstalling is
+how it updates. Three numbers, three reasons to change:
 
 | Number | Where | Bumped when |
 | --- | --- | --- |
@@ -167,43 +141,43 @@ Three numbers, three reasons to change:
 | `min_herdr_version` | `herdr-plugin.toml` | a script starts using a newer Herdr API. The only one that can block an install |
 | `ZOE_SINCE` | `herdr/ensure-zoe.sh` | the command line the scripts call changes. A label for the error message, not a check |
 
-None of them follows a zoetrope release on its own, and a `zoe` release that
-leaves the command line alone changes nothing here. Zoe's own improvements
-reach people through Homebrew and crates.io without the bridge moving at all.
+None of them follows a zoetrope release. Zoe's own improvements reach people
+through Homebrew and crates.io without the bridge moving at all, and the bridge
+only has to move when it starts calling something new.
 
-The binary is gated on what it can do rather than on what it calls itself: the
+`zoe` is gated on what it accepts rather than on what it calls itself: the
 build step asks `zoe --help` whether it takes `--provider`. A version string is
 a label, and a binary built from a checkout carries the crate version of its
 base release, so a floor would refuse a `zoe` that has the flag, while a future
-release that renamed the flag would pass a floor and fail at the first key
+release that renamed the flag would pass a floor and then fail at the first key
 press.
 
-One rule ties the two release channels together: a script here may only call a
-`zoe` command line that is already published, since installs take the branch
-while the binary comes from a release. Adding a call to something unreleased
-would break every fresh install until the crate ships.
+One rule ties the two release channels together. A script here may only call a
+`zoe` command line that is already published, because installs take the branch
+while the binary comes from a release. Calling something unreleased would break
+every fresh install until the crate ships.
 
-## Provenance of the field names
+## Notes on Herdr's API
 
-Taken from `herdr api schema --json` on herdr 0.8.2 (protocol 20), the plugin
-and socket docs at v0.9.0, and live responses, not from memory:
+Read from `herdr api schema --json` on Herdr 0.8.2 (protocol 20), the plugin
+and socket docs at v0.9.0, and live responses:
 
-- `PaneInfo`: `pane_id` (not `id`), `agent`, `agent_session`, `agent_status`,
+- `PaneInfo` is `pane_id` (not `id`), `agent`, `agent_session`, `agent_status`,
   `cwd`, `foreground_cwd`, `display_agent`, `focused`, `tokens`, `workspace_id`
 - `pane.get` nests that record one level down, as
-  `{"result": {"pane": {...}, "type": "pane_info"}}`; `pane.list` answers
+  `{"result": {"pane": {...}, "type": "pane_info"}}`, and `pane.list` answers
   `.result.panes`
-- In a **pane** command, `HERDR_PANE_ID` is the plugin's own new pane, so
-  asking Herdr about it returns a pane with no agent. `focused_pane_id` in
+- In a pane command, `HERDR_PANE_ID` is the plugin's own new pane, so asking
+  Herdr about it returns a pane with no agent. `focused_pane_id` in
   `HERDR_PLUGIN_CONTEXT_JSON` is the pane the plugin was invoked from, in both
   action and pane commands, and is the one to use
-- `AgentSessionInfo`: `{source, agent, kind, value}`, all required; the whole
-  object is absent until an integration reports a session
-- `AgentSessionRefKind`: `"id" | "path"`; `src/agent_resume.rs` in Herdr maps
-  `herdr:claude` and `herdr:codex` to `Id` (`pi` and `omp` store a path, and
-  zoetrope does not read those agents)
-- Manifest: action `contexts` are `global`, `workspace`, `tab`, `pane`,
-  `selection` (stored, not rendered: 0.8.2 has no action menu); pane
-  `placement` is one of `overlay`, `popup`, `split`, `tab`, `zoomed`;
-  keybindings are not a manifest field, hence `setup-keys`
+- `AgentSessionInfo` is `{source, agent, kind, value}`, all required, and the
+  whole object is absent until an integration reports a session
+- `AgentSessionRefKind` is `"id"` or `"path"`. Herdr maps `herdr:claude` and
+  `herdr:codex` to an id; `pi` and `omp` store a path, and zoetrope does not
+  read those agents
+- Action `contexts` are `global`, `workspace`, `tab`, `pane` and `selection`,
+  stored but not rendered, since 0.8.2 has no action menu. Pane `placement` is
+  one of `overlay`, `popup`, `split`, `tab`, `zoomed`. Keybindings are not a
+  manifest field, which is why `setup-keys` exists
 - Every CLI response is `{id, result}` or `{id, error}`

--- a/herdr-plugin/README.md
+++ b/herdr-plugin/README.md
@@ -1,0 +1,209 @@
+# herdr-plugin-zoetrope
+
+Open the focused agent's session as a live flow graph, without leaving Herdr.
+Works for Claude Code and Codex panes.
+
+## First run
+
+```bash
+herdr integration install claude            # and/or: herdr integration install codex
+herdr plugin install furkankly/zoetrope/herdr-plugin
+herdr plugin action invoke setup-keys --plugin furkankly.zoetrope
+```
+
+Then start the agent in a pane, and press `prefix+shift+z` (`prefix` is
+`ctrl+b` unless you changed it). The graph opens as an overlay, following the
+session live.
+
+To get back to the agent, press `q` in the graph, or `prefix+shift+z` again:
+with the graph in front the key closes it. `?` in the graph lists zoetrope's
+own keys.
+
+Pressing the key with the graph in front closes it, so one key opens and puts
+away.
+
+Where it opens is a preference you make once, so `setup-keys` binds one key and
+writes the other two placements into the same block as comments:
+
+| Placement | Bound to | Use it when |
+| --- | --- | --- |
+| overlay | `prefix+shift+z` | a glance. Takes the tab, restores your focus and zoom on close |
+| split | commented | both on screen. Splits the agent pane, so the graph gets half of it |
+| tab | commented | keeping it open. Full area, one tab switch from the agent |
+
+To switch, uncomment one in your Herdr config, or point the live binding at
+`open-split` or `open-tab`, then `herdr server reload-config`.
+
+The **integration** is what makes any of this work: it adds a `SessionStart`
+hook to the agent so Herdr learns the native session id of whatever runs in a
+pane. Without it Herdr knows a pane holds Claude Code but not which session,
+and the plugin has nothing to open. Agents already running when you install it
+keep reporting nothing, so start them again. `herdr integration status` lists
+what is installed.
+
+The **plugin install** checks that a `zoe` new enough to open a session by id
+is on `PATH`, and installs one with Homebrew, or cargo, when it is missing.
+Nothing is vendored: `zoe` is a standalone tool with its own releases, and the
+plugin drives the one you have rather than keeping a private copy on a separate
+update schedule. An older `zoe` is reported with the upgrade commands, never
+replaced. `jq` is needed as well.
+
+The **key step** binds `prefix+shift+z`, next to Herdr's own `prefix+z` for
+zoom, and offers `prefix+shift+v` and `prefix+shift+c` as comments beside
+`prefix+v` for split and `prefix+c` for tab. It writes one marked block into the Herdr config it finds (the
+same lookup Herdr uses: `HERDR_CONFIG_PATH`, then `$XDG_CONFIG_HOME/herdr`,
+then `~/.config/herdr/config.toml`), backs the file up first, refuses if
+`prefix+shift+z` is already bound, and reloads the running Herdr. The outcome
+shows as a Herdr notification and in `herdr plugin log list`. `remove-keys`
+deletes the block again. To use another key, skip `setup-keys` and bind the
+action yourself:
+
+```toml
+[[keys.command]]
+key = "prefix+shift+z"
+type = "plugin_action"
+command = "furkankly.zoetrope.open"
+description = "zoetrope: session graph"
+
+[[keys.command]]
+key = "prefix+shift+v"
+type = "plugin_action"
+command = "furkankly.zoetrope.open-split"
+description = "zoetrope: session graph (split)"
+
+[[keys.command]]
+key = "prefix+shift+c"
+type = "plugin_action"
+command = "furkankly.zoetrope.open-tab"
+description = "zoetrope: session graph (tab)"
+```
+
+A key already bound to something else is left alone and named in the result,
+so `setup-keys` never takes a key you are using.
+
+Without a key, the actions are still there from the command line:
+
+```bash
+herdr plugin action invoke open --plugin furkankly.zoetrope
+herdr plugin action invoke open-split --plugin furkankly.zoetrope
+herdr plugin action invoke open-tab --plugin furkankly.zoetrope
+```
+
+From a checkout:
+
+```bash
+herdr plugin link "$(pwd)"    # link runs no build step, so have zoe on PATH
+```
+
+## How it works
+
+Herdr plugin panes run an ordinary argv command in a real TTY, so a ratatui
+program is a first-class plugin UI. Nothing is embedded into Herdr's render
+loop: zoetrope's own TUI is the plugin UI, and the plugin is three shell
+scripts.
+
+Three scripts:
+
+1. `herdr/pane.sh` is all three actions, which differ only in the placement
+   they pass. It opens the `graph` pane, or closes it when
+   the graph is the focused pane, which makes the key a toggle. Herdr labels a
+   plugin pane with its manifest title, so a focused pane labelled `zoetrope`
+   holding no agent is the plugin's own.
+2. `herdr/open.sh` is the pane. It resolves the session and runs
+   `zoe --provider <agent> --follow <id>`.
+3. `herdr/resolve.sh` asks `pane.get` about the **focused** pane and prints
+   `<agent> <session-id>`.
+
+Every failure is printed in the pane and held until you press enter. An action
+runs headless, its output goes to `herdr plugin log`, and Herdr notifications
+can be turned off, so the pane's own terminal is the only place a message is
+certain to be seen.
+
+`pane.get` carries a stored session reference for the agent in the pane:
+
+```json
+{ "pane_id": "...", "agent": "codex", "cwd": "...",
+  "agent_session": { "source": "herdr:codex", "agent": "codex",
+                     "kind": "id", "value": "..." } }
+```
+
+Herdr's Claude Code and Codex integrations report the native session id from a
+`SessionStart` hook, so `kind` is `"id"` for both, and `zoe <id>` is exactly
+what that is for. The plugin passes `--provider` with the agent Herdr named, so
+the lookup stays inside that agent's files, and `--follow`, since the pane's
+agent is running.
+
+| Herdr reports | What happens |
+| --- | --- |
+| an id for a `claude` or `codex` pane | `zoe --provider <agent> --follow <id>` |
+| an agent but no session id | how to install the integration and why the agent has to be restarted |
+| no agent in the pane | a line saying to focus an agent pane |
+| an agent zoetrope does not read | the same, naming the agent |
+
+There is no fallback through the working directory. Herdr knows the session,
+so the plugin uses it or says what it got instead.
+
+## Keys, once the graph is up
+
+Herdr sees the prefix chord first and everything else goes to the pane, in
+every placement. So zoetrope keeps its own keys (`q`, `?`, `space`, arrows,
+`hjkl`, `+`/`-`, `[`/`]`, `g`/`G`) and Herdr keeps `prefix+...`. Herdr's
+`hjkl` pane moves live inside navigate mode, which the prefix opens, so they
+never shadow the graph's own. The one way to collide is a custom
+`[[keys.command]]` bound to a bare chord rather than a prefix chord: Herdr
+grabs those globally, before any pane.
+
+## Versions
+
+The plugin has no release of its own. `herdr plugin install` clones the repo at
+its default branch, so what people get is what is on main, and `herdr plugin
+uninstall` then `install` is how it updates.
+
+Three numbers, three reasons to change:
+
+| Number | Where | Bumped when |
+| --- | --- | --- |
+| `version` | `herdr-plugin.toml` | the files in this directory change. Displayed, never resolved |
+| `min_herdr_version` | `herdr-plugin.toml` | a script starts using a newer Herdr API. The only one that can block an install |
+| `ZOE_SINCE` | `herdr/ensure-zoe.sh` | the command line the scripts call changes. A label for the error message, not a check |
+
+None of them follows a zoetrope release on its own, and a `zoe` release that
+leaves the command line alone changes nothing here. Zoe's own improvements
+reach people through Homebrew and crates.io without the bridge moving at all.
+
+The binary is gated on what it can do rather than on what it calls itself: the
+build step asks `zoe --help` whether it takes `--provider`. A version string is
+a label, and a binary built from a checkout carries the crate version of its
+base release, so a floor would refuse a `zoe` that has the flag, while a future
+release that renamed the flag would pass a floor and fail at the first key
+press.
+
+One rule ties the two release channels together: a script here may only call a
+`zoe` command line that is already published, since installs take the branch
+while the binary comes from a release. Adding a call to something unreleased
+would break every fresh install until the crate ships.
+
+## Provenance of the field names
+
+Taken from `herdr api schema --json` on herdr 0.8.2 (protocol 20), the plugin
+and socket docs at v0.9.0, and live responses, not from memory:
+
+- `PaneInfo`: `pane_id` (not `id`), `agent`, `agent_session`, `agent_status`,
+  `cwd`, `foreground_cwd`, `display_agent`, `focused`, `tokens`, `workspace_id`
+- `pane.get` nests that record one level down, as
+  `{"result": {"pane": {...}, "type": "pane_info"}}`; `pane.list` answers
+  `.result.panes`
+- In a **pane** command, `HERDR_PANE_ID` is the plugin's own new pane, so
+  asking Herdr about it returns a pane with no agent. `focused_pane_id` in
+  `HERDR_PLUGIN_CONTEXT_JSON` is the pane the plugin was invoked from, in both
+  action and pane commands, and is the one to use
+- `AgentSessionInfo`: `{source, agent, kind, value}`, all required; the whole
+  object is absent until an integration reports a session
+- `AgentSessionRefKind`: `"id" | "path"`; `src/agent_resume.rs` in Herdr maps
+  `herdr:claude` and `herdr:codex` to `Id` (`pi` and `omp` store a path, and
+  zoetrope does not read those agents)
+- Manifest: action `contexts` are `global`, `workspace`, `tab`, `pane`,
+  `selection` (stored, not rendered: 0.8.2 has no action menu); pane
+  `placement` is one of `overlay`, `popup`, `split`, `tab`, `zoomed`;
+  keybindings are not a manifest field, hence `setup-keys`
+- Every CLI response is `{id, result}` or `{id, error}`

--- a/herdr-plugin/README.md
+++ b/herdr-plugin/README.md
@@ -22,22 +22,12 @@ is installed.
 
 **The plugin install** checks that a `zoe` new enough to open a session by id
 is on `PATH`, and installs one with Homebrew or cargo when it is missing. An
-older `zoe` is reported with the upgrade commands, never replaced. Nothing is
-vendored: `zoe` is a standalone tool with its own releases, and the plugin
-drives the one you have. `jq` is needed as well.
+older `zoe` is reported with the upgrade commands, never replaced. `jq` is
+needed as well.
 
-**The key step** writes one marked block into the Herdr config, since plugins
-cannot ship keys in their manifest. It finds the file the way Herdr does
-(`HERDR_CONFIG_PATH`, then `$XDG_CONFIG_HOME/herdr`, then
-`~/.config/herdr/config.toml`), backs it up, leaves a key that is already bound
-alone and names it, validates the result and rolls back if it does not parse,
-then reloads the running Herdr. `remove-keys` deletes the block again.
-
-From a checkout instead:
-
-```bash
-herdr plugin link "$(pwd)"    # link runs no build step, so have zoe on PATH
-```
+**The key step** writes one marked block into your Herdr config, since plugins
+cannot ship keys in their manifest. It backs the file up first, never takes a
+key you already use, and reloads Herdr. `remove-keys` deletes the block again.
 
 ## Usage
 
@@ -56,8 +46,8 @@ writes the other two placements into the same block as comments:
 | tab | commented | keeping it open. Full area, one tab switch from the agent |
 
 To switch, uncomment one in your Herdr config, or point the live binding at
-`open-split` or `open-tab`, then run `herdr server reload-config`. To bind your
-own keys instead, skip `setup-keys` and write them yourself:
+`open-split` or `open-tab`, then run `herdr server reload-config`. To use your
+own keys instead, skip `setup-keys` and bind the actions yourself:
 
 ```toml
 [[keys.command]]
@@ -75,53 +65,13 @@ herdr plugin action invoke open-split --plugin furkankly.zoetrope
 herdr plugin action invoke open-tab --plugin furkankly.zoetrope
 ```
 
-## Keys inside the graph
+## When it cannot open a session
 
-Herdr sees the prefix chord first and everything else reaches the pane, in
-every placement. So zoetrope keeps its own keys (`q`, `?`, `space`, arrows,
-`hjkl`, `+` and `-`, `[` and `]`, `g` and `G`) and Herdr keeps `prefix+...`.
-Herdr's own `hjkl` pane moves live inside navigate mode, which the prefix
-opens, so they never shadow the graph's. The one way to collide is a custom
-`[[keys.command]]` bound to a bare chord rather than a prefix chord, since
-Herdr grabs those before any pane sees them.
+The pane says why and waits for you to press enter, rather than closing on you:
 
-## How it works
-
-Herdr plugin panes run an ordinary argv command in a real TTY, so a ratatui
-program is a first-class plugin UI. Nothing is embedded into Herdr's render
-loop: zoetrope's own TUI is the plugin UI, and the plugin is three scripts.
-
-1. `herdr/pane.sh` is all three actions, which differ only in the placement
-   they pass. It opens the graph pane, or closes it when the graph is the
-   focused pane, which is what makes the key a toggle. Herdr labels a plugin
-   pane with its manifest title, so a focused pane labelled `zoetrope` holding
-   no agent is the plugin's own.
-2. `herdr/open.sh` is the pane. It resolves the session and runs
-   `zoe --provider <agent> --follow <id>`.
-3. `herdr/resolve.sh` asks `pane.get` about the focused pane and prints
-   `<agent> <session-id>`.
-
-Every failure is printed in the pane and held until you press enter. An action
-runs headless with its output going to `herdr plugin log`, and Herdr
-notifications can be switched off, so the pane's own terminal is the only place
-a message is certain to be seen.
-
-`pane.get` carries a stored session reference for the agent in the pane:
-
-```json
-{ "pane_id": "...", "agent": "codex", "cwd": "...",
-  "agent_session": { "source": "herdr:codex", "agent": "codex",
-                     "kind": "id", "value": "..." } }
-```
-
-Herdr's Claude Code and Codex integrations both report the native session id,
-so `kind` is `"id"` for either, and `zoe <id>` is exactly what that is for. The
-plugin passes `--provider` with the agent Herdr named, so the lookup stays
-inside that agent's files, and `--follow`, since the pane's agent is running.
-
-| Herdr reports | What happens |
+| Herdr reports | What you see |
 | --- | --- |
-| an id for a `claude` or `codex` pane | `zoe --provider <agent> --follow <id>` |
+| an id for a `claude` or `codex` pane | the graph |
 | an agent but no session id | how to install the integration, and why the agent has to be restarted |
 | no agent in the pane | a line saying to focus an agent pane |
 | an agent zoetrope does not read | the same, naming the agent |
@@ -129,55 +79,14 @@ inside that agent's files, and `--follow`, since the pane's agent is running.
 There is no fallback through the working directory. Herdr knows the session, so
 the plugin uses it or says what it got instead.
 
-## Versions
+## Keys inside the graph
 
-The plugin has no release of its own. `herdr plugin install` clones the repo at
-its default branch, so what people get is what is on main, and reinstalling is
-how it updates. Three numbers, three reasons to change:
+Herdr sees the prefix chord first and everything else reaches the pane, in
+every placement. So zoetrope keeps its own keys (`q`, `?`, `space`, arrows,
+`hjkl`, `+` and `-`, `[` and `]`, `g` and `G`) and Herdr keeps `prefix+...`.
+Press `?` in the graph for the full map.
 
-| Number | Where | Bumped when |
-| --- | --- | --- |
-| `version` | `herdr-plugin.toml` | the files in this directory change. Displayed, never resolved |
-| `min_herdr_version` | `herdr-plugin.toml` | a script starts using a newer Herdr API. The only one that can block an install |
-| `ZOE_SINCE` | `herdr/ensure-zoe.sh` | the command line the scripts call changes. A label for the error message, not a check |
+---
 
-None of them follows a zoetrope release. Zoe's own improvements reach people
-through Homebrew and crates.io without the bridge moving at all, and the bridge
-only has to move when it starts calling something new.
-
-`zoe` is gated on what it accepts rather than on what it calls itself: the
-build step asks `zoe --help` whether it takes `--provider`. A version string is
-a label, and a binary built from a checkout carries the crate version of its
-base release, so a floor would refuse a `zoe` that has the flag, while a future
-release that renamed the flag would pass a floor and then fail at the first key
-press.
-
-One rule ties the two release channels together. A script here may only call a
-`zoe` command line that is already published, because installs take the branch
-while the binary comes from a release. Calling something unreleased would break
-every fresh install until the crate ships.
-
-## Notes on Herdr's API
-
-Read from `herdr api schema --json` on Herdr 0.8.2 (protocol 20), the plugin
-and socket docs at v0.9.0, and live responses:
-
-- `PaneInfo` is `pane_id` (not `id`), `agent`, `agent_session`, `agent_status`,
-  `cwd`, `foreground_cwd`, `display_agent`, `focused`, `tokens`, `workspace_id`
-- `pane.get` nests that record one level down, as
-  `{"result": {"pane": {...}, "type": "pane_info"}}`, and `pane.list` answers
-  `.result.panes`
-- In a pane command, `HERDR_PANE_ID` is the plugin's own new pane, so asking
-  Herdr about it returns a pane with no agent. `focused_pane_id` in
-  `HERDR_PLUGIN_CONTEXT_JSON` is the pane the plugin was invoked from, in both
-  action and pane commands, and is the one to use
-- `AgentSessionInfo` is `{source, agent, kind, value}`, all required, and the
-  whole object is absent until an integration reports a session
-- `AgentSessionRefKind` is `"id"` or `"path"`. Herdr maps `herdr:claude` and
-  `herdr:codex` to an id; `pi` and `omp` store a path, and zoetrope does not
-  read those agents
-- Action `contexts` are `global`, `workspace`, `tab`, `pane` and `selection`,
-  stored but not rendered, since 0.8.2 has no action menu. Pane `placement` is
-  one of `overlay`, `popup`, `split`, `tab`, `zoomed`. Keybindings are not a
-  manifest field, which is why `setup-keys` exists
-- Every CLI response is `{id, result}` or `{id, error}`
+How the bridge is built, why it is versioned the way it is, and the Herdr API
+it reads: [`docs/HERDR-PLUGIN.md`](../docs/HERDR-PLUGIN.md).

--- a/herdr-plugin/herdr-plugin.toml
+++ b/herdr-plugin/herdr-plugin.toml
@@ -1,0 +1,76 @@
+id = "furkankly.zoetrope"
+name = "zoetrope"
+# This versions the bridge in this directory, not zoetrope. The scripts here
+# launch `zoe`; the graph, and every improvement to it, arrives with the binary
+# through Homebrew and crates.io, on its own release schedule and without any
+# change here. So this number moves when these files move, and stays put
+# through a zoe release that leaves the command line alone.
+#
+# Herdr displays it and nothing reads it. Plugins that do keep it in step with
+# their tool have a reason to: their installer builds a release download URL
+# out of it. Nothing here downloads anything, so a mirrored number would be a
+# hand-edited label with no reader. The one version that gates an install is
+# min_herdr_version below; the one that describes what `zoe` must be able to do
+# lives in herdr/ensure-zoe.sh.
+version = "0.1.0"
+description = "Watch the focused agent's session as a live flow graph."
+platforms = ["macos", "linux"]
+
+# `agent_session` on pane.get / agent.get is what makes this plugin worth having:
+# Herdr already knows which agent occupies a pane and its native session id, which
+# is the pair zoetrope's own discovery would otherwise have to infer. 0.8.2 is the
+# release the field was read from (`herdr api schema --json`, protocol 20).
+min_herdr_version = "0.8.2"
+
+# `plugin install` runs this after the preview; `plugin link` does not. It only
+# checks for zoe, and installs it when missing.
+[[build]]
+command = ["bash", "herdr/ensure-zoe.sh"]
+
+# Overlay: a temporary zoomed pane that restores the previous focus and zoom when
+# it closes. Watching the graph is a peek, not a side-by-side workflow. Users who
+# want it persistent can open it as a split from the action below.
+[[panes]]
+id = "graph"
+title = "zoetrope"
+placement = "overlay"
+command = ["bash", "herdr/open.sh"]
+
+[[actions]]
+id = "open"
+title = "zoetrope: session graph (overlay)"
+description = "Open the focused agent's session as a flow graph, over the focused pane. Closing it restores your layout. This is what the default key does."
+contexts = ["pane", "workspace"]
+command = ["bash", "herdr/pane.sh", "open"]
+
+# Beside the agent instead of over it: a persistent split, no zoom, no overlay.
+[[actions]]
+id = "open-split"
+title = "zoetrope: session graph (split)"
+description = "Open the focused agent's session as a flow graph, split beside the focused pane. Stays until you close it."
+contexts = ["pane", "workspace"]
+command = ["bash", "herdr/pane.sh", "open", "split"]
+
+# Its own tab: full area, kept until closed, one tab switch away from the agent.
+[[actions]]
+id = "open-tab"
+title = "zoetrope: session graph (tab)"
+description = "Open the focused agent's session as a flow graph in its own tab. Full size, one tab switch from the agent."
+contexts = ["pane", "workspace"]
+command = ["bash", "herdr/pane.sh", "open", "tab"]
+
+# Herdr binds keys only from the user's config, so the default key is installed
+# by an action: one marker-fenced block, removable by the sibling action.
+[[actions]]
+id = "setup-keys"
+title = "zoetrope: install the default keybinding"
+description = "Bind prefix+shift+z to the overlay, and write the split and tab placements beside it as comments. One block in your Herdr config, backed up first."
+contexts = ["workspace"]
+command = ["bash", "herdr/keys.sh", "setup"]
+
+[[actions]]
+id = "remove-keys"
+title = "zoetrope: remove the default keybinding"
+description = "Delete the block setup-keys wrote."
+contexts = ["workspace"]
+command = ["bash", "herdr/keys.sh", "remove"]

--- a/herdr-plugin/herdr/ensure-zoe.sh
+++ b/herdr-plugin/herdr/ensure-zoe.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Build step: make sure a `zoe` the plugin can drive is on PATH.
+#
+# Runs during `herdr plugin install`, after the preview has shown this command;
+# `herdr plugin link` skips build steps. Nothing is vendored: `zoe` is a
+# standalone tool with a Homebrew tap and a crates.io release, and the plugin
+# drives the one the user has rather than keeping a private copy on its own
+# update schedule. When it is missing entirely, it is installed with whichever
+# package manager is available.
+set -euo pipefail
+
+# What the pane needs is `zoe --provider <agent> --follow <id>`: opening a
+# session by id, narrowed to one agent. The check below asks the binary whether
+# it takes that, rather than comparing version strings, because a version is a
+# label and this is the thing that has to work. A build from a checkout carries
+# the crate version of its base release, so a floor would reject a binary that
+# has the flag; and a future release that renamed the flag would pass a floor
+# and then fail at the first key press. The number here only names the release
+# where this appeared, for the messages.
+ZOE_SINCE="0.2.0"
+
+takes_provider() {
+  zoe --help 2>/dev/null | grep -q -- '--provider'
+}
+
+version_of() {
+  zoe --version 2>/dev/null | tr ' ' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | head -1
+}
+
+# A checkout carries zoetrope's own source when the plugin lives in its repo,
+# so someone installing from main before a release can build exactly what these
+# scripts need. Printed as advice; this step never replaces a managed binary.
+from_source_hint() {
+  root=$(cd "${HERDR_PLUGIN_ROOT:-.}/.." 2>/dev/null && pwd) || return 0
+  [ -f "$root/Cargo.toml" ] || return 0
+  printf '    cargo install --path "%s" --force   (build it from this checkout)\n' "$root"
+}
+
+report() {
+  {
+    printf '\n  %s\n\n' "$1"
+    printf '  %s:\n' "$2"
+    printf '    %s furkankly/tap/zoetrope\n' "$3"
+    printf '    cargo install zoetrope%s\n' "$4"
+    from_source_hint
+    printf '\n  then run the plugin install again.\n\n'
+  } >&2
+  exit 1
+}
+
+too_old() { report "$1" "Upgrade with one of" "brew upgrade" " --force"; }
+missing() { report "$1" "Install it with one of" "brew install" ""; }
+
+check() {
+  if takes_provider; then
+    echo "zoe $(version_of) at $(command -v zoe) opens sessions by id: good."
+    return 0
+  fi
+  too_old "zoe $(version_of) at $(command -v zoe) does not take --provider, so it cannot open the session Herdr names. That arrived in $ZOE_SINCE."
+}
+
+if command -v zoe >/dev/null 2>&1; then
+  check
+  exit 0
+fi
+
+if command -v brew >/dev/null 2>&1; then
+  echo "zoe is not on PATH; installing it with Homebrew."
+  brew install furkankly/tap/zoetrope
+elif command -v cargo >/dev/null 2>&1; then
+  echo "zoe is not on PATH; installing it with cargo (this compiles it, a few minutes)."
+  cargo install zoetrope
+else
+  missing "zoe is not on PATH, and neither Homebrew nor cargo is available to install it."
+fi
+
+command -v zoe >/dev/null 2>&1 || missing "zoe was installed but is not on PATH; add its bin directory to PATH."
+check

--- a/herdr-plugin/herdr/keys.sh
+++ b/herdr-plugin/herdr/keys.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Action command: install or remove the plugin's default keybindings.
+#
+# Herdr plugins cannot ship keys in their manifest (plugin v1 binds keys only
+# from the user's config), so this writes one marker-fenced block into the
+# config Herdr loads, the way it resolves the path itself: HERDR_CONFIG_PATH,
+# then $XDG_CONFIG_HOME/herdr/config.toml, then ~/.config/herdr/config.toml.
+#
+# Rules: never touch anything outside the block, leave a key that is already
+# bound elsewhere alone and say so, back the file up before writing, hand the
+# result to `herdr config check`, and roll back if it does not pass.
+set -euo pipefail
+
+herdr="${HERDR_BIN_PATH:-herdr}"
+plugin="${HERDR_PLUGIN_ID:-furkankly.zoetrope}"
+begin="# >>> $plugin keys (managed: \`setup-keys\` writes this block, \`remove-keys\` deletes it)"
+end="# <<< $plugin keys"
+
+# Where the graph opens is a standing preference, not a per-press decision, so
+# one key is bound and the other placements are written into the same block as
+# comments. Switching is uncommenting a binding, or changing `open` to
+# `open-tab` in the one that is live. Each key sits next to the Herdr default
+# that does the same thing to a pane: prefix+z zooms, prefix+v splits,
+# prefix+c opens a tab.
+#
+# key | action id | description
+bindings=(
+  "prefix+shift+z|open|zoetrope: session graph (overlay)"
+)
+alternates=(
+  "prefix+shift+v|open-split|zoetrope: session graph (split)"
+  "prefix+shift+c|open-tab|zoetrope: session graph (tab)"
+)
+
+config_path() {
+  if [ "${HERDR_CONFIG_PATH+set}" = set ]; then
+    printf '%s' "$HERDR_CONFIG_PATH"
+  elif [ -n "${XDG_CONFIG_HOME:-}" ]; then
+    printf '%s/herdr/config.toml' "$XDG_CONFIG_HOME"
+  else
+    printf '%s/.config/herdr/config.toml' "$HOME"
+  fi
+}
+
+# The file without the managed block.
+strip_block() {
+  awk -v b="$begin" -v e="$end" '
+    $0 == b { skip = 1; next }
+    $0 == e { skip = 0; next }
+    !skip
+  ' "$1"
+}
+
+# An action runs on the server with no terminal, and `plugin action invoke`
+# returns before it finishes: stdout goes to `herdr plugin log`. A notification
+# is sent too, for the setups that have them switched on.
+say() {
+  echo "$*"
+  "$herdr" notification show "zoetrope" --body "$*" --sound none >/dev/null 2>&1 || true
+}
+
+fail() {
+  echo "$*" >&2
+  "$herdr" notification show "zoetrope: keybindings not installed" --body "$*" --sound none >/dev/null 2>&1 || true
+  exit 1
+}
+
+reload() {
+  "$herdr" server reload-config >/dev/null 2>&1 \
+    || echo "No running Herdr to reload; the keys are live from the next start."
+}
+
+path=$(config_path)
+[ -n "$path" ] || fail "HERDR_CONFIG_PATH is set but empty, so Herdr loads no config and there is nowhere to put a key."
+
+case "${1:-}" in
+  setup)
+    mkdir -p "$(dirname "$path")"
+    [ -f "$path" ] || : > "$path"
+    "$herdr" config check >/dev/null 2>&1 || fail "$path does not pass \`herdr config check\`; fix it first, nothing was changed."
+
+    rest=$(strip_block "$path")
+    installed=""
+    skipped=""
+    lines=()
+    for entry in "${bindings[@]}"; do
+      key=${entry%%|*}
+      rem=${entry#*|}
+      action=${rem%%|*}
+      desc=${rem#*|}
+      if printf '%s\n' "$rest" | grep -q "\"$key\""; then
+        skipped="$skipped $key"
+        continue
+      fi
+      installed="$installed $key"
+      lines+=("[[keys.command]]" "key = \"$key\"" "type = \"plugin_action\"" \
+              "command = \"$plugin.$action\"" "description = \"$desc\"" "")
+    done
+    installed=${installed# }
+    skipped=${skipped# }
+
+    # The placements this block does not bind, offered in place.
+    lines+=("# The graph opens over the focused pane and gives the layout back when" \
+            "# it closes. The same key closes it. Two other placements, if you would" \
+            "# rather keep the graph on screen: uncomment one, or point the binding" \
+            "# above at its action. Then: herdr server reload-config")
+    for entry in "${alternates[@]}"; do
+      key=${entry%%|*}
+      rem=${entry#*|}
+      action=${rem%%|*}
+      desc=${rem#*|}
+      lines+=("# [[keys.command]]" "# key = \"$key\"" "# type = \"plugin_action\"" \
+              "# command = \"$plugin.$action\"" "# description = \"$desc\"" "")
+    done
+
+    [ -n "$installed" ] || fail "Every default key is already bound in $path ($skipped), so nothing was changed. Bind $plugin.open to a key of your own instead."
+
+    cp "$path" "$path.zoetrope-backup"
+    # `rest` came from a command substitution, which already dropped every
+    # trailing newline, so the block always lands after exactly one blank line.
+    { [ -n "$rest" ] && printf '%s\n\n' "$rest"
+      printf '%s\n' "$begin"
+      printf '%s\n' "${lines[@]}"
+      printf '%s\n' "$end"
+    } > "$path"
+
+    if ! "$herdr" config check >/dev/null 2>&1; then
+      cp "$path.zoetrope-backup" "$path"
+      fail "The written config did not pass \`herdr config check\`; restored $path from the backup."
+    fi
+    reload
+    msg="Bound $installed in $path (backup: $path.zoetrope-backup). Focus an agent pane and press ${installed%% *}. The split and tab placements are in the same block, commented out."
+    [ -z "$skipped" ] || msg="$msg Left $skipped alone, already bound there."
+    say "$msg"
+    ;;
+  remove)
+    [ -f "$path" ] || { say "No config at $path, nothing to remove."; exit 0; }
+    grep -qxF "$begin" "$path" || { say "No $plugin block in $path, nothing to remove."; exit 0; }
+    cp "$path" "$path.zoetrope-backup"
+    rest=$(strip_block "$path.zoetrope-backup")
+    if [ -n "$rest" ]; then printf '%s\n' "$rest" > "$path"; else : > "$path"; fi
+    reload
+    say "Removed the $plugin keybindings from $path (backup: $path.zoetrope-backup)."
+    ;;
+  *)
+    echo "usage: keys.sh setup|remove" >&2
+    exit 2
+    ;;
+esac

--- a/herdr-plugin/herdr/open.sh
+++ b/herdr-plugin/herdr/open.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Pane command: resolve the session of the pane this was opened from, and run
+# `zoe` on it. Every failure is printed here and held until you press enter,
+# since this terminal is what the user is looking at.
+set -euo pipefail
+
+root="${HERDR_PLUGIN_ROOT:-.}"
+
+die() {
+  printf '\n  %s\n\n' "$*" >&2
+  read -r -p '  press enter to close ' _ || true
+  exit 1
+}
+
+command -v zoe >/dev/null 2>&1 || die "zoe is not on PATH (brew install furkankly/tap/zoetrope, or cargo install zoetrope)"
+
+if ! target=$(bash "$root/herdr/resolve.sh" 2>&1); then
+  die "$target"
+fi
+
+# The pane's agent is running, so ride the live edge; space and the scrubber
+# go back.
+zoe --provider "${target%% *}" --follow "${target#* }" \
+  || die "zoe exited with status $? (zoe --provider ${target%% *} --follow ${target#* })"

--- a/herdr-plugin/herdr/pane.sh
+++ b/herdr-plugin/herdr/pane.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Action command: open the graph pane, or close it when it is the focused one.
+#
+# Pressing the key again with the graph in front should put the agent back, not
+# ask the graph pane which session it is running. Herdr labels a plugin pane
+# with its manifest title, so a focused pane labelled "zoetrope" that holds no
+# agent is ours.
+#
+# The pane resolves the session itself (herdr/open.sh). An action runs headless
+# with its output going to `herdr plugin log`, and Herdr notifications can be
+# turned off, so the pane's own terminal is the only place a message is certain
+# to be seen.
+set -euo pipefail
+
+herdr="${HERDR_BIN_PATH:-herdr}"
+ctx="${HERDR_PLUGIN_CONTEXT_JSON:-{\}}"
+title="zoetrope"
+placement="${2:-overlay}"
+
+case "${1:-open}" in
+  open) ;;
+  *) printf 'usage: pane.sh open [overlay|popup|split|tab|zoomed]\n' >&2; exit 2 ;;
+esac
+
+if command -v jq >/dev/null 2>&1; then
+  focused=$(printf '%s' "$ctx" | jq -r '.focused_pane_id // empty')
+  if [ -n "$focused" ]; then
+    pane=$("$herdr" pane get "$focused" 2>/dev/null | jq -r '.result.pane // empty' 2>/dev/null || true)
+    label=$(printf '%s' "$pane" | jq -r '.label // empty' 2>/dev/null || true)
+    agent=$(printf '%s' "$pane" | jq -r '.agent // empty' 2>/dev/null || true)
+    if [ "$label" = "$title" ] && [ -z "$agent" ]; then
+      exec "$herdr" plugin pane close "$focused"
+    fi
+  fi
+fi
+
+exec "$herdr" plugin pane open \
+  --plugin "${HERDR_PLUGIN_ID:-furkankly.zoetrope}" \
+  --entrypoint graph \
+  --placement "$placement"

--- a/herdr-plugin/herdr/resolve.sh
+++ b/herdr-plugin/herdr/resolve.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Print "<agent> <session-id>" for the pane the plugin was invoked from, or
+# exit non-zero with the reason on stderr.
+#
+# The pane id comes from `focused_pane_id` in HERDR_PLUGIN_CONTEXT_JSON, never
+# from HERDR_PANE_ID: in a pane command HERDR_PANE_ID is the plugin's own new
+# pane, and asking Herdr about that one returns a pane with no agent. The
+# context names the pane that was focused when the plugin was invoked, and it
+# is the same field for an action and for a pane command.
+#
+# Herdr's Claude Code and Codex integrations report the native session id from
+# a SessionStart hook (`pane.report_agent_session`), so `pane.get` carries
+# `agent_session: {source, agent, kind: "id", value}` for both. That pair is
+# all zoe needs. Nothing is guessed from the working directory; when Herdr has
+# no id, the caller says so.
+set -euo pipefail
+
+herdr="${HERDR_BIN_PATH:-herdr}"
+ctx="${HERDR_PLUGIN_CONTEXT_JSON:-{\}}"
+
+command -v jq >/dev/null 2>&1 || { echo "jq is not on PATH, and the plugin reads Herdr's JSON with it" >&2; exit 1; }
+
+pane_id=$(printf '%s' "$ctx" | jq -r '.focused_pane_id // empty')
+[ -n "$pane_id" ] || { echo "no focused pane in the invocation context" >&2; exit 1; }
+
+resp=$("$herdr" pane get "$pane_id" 2>&1) || { echo "herdr pane get failed: $resp" >&2; exit 1; }
+err=$(printf '%s' "$resp" | jq -r '.error.message // empty' 2>/dev/null || true)
+[ -z "$err" ] || { echo "herdr: $err" >&2; exit 1; }
+
+# `pane.get` answers `{"result": {"pane": {...}, "type": "pane_info"}}`: the
+# record is under `.result.pane`, not `.result` itself.
+pane=$(printf '%s' "$resp" | jq '.result.pane // .result')
+agent=$(printf '%s' "$pane" | jq -r '.agent_session.agent // .agent // empty')
+kind=$(printf  '%s' "$pane" | jq -r '.agent_session.kind  // empty')
+value=$(printf '%s' "$pane" | jq -r '.agent_session.value // empty')
+
+case "$agent" in
+  claude | codex) ;;
+  "") echo "pane $pane_id has no agent: focus a Claude Code or Codex pane" >&2; exit 1 ;;
+  *)  echo "agent '$agent' in pane $pane_id is not one zoe reads (Claude Code and Codex)" >&2; exit 1 ;;
+esac
+
+case "$kind" in
+  id) ;;
+  "") cat >&2 <<MSG
+Herdr has no session id for this $agent pane.
+
+  The id comes from the agent's SessionStart hook, which fires only when a
+  session begins. So: install the integration if it is missing, then start the
+  agent in that pane again. A session that was already running when the
+  integration was installed never reports one.
+
+    herdr integration install $agent    (herdr integration status lists them)
+MSG
+     exit 1 ;;
+  *)  echo "Herdr reports a $kind for this $agent pane, and the plugin expects an id" >&2; exit 1 ;;
+esac
+
+printf '%s %s\n' "$agent" "$value"

--- a/web/src/content/docs/guides/install.md
+++ b/web/src/content/docs/guides/install.md
@@ -75,6 +75,19 @@ cargo build --release
   (`rustup` recommended).
 - A terminal that supports truecolor and mouse events (most modern terminals do).
 
+## Inside Herdr
+
+If you run your agents in [Herdr](https://herdr.dev), the plugin in
+`herdr-plugin/` is a third way in, and it installs zoetrope for you when it is
+missing:
+
+```bash
+herdr plugin install furkankly/zoetrope/herdr-plugin
+```
+
+It opens the focused pane's session as a graph on a key press. See
+[Usage](/guides/usage/#launching-inside-herdr).
+
 ## Build the browser app yourself
 
 The browser frontend isn't part of the published crate — it's a separate,
@@ -96,19 +109,6 @@ and `trunk` (`cargo install trunk`). `pnpm build:wasm` (that is,
 `bash scripts/build-wasm.sh`) builds only the wasm; lint it from the repo root
 with `cd web/wasm && cargo clippy` — that crate's `.cargo/config.toml` defaults the
 target to wasm32, so no flags are needed.
-
-## Inside Herdr
-
-If you run your agents in [Herdr](https://herdr.dev), the plugin in
-`herdr-plugin/` is a third way in, and it installs zoetrope for you when it is
-missing:
-
-```bash
-herdr plugin install furkankly/zoetrope/herdr-plugin
-```
-
-It opens the focused pane's session as a graph on a key press. See
-[Usage](/guides/usage/#launching-inside-herdr).
 
 ## Status
 

--- a/web/src/content/docs/guides/install.md
+++ b/web/src/content/docs/guides/install.md
@@ -97,6 +97,19 @@ and `trunk` (`cargo install trunk`). `pnpm build:wasm` (that is,
 with `cd web/wasm && cargo clippy` — that crate's `.cargo/config.toml` defaults the
 target to wasm32, so no flags are needed.
 
+## Inside Herdr
+
+If you run your agents in [Herdr](https://herdr.dev), the plugin in
+`herdr-plugin/` is a third way in, and it installs zoetrope for you when it is
+missing:
+
+```bash
+herdr plugin install furkankly/zoetrope/herdr-plugin
+```
+
+It opens the focused pane's session as a graph on a key press. See
+[Usage](/guides/usage/#launching-inside-herdr).
+
 ## Status
 
 Early and pre-release. It's usable for dogfooding your own sessions, but the keys,

--- a/web/src/content/docs/guides/usage.md
+++ b/web/src/content/docs/guides/usage.md
@@ -46,6 +46,23 @@ The [browser app](/app) boots into a bundled demo. To watch your own session:
   subagents' rollouts. Drop the root alone and you get the main agent only;
   zoetrope will say so rather than pretending the session had no subagents.
 
+## Launching (inside Herdr)
+
+[Herdr](https://herdr.dev) runs coding agents in panes and knows which session
+each one is. The plugin in `herdr-plugin/` asks it about the focused pane and
+launches `zoe` on that session, so nothing has to be discovered or named:
+
+```bash
+herdr integration install claude          # and/or codex, so Herdr learns session ids
+herdr plugin install furkankly/zoetrope/herdr-plugin
+herdr plugin action invoke setup-keys --plugin furkankly.zoetrope
+```
+
+Then `prefix+shift+z` in an agent pane opens the graph over it, following live,
+and closes it again. The session id comes from the agent's `SessionStart` hook,
+which is what `herdr integration install` adds, so a session that was already
+running when you installed it has to be started again before Herdr can name it.
+
 ## Keys
 
 | Key | Action |


### PR DESCRIPTION
**Why**

[Herdr](https://herdr.dev) runs coding agents in panes, and it already knows two things zoetrope otherwise has to work out: which agent is in a pane, and the native id of the session running there. Its integrations get that id from each agent's `SessionStart` hook. That is exactly the pair `zoe <id> --provider <agent>` wants, so the two fit together with almost no code.

This adds the plugin that connects them. Focus an agent pane, press a key, and the session in that pane opens as a live graph over it. No file paths, no ids, no guessing which session belongs to the project.

**What it is**

A manifest and five shell scripts in `herdr-plugin/`, and nothing else. Herdr plugin panes run an ordinary command in a real terminal, so `zoe` itself is the plugin UI, and none of the graph is written twice.

- `herdr/resolve.sh` asks Herdr about the focused pane and prints the agent and session id.
- `herdr/open.sh` is the pane: it runs `zoe --provider <agent> --follow <id>`.
- `herdr/pane.sh` is the three actions, which differ only in placement: over the pane, split beside it, or its own tab. It also closes the graph when the graph is what is focused, so one key opens and puts away.
- `herdr/keys.sh` installs the default key, since Herdr plugins cannot ship keybindings in their manifest.
- `herdr/ensure-zoe.sh` checks that a usable `zoe` is on `PATH` at install time, and installs one with Homebrew or cargo when it is missing.

Nothing is vendored. `zoe` is a standalone tool with its own releases, so the plugin drives the one the user has rather than keeping a private copy on a separate update schedule.

**Where it is documented**

`herdr-plugin/README.md` is for whoever installs it: three commands, the key, the placements, and what the pane says when it cannot open a session. `docs/HERDR-PLUGIN.md` is the reference beside the other design notes: where the bridge sits on the provider boundary, the Herdr fields it reads and why those and not the obvious-looking ones, and how the two release channels relate.

The README and both site guides gain the Herdr route beside the other ways to launch, and `docs/DISCOVERY.md` now points at the plugin as the case `Target::Id` was written for: the id is known, the file is not.

**Ordering note**

The scripts need `zoe` 0.2.0, which is not published yet. The build step refuses an older binary with the upgrade command rather than installing something broken, so the only cost of merging first is that a fresh install fails cleanly until the release lands.
